### PR TITLE
Property implementation

### DIFF
--- a/src/emu/common/CMakeLists.txt
+++ b/src/emu/common/CMakeLists.txt
@@ -18,7 +18,8 @@ add_library(common
     src/data_displayer.cpp
     src/flate.cpp
     src/types.cpp
-    src/random.cpp)
+    src/random.cpp
+    src/hash.cpp)
 
 target_include_directories(common PUBLIC include)
 target_link_libraries(common PUBLIC spdlog)

--- a/src/emu/common/include/common/hash.h
+++ b/src/emu/common/include/common/hash.h
@@ -22,53 +22,20 @@
 #include <cstdint>
 #include <string>
 
+#include <tuple>
+#include <unordered_map>
+
 namespace eka2l1 {
     namespace common {
         // https://stackoverflow.com/questions/7968674/unexpected-collision-with-stdhash
-        uint32_t hash(std::string const &s) {
-            uint32_t h = 5381;
-
-            for (auto c : s)
-                h = ((h << 5) + h) + c; /* hash * 33 + c */
-
-            return h;
-        }
-
-        std::string normalize_for_hash(std::string org) {
-            auto remove = [](std::string &inp, std::string to_remove) {
-                size_t pos = 0;
-
-                do {
-                    pos = inp.find(to_remove, pos);
-
-                    if (pos == std::string::npos) {
-                        break;
-                    } else {
-                        inp.erase(pos, to_remove.length());
-                    }
-                } while (true);
-            };
-
-            for (auto &c : org) {
-                c = tolower(c);
-            }
-
-            remove(org, " ");
-            // Remove class in arg
-
-            std::size_t beg = org.find("(");
-            std::size_t end = org.find(")");
-
-            std::string sub = org.substr(beg, end);
-
-            remove(sub, "class");
-            remove(sub, "const");
-            remove(sub, "struct");
-
-            auto res = org.substr(0, beg) + sub + org.substr(end + 1);
-
-            return res;
-        }
+        uint32_t hash(std::string const &s);
+        std::string normalize_for_hash(std::string org);
     }
 }
 
+namespace std {
+    template <>
+    struct hash<std::pair<int, int>> {
+        std::size_t operator()(const std::pair<int, int> &p) const;
+    };
+};

--- a/src/emu/common/src/hash.cpp
+++ b/src/emu/common/src/hash.cpp
@@ -1,0 +1,59 @@
+#include <common/hash.h>
+
+namespace std {
+    std::size_t hash<std::pair<int, int>>::operator()(const std::pair<int, int> &p) const {
+        auto h1 = std::hash<int>{}(p.first);
+        auto h2 = std::hash<int>{}(p.second);
+
+        return h1 ^ h2;
+    }
+};
+
+namespace eka2l1 {
+    namespace common {
+        uint32_t hash(std::string const &s) {
+            uint32_t h = 5381;
+
+            for (auto c : s)
+                h = ((h << 5) + h) + c; /* hash * 33 + c */
+
+            return h;
+        }
+
+        std::string normalize_for_hash(std::string org) {
+            auto remove = [](std::string &inp, std::string to_remove) {
+                size_t pos = 0;
+
+                do {
+                    pos = inp.find(to_remove, pos);
+
+                    if (pos == std::string::npos) {
+                        break;
+                    } else {
+                        inp.erase(pos, to_remove.length());
+                    }
+                } while (true);
+            };
+
+            for (auto &c : org) {
+                c = tolower(c);
+            }
+
+            remove(org, " ");
+            // Remove class in arg
+
+            std::size_t beg = org.find("(");
+            std::size_t end = org.find(")");
+
+            std::string sub = org.substr(beg, end);
+
+            remove(sub, "class");
+            remove(sub, "const");
+            remove(sub, "struct");
+
+            auto res = org.substr(0, beg) + sub + org.substr(end + 1);
+
+            return res;
+        }
+    }
+}

--- a/src/emu/core/include/core/core_kernel.h
+++ b/src/emu/core/include/core/core_kernel.h
@@ -31,6 +31,8 @@
 #include <services/session.h>
 #include <services/property.h>
 
+#include <common/hash.h>
+
 #include <ipc.h>
 #include <process.h>
 #include <ptr.h>

--- a/src/emu/core/include/core/core_kernel.h
+++ b/src/emu/core/include/core/core_kernel.h
@@ -29,6 +29,7 @@
 
 #include <services/server.h>
 #include <services/session.h>
+#include <services/property.h>
 
 #include <ipc.h>
 #include <process.h>
@@ -60,6 +61,10 @@ namespace eka2l1 {
     using timer_ptr = std::shared_ptr<kernel::timer>;
     using kernel_obj_ptr = std::shared_ptr<kernel::kernel_obj>;
 
+    using property_ptr = std::shared_ptr<service::property>;
+
+    using prop_ident_pair = std::pair<int, int>;
+
     class kernel_system {
         friend class process;
 
@@ -79,7 +84,9 @@ namespace eka2l1 {
         std::map<kernel::uid, timer_ptr> timers;
         std::map<kernel::uid, session_ptr> sessions;
         std::map<kernel::uid, server_ptr> servers;
+        std::map<kernel::uid, property_ptr> properties;
 
+        std::unordered_map<prop_ident_pair, int *> prop_request_queue;
         std::unordered_map<kernel::uid, ipc_msg_ptr> msgs;
 
         /* End kernel objects map */
@@ -185,6 +192,15 @@ namespace eka2l1 {
         */
         ipc_msg_ptr create_msg(kernel::owner_type owner);
 
+        /*! \brief Create a property. 
+         *
+         *  This property created will be added to a map. When a static RProperty::Get method is called,
+         * it search the cagetory and key pair tied in the map. Note that this implementation is lacking
+         * platform security intended in 9.x version of Symbian. Should be in TODO list ;) .
+        */
+        property_ptr create_prop(service::property_type pt, uint32_t pre_allocated);
+        void delete_prop(property_ptr prop);
+
         /*! \brief Free a message. */
         void free_msg(ipc_msg_ptr msg);
 
@@ -213,6 +229,13 @@ namespace eka2l1 {
         bool close_process(process *pr);
         bool close_process(const kernel::uid id);
         bool close_all_processes();
+
+        bool notify_prop(prop_ident_pair ident);
+        bool subscribe_prop(prop_ident_pair ident, int *request_sts);
+        bool unsubscribe_prop(prop_ident_pair ident);
+
+        property_ptr get_prop(int cagetory, int key); // Get property by category and key
+        property_ptr get_prop(kernel::uid id);
 
         kernel::uid crr_process() const {
             return crr_process_id;

--- a/src/emu/core/include/core/hle/epoc9/err.h
+++ b/src/emu/core/include/core/hle/epoc9/err.h
@@ -25,7 +25,8 @@
 const TInt KErrNone = 0;
 const TInt KErrNotFound = -1;
 const TInt KErrGeneral = -2;
-const TInt KErrNoMemory = -3;
+const TInt KErrCancel = -3;
+const TInt KErrNoMemory = -4;
 const TInt KErrNotSupported = -5;
 const TInt KErrArgument = -6;
 const TInt KErrTotalLossOfPrecision = -7;

--- a/src/emu/core/include/core/hle/epoc9/prop.h
+++ b/src/emu/core/include/core/hle/epoc9/prop.h
@@ -20,30 +20,16 @@
 
 #pragma once
 
-#include <hle/bridge.h>
+#include <epoc9/err.h>
+#include <epoc9/types.h>
+#include <epoc9/base.h>
 
-#include <cstdint>
+#include <hle/bridge.h>
 #include <ptr.h>
 
-typedef char TInt8;
-typedef short TInt16;
-typedef int32_t TInt32;
-typedef int64_t TInt64;
+struct RProperty : public RHandleBase {};
 
-typedef int TInt;
-typedef unsigned int TUint;
-typedef bool TBool;
+BRIDGE_FUNC(TInt, RPropertyAttach, eka2l1::ptr<RProperty> aProp, TUid aCagetory, TUint aKey, TOwnerType aType = EOwnerProcess);
+BRIDGE_FUNC(TInt, RPropertyCancel, eka2l1::ptr<RProperty> aProp);
 
-typedef unsigned char TUint8;
-typedef unsigned short TUint16;
-typedef uint32_t TUint32;
-typedef uint64_t TUint64;
-
-using TAny = void;
-
-enum TOwnerType {
-    EOwnerProcess,
-    EOwnerThread
-};
-
-using TUid = uint32_t;
+extern const eka2l1::hle::func_map prop_register_funcs;

--- a/src/emu/core/include/core/hle/epoc9/prop.h
+++ b/src/emu/core/include/core/hle/epoc9/prop.h
@@ -31,5 +31,8 @@ struct RProperty : public RHandleBase {};
 
 BRIDGE_FUNC(TInt, RPropertyAttach, eka2l1::ptr<RProperty> aProp, TUid aCagetory, TUint aKey, TOwnerType aType = EOwnerProcess);
 BRIDGE_FUNC(TInt, RPropertyCancel, eka2l1::ptr<RProperty> aProp);
+BRIDGE_FUNC(TInt, RPropertyDefineNoSec, eka2l1::ptr<RProperty> aProp, TUid aCategory, TUint aKey, TInt aAttr, TInt aPreallocate);
+BRIDGE_FUNC(TInt, RPropertyGetGlobalInt, TUid aCagetory, TUint aKey, eka2l1::ptr<TInt> aValue);
+BRIDGE_FUNC(TInt, RPropertyGetInt, eka2l1::ptr<RProperty> aProp, eka2l1::ptr<TInt> aVal);
 
 extern const eka2l1::hle::func_map prop_register_funcs;

--- a/src/emu/core/include/core/hle/epoc9/register.h
+++ b/src/emu/core/include/core/hle/epoc9/register.h
@@ -13,6 +13,7 @@
 #include <epoc9/trap.h>
 #include <epoc9/svc.h>
 #include <epoc9/svr.h>
+#include <epoc9/prop.h>
 
 #include <hle/libmanager.h>
 

--- a/src/emu/core/include/core/services/property.h
+++ b/src/emu/core/include/core/services/property.h
@@ -13,6 +13,7 @@ namespace eka2l1 {
             bin_data
         };
 
+        /*! \brief Property is a kind of environment data. */
         class property: public kernel::kernel_obj, public std::pair<int, int> {
         protected:
             union {
@@ -30,8 +31,6 @@ namespace eka2l1 {
 
             bool set(int val);
             bool set(uint8_t *data, uint32_t arr_length);
-
-            void delete_prop();
 
             int get_int();
             std::vector<uint8_t> get_bin();

--- a/src/emu/core/include/core/services/property.h
+++ b/src/emu/core/include/core/services/property.h
@@ -13,7 +13,13 @@ namespace eka2l1 {
             bin_data
         };
 
-        /*! \brief Property is a kind of environment data. */
+        /*! \brief Property is a kind of environment data. 
+		 *
+		 * Property is defined by cagetory and key. Each property contains either
+		 * integer or binary data. Properties are stored in the kernel until shutdown,
+		 * and they are the way of ITC (Inter-Thread communication).
+ 		 *
+		*/
         class property: public kernel::kernel_obj, public std::pair<int, int> {
         protected:
             union {
@@ -29,12 +35,32 @@ namespace eka2l1 {
         public:
             property(kernel_system *kern, service::property_type pt, uint32_t pre_allocated);
 
+			/*! \brief Set the property value (integer).
+             *
+             * If the property type is not integer, this return false, else
+             * it will set the value and notify the request.		
+             *
+             * \param val The value to set.		 
+			*/
             bool set(int val);
+			
+			
+			/*! \brief Set the property value (bin).
+             *
+             * If the property type is not binary, this return false, else
+             * it will set the value and notify the request.	
+             * 
+             * \param data The pointer to binary data.	
+             * \param arr_length The binary data length.
+             *
+             * \returns false if arr_length exceeds allocated data length or property is not binary.			 
+			*/
             bool set(uint8_t *data, uint32_t arr_length);
 
             int get_int();
             std::vector<uint8_t> get_bin();
 
+			/*! \brief Notify the request that there is data change */
             void notify_request();
         };
     }

--- a/src/emu/core/src/core_kernel.cpp
+++ b/src/emu/core/src/core_kernel.cpp
@@ -567,7 +567,7 @@ namespace eka2l1 {
     property_ptr kernel_system::get_prop(int cagetory, int key) {
         auto &prop_res = std::find_if(properties.begin(), properties.end(),
             [=](const auto &prop) {
-                property_ptr temp = *prop.second;
+                property_ptr temp = prop.second;
                 return temp->first == cagetory && temp->second == key; // Sorry, im too lazy to search on de internet :D
             });
 

--- a/src/emu/core/src/core_kernel.cpp
+++ b/src/emu/core/src/core_kernel.cpp
@@ -527,6 +527,8 @@ namespace eka2l1 {
             return false;
         }
 
+        // This still right for the requirement: Status is still accepted even if the prop is not yet
+        // definied. 
         prop_request_queue.emplace(ident, request_sts);
 
         return true;

--- a/src/emu/core/src/core_kernel.cpp
+++ b/src/emu/core/src/core_kernel.cpp
@@ -476,7 +476,7 @@ namespace eka2l1 {
 
     server_ptr kernel_system::get_server(kernel::uid id) {
         auto &res = servers.find(id);
- 
+
         if (res != servers.end()) {
             return res->second;
         }
@@ -492,5 +492,99 @@ namespace eka2l1 {
         }
 
         return session_ptr(nullptr);
+    }
+
+    property_ptr kernel_system::create_prop(service::property_type pt, uint32_t pre_allocated) {
+        property_ptr new_prop = std::make_shared<service::property>(this, pt, pre_allocated);
+        uint32_t id = new_prop->unique_id();
+
+        properties.emplace(id, std::move(new_prop));
+
+        return properties[id];
+    }
+
+    bool kernel_system::notify_prop(prop_ident_pair ident) {
+        auto &request_ident = prop_request_queue.find(ident);
+
+        if (request_ident == prop_request_queue.end()) {
+            return false;
+        }
+
+        int *request = request_ident->second;
+        *request = 0; // KErrNone
+
+        // Request completed
+        crr_thread()->signal_request();
+
+        return true;
+    }
+
+    bool kernel_system::subscribe_prop(prop_ident_pair ident, int *request_sts) {
+        auto &request_ident = prop_request_queue.find(ident);
+
+        if (request_ident != prop_request_queue.end()) {
+            // Unsub first
+            return false;
+        }
+
+        prop_request_queue.emplace(ident, request_sts);
+
+        return true;
+    }
+
+    void kernel_system::delete_prop(property_ptr prop) {
+        std::pair<int, int> prop_ident(prop->first, prop->second);
+        auto &request_ident = prop_request_queue.find(prop_ident);
+
+        if (request_ident == prop_request_queue.end()) {
+            // Unsub first
+            return;
+        }
+
+        *request_ident->second = -1; // KErrNotFound
+        crr_thread()->signal_request();
+
+        prop_request_queue.erase(prop_ident);
+        properties.erase(prop->unique_id());
+    }
+
+    bool kernel_system::unsubscribe_prop(prop_ident_pair ident) {
+        auto &request_ident = prop_request_queue.find(ident);
+
+        if (request_ident == prop_request_queue.end()) {
+            // Unsub first
+            return false;
+        }
+
+        *request_ident->second = -2; // KErrCancel
+        crr_thread()->signal_request();
+
+        prop_request_queue.erase(ident);
+
+        return true;
+    }
+
+    property_ptr kernel_system::get_prop(int cagetory, int key) {
+        auto &prop_res = std::find_if(properties.begin(), properties.end(),
+            [=](const auto &prop) {
+                property_ptr temp = *prop.second;
+                return temp->first == cagetory && temp->second == key; // Sorry, im too lazy to search on de internet :D
+            });
+
+        if (prop_res == properties.end()) {
+            return property_ptr(nullptr);
+        }
+
+        return prop_res->second;
+    }
+
+    property_ptr kernel_system::get_prop(kernel::uid id) {
+        auto &res = properties.find(id);
+
+        if (res == properties.end()) {
+            return property_ptr(nullptr);
+        }
+
+        return res->second;
     }
 }

--- a/src/emu/core/src/hle/epoc9/CMakeLists.txt
+++ b/src/emu/core/src/hle/epoc9/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(epoc9
     ${CORE_INCLUDE_DIR}/hle/epoc9/register.h
     ${CORE_INCLUDE_DIR}/hle/epoc9/svc.h
     ${CORE_INCLUDE_DIR}/hle/epoc9/svr.h
+    ${CORE_INCLUDE_DIR}/hle/epoc9/prop.h
     allocator.cpp
     base.cpp
     char.cpp
@@ -32,7 +33,8 @@ add_library(epoc9
     trap.cpp
     register.cpp
     svc.cpp
-    svr.cpp)
+    svr.cpp
+    prop.cpp)
 
 target_include_directories(epoc9 PUBLIC ${CORE_INCLUDE_DIR}/hle)
 target_link_libraries(epoc9 PUBLIC common)

--- a/src/emu/core/src/hle/epoc9/prop.cpp
+++ b/src/emu/core/src/hle/epoc9/prop.cpp
@@ -1,0 +1,62 @@
+#include <epoc9/prop.h>
+
+using namespace eka2l1;
+
+BRIDGE_FUNC(TInt, RPropertyAttach, eka2l1::ptr<RProperty> aProp, TUid aCagetory, TUint aKey, TOwnerType aType = EOwnerProcess) {
+    memory_system *mem = sys->get_memory_system();
+    kernel_system *kern = sys->get_kernel_system();
+
+    RProperty *prop_lle = aProp.get(mem);
+
+    property_ptr prop_hle = kern->get_prop(aCagetory, aKey);
+
+    if (!prop_hle) {
+        // Still success
+        return KErrNone;
+    }
+
+    prop_lle->iHandle = prop_hle->unique_id();
+    prop_hle->set_owner_type(aType == EOwnerProcess ? kernel::owner_type::process : kernel::owner_type::thread);
+
+    return KErrNone;
+}
+
+BRIDGE_FUNC(TInt, RPropertyCancel, eka2l1::ptr<RProperty> aProp) {
+    memory_system *mem = sys->get_memory_system();
+    kernel_system *kern = sys->get_kernel_system();
+
+    RProperty *prop_lle = aProp.get(mem);
+
+    property_ptr prop_hle = kern->get_prop(prop_lle->iHandle);
+
+    if (!prop_hle) {
+        return KErrBadHandle;
+    }
+
+    kern->unsubscribe_prop(std::make_pair(prop_hle->first, prop_hle->second));
+
+    return KErrNone;
+}
+
+BRIDGE_FUNC(TInt, RPropertyDefineNoSec, TUid aCategory, TUint aKey, TInt aAttr, TInt aPreallocate) {
+    memory_system *mem = sys->get_memory_system();
+    kernel_system *kern = sys->get_kernel_system();
+
+    RProperty *prop_lle = aProp.get(mem);
+
+    property_ptr prop_hle = kern->create_prop(aAttr >= 0 ? service::property_type::bin_data : service::property_type::int_data,
+        aPreallocate);
+
+    prop_hle->first = aCategory;
+    prop_hle->second = aKey;
+
+    prop_lle->iHandle = prop_hle->unique_id();
+
+    return KErrNone;
+}
+
+const eka2l1::hle::func_map prop_register_funcs = {
+    BRIDGE_REGISTER(525391138, RPropertyAttach),
+    BRIDGE_REGISTER(1292343699, RPropertyCancel),
+    BRIDGE_REGISTER(2000262280, RPropertyDefineNoSec)
+};

--- a/src/emu/core/src/hle/epoc9/prop.cpp
+++ b/src/emu/core/src/hle/epoc9/prop.cpp
@@ -2,7 +2,7 @@
 
 using namespace eka2l1;
 
-BRIDGE_FUNC(TInt, RPropertyAttach, eka2l1::ptr<RProperty> aProp, TUid aCagetory, TUint aKey, TOwnerType aType = EOwnerProcess) {
+BRIDGE_FUNC(TInt, RPropertyAttach, eka2l1::ptr<RProperty> aProp, TUid aCagetory, TUint aKey, TOwnerType aType) {
     memory_system *mem = sys->get_memory_system();
     kernel_system *kern = sys->get_kernel_system();
 
@@ -38,7 +38,7 @@ BRIDGE_FUNC(TInt, RPropertyCancel, eka2l1::ptr<RProperty> aProp) {
     return KErrNone;
 }
 
-BRIDGE_FUNC(TInt, RPropertyDefineNoSec, TUid aCategory, TUint aKey, TInt aAttr, TInt aPreallocate) {
+BRIDGE_FUNC(TInt, RPropertyDefineNoSec, eka2l1::ptr<RProperty> aProp, TUid aCategory, TUint aKey, TInt aAttr, TInt aPreallocate) {
     memory_system *mem = sys->get_memory_system();
     kernel_system *kern = sys->get_kernel_system();
 
@@ -55,8 +55,57 @@ BRIDGE_FUNC(TInt, RPropertyDefineNoSec, TUid aCategory, TUint aKey, TInt aAttr, 
     return KErrNone;
 }
 
+BRIDGE_FUNC(TInt, RPropertyGetInt, eka2l1::ptr<RProperty> aProp, eka2l1::ptr<TInt> aVal) {
+    memory_system *mem = sys->get_memory_system();
+    kernel_system *kern = sys->get_kernel_system();
+
+    RProperty *prop_lle = aProp.get(mem);
+    TInt *val_pass = aVal.get(mem);
+
+    property_ptr prop_hle = kern->get_prop(prop_lle->iHandle);
+
+    if (!prop_hle) {
+        return KErrNotFound;
+    }
+
+    int val = prop_hle->get_int();
+
+    if (val == -1) {
+        return KErrArgument;
+    }
+
+    *val_pass = val;
+
+    return KErrNone;
+}
+
+BRIDGE_FUNC(TInt, RPropertyGetGlobalInt, TUid aCagetory, TUint aKey, eka2l1::ptr<TInt> aValue) {
+    memory_system *mem = sys->get_memory_system();
+    kernel_system *kern = sys->get_kernel_system();
+
+    TInt *val_pass = aValue.get(mem);
+
+    property_ptr prop_hle = kern->get_prop(aCagetory, aKey);
+
+    if (!prop_hle) {
+        return KErrNotFound;
+    }
+
+    int val = prop_hle->get_int();
+
+    if (val == -1) {
+        return KErrArgument;
+    }
+
+    *val_pass = val;
+
+    return KErrNone;
+}
+
 const eka2l1::hle::func_map prop_register_funcs = {
     BRIDGE_REGISTER(525391138, RPropertyAttach),
     BRIDGE_REGISTER(1292343699, RPropertyCancel),
-    BRIDGE_REGISTER(2000262280, RPropertyDefineNoSec)
+    BRIDGE_REGISTER(2000262280, RPropertyDefineNoSec),
+    BRIDGE_REGISTER(3651614895, RPropertyGetInt),
+    BRIDGE_REGISTER(1693319139, RPropertyGetGlobalInt)
 };

--- a/src/emu/core/src/hle/epoc9/register.cpp
+++ b/src/emu/core/src/hle/epoc9/register.cpp
@@ -31,6 +31,7 @@ void register_epoc9(eka2l1::hle::lib_manager &mngr) {
     ADD_REGISTERS(mngr, cons_register_funcs);
     ADD_REGISTERS(mngr, trap_register_funcs);
     ADD_REGISTERS(mngr, svr_register_funcs);
+    ADD_REGISTERS(mngr, prop_register_funcs);
 
     ADD_SVC_REGISTERS(mngr, svc_register_funcs);
 

--- a/src/emu/core/src/loader/sis_fields.cpp
+++ b/src/emu/core/src/loader/sis_fields.cpp
@@ -64,7 +64,7 @@ namespace eka2l1 {
 
             switch (arr.element_type) {
             case sis_field_type::SISString:
-                while ((uint32_t)stream->tellg() - crr_pos < (arr.len_low | (arr.len_high << 32)) - 4) {
+                while ((uint64_t)stream->tellg() - crr_pos < (arr.len_low | (arr.len_high << 32)) - 4) {
                     auto str = std::make_shared<sis_string>(parse_string(true));
                     str->type = arr.element_type;
                     arr.fields.push_back(str);
@@ -84,7 +84,7 @@ namespace eka2l1 {
                 break;
 
             case sis_field_type::SISLanguage:
-                while ((uint32_t)stream->tellg() - crr_pos < (arr.len_low | (arr.len_high << 32)) - 4) {
+                while ((uint64_t)stream->tellg() - crr_pos < (arr.len_low | (arr.len_high << 32)) - 4) {
                     auto str = std::make_shared<sis_supported_lang>(parse_supported_lang(true));
                     str->type = arr.element_type;
                     arr.fields.push_back(str);
@@ -94,7 +94,7 @@ namespace eka2l1 {
                 break;
 
             case sis_field_type::SISDependency:
-                while ((uint32_t)stream->tellg() - crr_pos < (arr.len_low | (arr.len_high << 32)) - 4) {
+                while ((uint64_t)stream->tellg() - crr_pos < (arr.len_low | (arr.len_high << 32)) - 4) {
                     auto str = std::make_shared<sis_dependency>(parse_dependency(true));
                     str->type = arr.element_type;
                     arr.fields.push_back(str);
@@ -104,7 +104,7 @@ namespace eka2l1 {
                 break;
 
             case sis_field_type::SISProperty:
-                while ((uint32_t)stream->tellg() - crr_pos < (arr.len_low | (arr.len_high << 32)) - 4) {
+                while ((uint64_t)stream->tellg() - crr_pos < (arr.len_low | (arr.len_high << 32)) - 4) {
                     auto str = std::make_shared<sis_property>(parse_property(true));
                     str->type = arr.element_type;
                     arr.fields.push_back(str);
@@ -114,7 +114,7 @@ namespace eka2l1 {
                 break;
 
             case sis_field_type::SISFileDes:
-                while ((uint32_t)stream->tellg() - crr_pos < (arr.len_low | (arr.len_high << 32)) - 4) {
+                while ((uint64_t)stream->tellg() - crr_pos < (arr.len_low | (arr.len_high << 32)) - 4) {
                     auto str = std::make_shared<sis_file_des>(parse_file_description(true));
                     str->type = arr.element_type;
                     arr.fields.push_back(str);
@@ -124,7 +124,7 @@ namespace eka2l1 {
                 break;
 
             case sis_field_type::SISController:
-                while ((uint32_t)stream->tellg() - crr_pos < (arr.len_low | (arr.len_high << 32)) - 4) {
+                while ((uint64_t)stream->tellg() - crr_pos < (arr.len_low | (arr.len_high << 32)) - 4) {
                     auto str = std::make_shared<sis_controller>(parse_controller(true));
                     str->type = arr.element_type;
                     arr.fields.push_back(str);
@@ -134,7 +134,7 @@ namespace eka2l1 {
                 break;
 
             case sis_field_type::SISFileData:
-                while ((uint32_t)stream->tellg() - crr_pos < (arr.len_low | (arr.len_high << 32)) - 4) {
+                while ((uint64_t)stream->tellg() - crr_pos < (arr.len_low | (arr.len_high << 32)) - 4) {
                     auto str = std::make_shared<sis_file_data>(parse_file_data(true));
                     str->type = arr.element_type;
                     arr.fields.push_back(str);
@@ -144,7 +144,7 @@ namespace eka2l1 {
                 break;
 
             case sis_field_type::SISdataUnit:
-                while ((uint32_t)stream->tellg() - crr_pos < (arr.len_low | (arr.len_high << 32)) - 4) {
+                while ((uint64_t)stream->tellg() - crr_pos < (arr.len_low | (arr.len_high << 32)) - 4) {
                     auto str = std::make_shared<sis_data_unit>(parse_data_unit(true));
                     str->type = arr.element_type;
                     arr.fields.push_back(str);
@@ -154,7 +154,7 @@ namespace eka2l1 {
                 break;
 
             case sis_field_type::SISExpression:
-                while ((uint32_t)stream->tellg() - crr_pos < (arr.len_low | (arr.len_high << 32)) - 4) {
+                while ((uint64_t)stream->tellg() - crr_pos < (arr.len_low | (arr.len_high << 32)) - 4) {
                     auto str = std::make_shared<sis_expression>(parse_expression(true));
                     str->type = arr.element_type;
                     arr.fields.push_back(str);
@@ -164,7 +164,7 @@ namespace eka2l1 {
                 break;
 
             case sis_field_type::SISIf:
-                while ((uint32_t)stream->tellg() - crr_pos < (arr.len_low | (arr.len_high << 32)) - 4) {
+                while ((uint64_t)stream->tellg() - crr_pos < (arr.len_low | (arr.len_high << 32)) - 4) {
                     auto str = std::make_shared<sis_if>(parse_if(true));
                     str->type = arr.element_type;
                     arr.fields.push_back(str);
@@ -174,7 +174,7 @@ namespace eka2l1 {
                 break;
 
             case sis_field_type::SISElseIf:
-                while ((uint32_t)stream->tellg() - crr_pos < (arr.len_low | (arr.len_high << 32)) - 4) {
+                while ((uint64_t)stream->tellg() - crr_pos < (arr.len_low | (arr.len_high << 32)) - 4) {
                     auto str = std::make_shared<sis_else_if>(parse_if_else(true));
                     str->type = arr.element_type;
                     arr.fields.push_back(str);
@@ -184,7 +184,7 @@ namespace eka2l1 {
                 break;
 
             case sis_field_type::SISSignature:
-                while ((uint32_t)stream->tellg() - crr_pos < (arr.len_low | (arr.len_high << 32)) - 4) {
+                while ((uint64_t)stream->tellg() - crr_pos < (arr.len_low | (arr.len_high << 32)) - 4) {
                     auto str = std::make_shared<sis_sig>(parse_signature(true));
                     str->type = arr.element_type;
                     arr.fields.push_back(str);

--- a/src/emu/core/src/services/property.cpp
+++ b/src/emu/core/src/services/property.cpp
@@ -1,12 +1,20 @@
 #include <core_kernel.h>
 #include <services/property.h>
 
+#include <common/log.h>
+
 namespace eka2l1 {
     namespace service {
         property::property(kernel_system *kern, service::property_type pt, uint32_t pre_allocated)
             : kernel::kernel_obj(kern, "", kernel::owner_type::process,
                   kern->get_id_base_owner(kernel::owner_type::process))
-              , data_type(pt), data_len(pre_allocated) {}
+            , data_type(pt)
+            , data_len(pre_allocated) {
+            if (pre_allocated > 512) {
+                LOG_WARN("Property trying to alloc more then 512 bytes, limited to 512 bytes");
+                data_len = 512;
+            }
+        }
 
         bool property::set(int val) {
             if (data_type == service::property_type::int_data) {
@@ -43,10 +51,6 @@ namespace eka2l1 {
             memcpy(local.data(), data.bindata.data(), bin_data_len);
 
             return local;
-        }
-
-        void property::delete_prop() {
-            notify_request();
         }
     }
 }

--- a/src/emu/core/src/services/property.cpp
+++ b/src/emu/core/src/services/property.cpp
@@ -41,6 +41,10 @@ namespace eka2l1 {
         }
 
         int property::get_int() {
+            if (data_type != service::property_type::int_data) {
+                return -1;
+            }
+
             return data.ndata;
         }
 
@@ -52,5 +56,10 @@ namespace eka2l1 {
 
             return local;
         }
+
+        void property::notify_request() {
+            kern->notify_prop(std::make_pair(first, second));
+        }
+
     }
 }


### PR DESCRIPTION
This PR implement the ITC Publish & Subscribe mechanism behind property.

A property is like an environment data, defined by category and key, can be either number or binary data. A thread can subscribe, unsubscribe, get, set a property. 

When subscribe to a property with a request status, that request status is stored and tied with pair of category and key.
When a property is changed, it notify the request and signal the request semaphore of thread.

Property will be used in complex app in the future, or simply just get/set system configs.

Note that:
    1. In Symbian, the security layer is important, while here I'm ignoring it.
    2. This doesn't implement all HLE functions of RProperty. Other can be implement easily.