### PR TITLE
Dynarmic support and ARM JIT refactoring

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,9 @@
 [submodule "src/external/glm"]
 	path = src/external/glm
 	url = https://github.com/g-truc/glm
+[submodule "dynarmic"]
+	path = src/external/dynarmic
+	url = https://github.com/merrymage/dynarmic
+[submodule "ext-boost"]
+	path = src/external/ext-boost
+	url = https://github.com/MerryMage/ext-boost

--- a/src/emu/core/include/core/arm/jit_dynarmic.h
+++ b/src/emu/core/include/core/arm/jit_dynarmic.h
@@ -102,6 +102,8 @@ namespace eka2l1 {
             void prepare_rescheduling() override;
 
             bool is_thumb_mode() override;
+
+            void imb_range(address start, uint32_t len);
         };
     }
 }

--- a/src/emu/core/include/core/arm/jit_dynarmic.h
+++ b/src/emu/core/include/core/arm/jit_dynarmic.h
@@ -18,3 +18,90 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <arm/jit_interface.h>
+#include <arm/jit_unicorn.h>
+
+#include <dynarmic/A32/a32.h>
+
+#include <memory>
+
+namespace eka2l1 {
+    class timing_system;
+    class disasm;
+    class memory_system;
+
+    namespace hle {
+        class lib_manager;
+    }
+
+    namespace arm {
+        class arm_dynarmic_callback;
+
+        class jit_dynarmic : public jit_interface {
+            friend class arm_dynarmic_callback;
+            
+            jit_unicorn fallback_jit;
+
+            std::unique_ptr<Dynarmic::A32::Jit> jit;
+            std::unique_ptr<arm_dynarmic_callback> cb;
+
+            timing_system *timing;
+            disasm *asmdis;
+            memory_system *mem;
+
+            hle::lib_manager *lib_mngr;
+        public:
+            bool execute_instructions(int num_instructions) override;
+
+            timing_system *get_timing_sys() {
+                return timing;
+            }
+
+            disasm *get_disasm_sys() {
+                return asmdis;
+            }
+
+            memory_system *get_memory_sys() {
+                return mem;
+            }
+
+            hle::lib_manager *get_lib_manager() {
+                return lib_mngr;
+            }
+
+            jit_dynarmic(timing_system *sys, memory_system *mem, disasm *asmdis, hle::lib_manager *mngr);
+            ~jit_dynarmic();
+
+            void run() override;
+            void stop() override;
+
+            void step() override;
+
+            uint32_t get_reg(size_t idx) override;
+            uint64_t get_sp() override;
+            uint64_t get_pc() override;
+            uint64_t get_vfp(size_t idx) override;
+
+            void set_reg(size_t idx, uint32_t val) override;
+            void set_pc(uint64_t val) override;
+            void set_sp(uint32_t val) override;
+            void set_lr(uint64_t val) override;
+            void set_vfp(size_t idx, uint64_t val) override;
+
+            uint32_t get_cpsr() override;
+
+            void save_context(thread_context &ctx) override;
+            void load_context(const thread_context &ctx) override;
+
+            void set_entry_point(address ep) override;
+            address get_entry_point() override;
+
+            void set_stack_top(address addr) override;
+            address get_stack_top() override;
+
+            void prepare_rescheduling() override;
+
+            bool is_thumb_mode() override;
+        };
+    }
+}

--- a/src/emu/core/include/core/arm/jit_factory.h
+++ b/src/emu/core/include/core/arm/jit_factory.h
@@ -33,7 +33,8 @@ namespace eka2l1 {
 
     namespace arm {
         enum jitter_arm_type {
-            unicorn = 0
+            unicorn = 0,
+            dynarmic = 1
         };
 
         class jit_interface;

--- a/src/emu/core/include/core/core_kernel.h
+++ b/src/emu/core/include/core/core_kernel.h
@@ -53,7 +53,7 @@ namespace eka2l1 {
     }
 
     using thread_ptr = std::shared_ptr<kernel::thread>;
-    using process_ptr = std::shared_ptr<process>;
+    using process_ptr = std::shared_ptr<eka2l1::process>;
     using chunk_ptr = std::shared_ptr<kernel::chunk>;
     using mutex_ptr = std::shared_ptr<kernel::mutex>;
     using sema_ptr = std::shared_ptr<kernel::semaphore>;

--- a/src/emu/core/include/core/disasm/disasm.h
+++ b/src/emu/core/include/core/disasm/disasm.h
@@ -26,7 +26,7 @@
 #include <vector>
 
 namespace eka2l1 {
-	/*! \brief Contains ARM jitter and related things. */
+    /*! \brief Contains ARM jitter and related things. */
     namespace arm {
         class jit_interface;
         using jitter = std::unique_ptr<jit_interface>;
@@ -43,13 +43,13 @@ namespace eka2l1 {
         data = 0x02
     };
 
-	/*! \brief Represents a subroutine. */
+    /*! \brief Represents a subroutine. */
     struct subroutine {
         std::vector<arm_inst_type> insts;
         ptr<uint8_t> end;
     };
 
-	/*! \brief An ARM disassembler. */
+    /*! \brief An ARM disassembler. */
     class disasm {
         using insn_ptr = std::unique_ptr<cs_insn, std::function<void(cs_insn *)>>;
         using csh_ptr = std::unique_ptr<csh, std::function<void(csh *)>>;
@@ -62,24 +62,26 @@ namespace eka2l1 {
         arm::jitter jitter;
 
     public:
-	    /*! \brief Initialize the disassembler.
+        /*! \brief Initialize the disassembler.
 		 * \param smem The memory system.
 		*/
         void init(memory_system *smem);
-        
-		/*! \brief Shutdown the disassembler. */
-		void shutdown();
 
-		/*! \brief Get a subroutine.
+        /*! \brief Shutdown the disassembler. */
+        void shutdown();
+
+        /*! \brief Get a subroutine.
 		 * \param beg HLE pointer to the start of a subroutine.
 		 * \returns The subroutine
 		*/
         subroutine get_subroutine(ptr<uint8_t> beg);
-		
-		/*! \brief Disassemble binary code.
+
+        /*! \brief Disassemble binary code.
 		 * \returns The description of the instruction.
 		*/
         std::string disassemble(const uint8_t *code, size_t size, uint64_t address, bool thumb);
+
+        /*! \brief Check if the address contains thumb inst*/
+        bool thumb(uint64_t address);
     };
 }
-

--- a/src/emu/core/include/core/hle/libmanager.h
+++ b/src/emu/core/include/core/hle/libmanager.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <common/types.h>
+#include <core_kernel.h>
 
 #include <functional>
 #include <map>
@@ -69,7 +70,7 @@ namespace eka2l1 {
             std::vector<uint32_t> loader;
         };
 
-		/*! \brief Manage libraries and HLE functions.
+        /*! \brief Manage libraries and HLE functions.
 		 * 
 		 * HLE functions are stored here. Libraries and images are also cached
 		 * and load when needed.
@@ -94,6 +95,15 @@ namespace eka2l1 {
             kernel_system *kern;
             system *sys;
 
+            chunk_ptr custom_stub;
+            chunk_ptr stub;
+
+            ptr<uint32_t> stub_ptr;
+            ptr<uint32_t> custom_stub_ptr;
+
+            std::map<uint32_t, ptr<uint32_t>> stubbed;
+            std::map<uint32_t, ptr<uint32_t>> custom_stubbed;
+
         public:
             std::map<sid, epoc_import_func> import_funcs;
             std::map<sid, epoc_import_func> svc_funcs;
@@ -101,21 +111,26 @@ namespace eka2l1 {
 
             lib_manager(){};
 
-			/*! \brief Intialize the library manager. 
+            ptr<uint32_t> get_stub(uint32_t id);
+            ptr<uint32_t> do_custom_stub(uint32_t addr);
+
+            void register_custom_func(std::pair<address, epoc_import_func> func);
+
+            /*! \brief Intialize the library manager. 
 			 * \param ver The EPOC version to import HLE functions.
 			*/
             void init(system *sys, kernel_system *kern, io_system *ios, memory_system *mems, epocver ver);
-            
-			/*! \brief Shutdown the library manager. */
-			void shutdown();
 
-			/*! \brief Reset the library manager. */
+            /*! \brief Shutdown the library manager. */
+            void shutdown();
+
+            /*! \brief Reset the library manager. */
             void reset();
 
-			/*! \brief Get the SIDS of a library. */
+            /*! \brief Get the SIDS of a library. */
             std::optional<sids> get_sids(const std::u16string &lib_name);
-			
-			/*! \brief Get the export addresses of a library. */
+
+            /*! \brief Get the export addresses of a library. */
             std::optional<exportaddrs> get_export_addrs(const std::u16string &lib_name);
 
             void register_hle(sid id, epoc_import_func func);
@@ -123,22 +138,22 @@ namespace eka2l1 {
             /*! \brief Get the HLE function from an SID */
             std::optional<epoc_import_func> get_hle(sid id);
 
-			/*! \brief Call HLE function with an ID */
+            /*! \brief Call HLE function with an ID */
             bool call_hle(sid id);
-			
-			/*! \brief Call a HLE function registered at a specific address */
+
+            /*! \brief Call a HLE function registered at a specific address */
             bool call_custom_hle(address addr);
-			
-			/*! \brief Call a HLE system call.
+
+            /*! \brief Call a HLE system call.
 			 * \param svcnum The system call ordinal.
 			*/
             bool call_svc(sid svcnum);
 
-			/*! \brief Load an E32Image. */
+            /*! \brief Load an E32Image. */
             loader::e32img_ptr load_e32img(const std::u16string &img_name);
-            
-			/*! \brief Load an ROM image. */
-			loader::romimg_ptr load_romimg(const std::u16string &rom_name, bool log_export = false);
+
+            /*! \brief Load an ROM image. */
+            loader::romimg_ptr load_romimg(const std::u16string &rom_name, bool log_export = false);
 
             /*! \brief Open the image code segment */
             void open_e32img(loader::e32img_ptr &img);
@@ -158,7 +173,7 @@ namespace eka2l1 {
             bool register_exports(const std::u16string &lib_name, exportaddrs &addrs, bool log_export = false);
             std::optional<sid> get_sid(exportaddr addr);
 
-			/*! \brief Given an SID, get the function name. */
+            /*! \brief Given an SID, get the function name. */
             std::optional<std::string> get_func_name(const sid id);
 
             std::map<uint32_t, e32img_inf> &get_e32imgs_cache() {
@@ -169,7 +184,7 @@ namespace eka2l1 {
                 return romimgs_cache;
             }
 
-			/*! \brief Given a class name, return the vtable address.
+            /*! \brief Given a class name, return the vtable address.
 			 * \returns 0 if the class doesn't exists in the cache, else returns the vtable address of that class.
 			*/
             address get_vtable_address(const std::string class_name);

--- a/src/emu/core/include/core/hle/libmanager.h
+++ b/src/emu/core/include/core/hle/libmanager.h
@@ -21,7 +21,6 @@
 #pragma once
 
 #include <common/types.h>
-#include <core_kernel.h>
 
 #include <functional>
 #include <map>
@@ -29,6 +28,8 @@
 #include <optional>
 #include <string>
 #include <vector>
+
+#include <ptr.h>
 
 namespace YAML {
     class Node;
@@ -47,7 +48,13 @@ namespace eka2l1 {
 
     typedef uint32_t address;
 
-    namespace loader {
+    namespace kernel {
+        class chunk;
+    }
+
+    using chunk_ptr = std::shared_ptr<kernel::chunk>;
+
+   namespace loader {
         struct eka2img;
         struct romimg;
 

--- a/src/emu/core/include/core/hle/libmanager.h
+++ b/src/emu/core/include/core/hle/libmanager.h
@@ -112,7 +112,7 @@ namespace eka2l1 {
             std::map<uint32_t, ptr<uint32_t>> custom_stubbed;
 
         public:
-            std::map<sid, epoc_import_func> import_funcs;
+            std::map<address, epoc_import_func> import_funcs;
             std::map<sid, epoc_import_func> svc_funcs;
             std::map<address, epoc_import_func> custom_funcs;
 
@@ -120,6 +120,8 @@ namespace eka2l1 {
 
             ptr<uint32_t> get_stub(uint32_t id);
             ptr<uint32_t> do_custom_stub(uint32_t addr);
+
+            void patch_hle();
 
             void register_custom_func(std::pair<address, epoc_import_func> func);
 

--- a/src/emu/core/include/core/kernel/kernel_obj.h
+++ b/src/emu/core/include/core/kernel/kernel_obj.h
@@ -30,6 +30,7 @@ namespace eka2l1 {
         using uid = uint64_t;
 
         enum class owner_type {
+            kernel,  // Kernel has id of 0xDDDDDDDD
             process,
             thread
         };

--- a/src/emu/core/include/core/loader/eka2img.h
+++ b/src/emu/core/include/core/loader/eka2img.h
@@ -193,9 +193,6 @@ namespace eka2l1 {
 
             chunk_ptr code_chunk;
             chunk_ptr data_chunk;
-            chunk_ptr stub_chunk;
-
-            eka2l1::ptr<uint32_t> stub_ptr;
 
             bool has_extended_header = false;
         };

--- a/src/emu/core/include/core/loader/eka2img.h
+++ b/src/emu/core/include/core/loader/eka2img.h
@@ -193,6 +193,9 @@ namespace eka2l1 {
 
             chunk_ptr code_chunk;
             chunk_ptr data_chunk;
+            chunk_ptr stub_chunk;
+
+            eka2l1::ptr<uint32_t> stub_ptr;
 
             bool has_extended_header = false;
         };

--- a/src/emu/core/src/arm/CMakeLists.txt
+++ b/src/emu/core/src/arm/CMakeLists.txt
@@ -1,9 +1,11 @@
 add_library(arm
 	${CORE_INCLUDE_DIR}/arm/jit_interface.h
-        ${CORE_INCLUDE_DIR}/arm/jit_unicorn.h
-        ${CORE_INCLUDE_DIR}/arm/jit_factory.h
-        jit_unicorn.cpp
-        jit_factory.cpp)
+    ${CORE_INCLUDE_DIR}/arm/jit_dynarmic.h
+    ${CORE_INCLUDE_DIR}/arm/jit_unicorn.h
+    ${CORE_INCLUDE_DIR}/arm/jit_factory.h
+    jit_unicorn.cpp
+    jit_factory.cpp
+    jit_dynarmic.cpp)
 
 target_include_directories(arm PUBLIC ${CORE_INCLUDE_DIR})
 
@@ -13,4 +15,5 @@ target_link_libraries(arm
 	disasm 
 	coremem 
 	coretiming
-	unicorn)
+	unicorn
+    dynarmic)

--- a/src/emu/core/src/arm/jit_dynarmic.cpp
+++ b/src/emu/core/src/arm/jit_dynarmic.cpp
@@ -107,6 +107,12 @@ namespace eka2l1 {
                     }
 
                     return;
+                } else if (svc == 1) {
+                    // Custom call
+                    uint32_t val = *parent.get_memory_sys()->get_addr<uint32_t>(parent.get_pc() + 4);
+                    bool res = mngr->call_custom_hle(val);
+
+                    return;
                 }
 
                 bool res = mngr->call_svc(svc);

--- a/src/emu/core/src/arm/jit_dynarmic.cpp
+++ b/src/emu/core/src/arm/jit_dynarmic.cpp
@@ -10,6 +10,7 @@ namespace eka2l1 {
             uint64_t interpreted;
 
             int routine_ticks = 32;
+            int default_ticks = 32;
 
             bool log_read = true;
             bool log_write = true;
@@ -21,6 +22,7 @@ namespace eka2l1 {
 
             void set_routine_ticks(int new_ticks) {
                 routine_ticks = new_ticks;
+                default_ticks = new_ticks;
             }
 
             uint8_t MemoryRead8(Dynarmic::A32::VAddr addr) override {
@@ -153,7 +155,7 @@ namespace eka2l1 {
                 uint64_t res = static_cast<uint64_t>(std::max(routine_ticks, 0));
 
                 if (res <= 0) {
-                    routine_ticks = 32;
+                    routine_ticks = default_ticks;
                 }
 
                 return res;

--- a/src/emu/core/src/arm/jit_dynarmic.cpp
+++ b/src/emu/core/src/arm/jit_dynarmic.cpp
@@ -1,0 +1,250 @@
+#include <arm/jit_dynarmic.h>
+#include <common/log.h>
+
+#include <core_timing.h>
+
+namespace eka2l1 {
+    namespace arm {
+        class arm_dynarmic_callback : public Dynarmic::A32::UserCallbacks {
+            jit_dynarmic &parent;
+            uint64_t interpreted;
+
+            int routine_ticks = 32;
+
+            bool log_read = true;
+            bool log_write = true;
+            bool log_code = true;
+
+        public:
+            explicit arm_dynarmic_callback(jit_dynarmic &parent)
+                : parent(parent) {}
+
+            void set_routine_ticks(int new_ticks) {
+                routine_ticks = new_ticks;
+            }
+
+            uint8_t MemoryRead8(Dynarmic::A32::VAddr addr) override {
+                uint8_t ret = *parent.get_memory_sys()->get_addr<uint8_t>(addr);
+
+                if (log_read) {
+                    LOG_TRACE("[Dynarmic] Read uint8_t at address: 0x{:x}, val = 0x{:x}", addr, ret);
+                }
+
+                return ret;
+            }
+
+            uint16_t MemoryRead16(Dynarmic::A32::VAddr addr) override {
+                uint16_t ret = *parent.get_memory_sys()->get_addr<uint16_t>(addr);
+
+                if (log_read) {
+                    LOG_TRACE("[Dynarmic] Read uint16_t at address: 0x{:x}, val = 0x{:x}", addr, ret);
+                }
+            }
+
+            uint32_t MemoryRead32(Dynarmic::A32::VAddr addr) override {
+                uint32_t ret = *parent.get_memory_sys()->get_addr<uint32_t>(addr);
+
+                if (log_read) {
+                    LOG_TRACE("[Dynarmic] Read uint32_t at address: 0x{:x}, val = 0x{:x}", addr, ret);
+                }
+
+                return ret;
+            }
+
+            void MemoryWrite8(Dynarmic::A32::VAddr addr, uint8_t value) override {
+                *parent.get_memory_sys()->get_addr<uint8_t>(addr) = value;
+
+                if (log_write) {
+                    LOG_TRACE("[Dynarmic] Write uint8_t at addr: 0x{:x}, val = 0x{:x}", addr, value);
+                }
+            }
+
+            void MemoryWrite16(Dynarmic::A32::VAddr addr, uint16_t value) override {
+                *parent.get_memory_sys()->get_addr<uint16_t>(addr) = value;
+
+                if (log_write) {
+                    LOG_TRACE("[Dynarmic] Write uint16_t at addr: 0x{:x}, val = 0x{:x}", addr, value);
+                }
+            }
+
+            void MemoryWrite32(Dynarmic::A32::VAddr addr, uint32_t value) override {
+                *parent.get_memory_sys()->get_addr<uint32_t>(addr) = value;
+
+                if (log_write) {
+                    LOG_TRACE("[Dynarmic] Write uint32_t at addr: 0x{:x}, val = 0x{:x}", addr, value);
+                }
+            }
+
+            void InterpreterFallback(Dynarmic::A32::VAddr addr, size_t num_insts) {
+                jit_interface::thread_context context;
+                parent.save_context(context);
+                parent.fallback_jit.load_context(context);
+                parent.fallback_jit.execute_instructions(num_insts);
+                parent.fallback_jit.save_context(context);
+                parent.load_context(context);
+
+                interpreted += num_insts;
+            }
+
+            void ExceptionRaised(uint32_t pc, Dynarmic::A32::Exception exception) override {
+                switch (exception) {
+                case Dynarmic::A32::Exception::Breakpoint:
+                    return;
+                default:
+                    LOG_WARN("Exception Raised at pc = 0x{:x}", pc);
+                }
+            }
+
+            void CallSVC(uint32_t svc) override {
+                hle::lib_manager *mngr = parent.get_lib_manager();
+
+                if (svc == 0) {
+                    uint32_t val = *parent.get_memory_sys()->get_addr<uint32_t>(parent.get_pc() + 4);
+                    bool res = mngr->call_hle(val);
+
+                    if (!res) {
+                        LOG_WARN("Unimplemented method!");
+                    }
+
+                    return;
+                }
+
+                bool res = mngr->call_svc(svc);
+
+                if (!res) {
+                    LOG_INFO("Unimplemented SVC call: 0x{:x}", svc);
+                }
+            }
+
+            void AddTicks(uint64_t ticks) override {
+                parent.get_timing_sys()->add_ticks(ticks - interpreted);
+                routine_ticks -= ticks + interpreted;
+
+                interpreted = 0;
+            }
+
+            uint64_t GetTicksRemaining() override {
+                uint64_t res = static_cast<uint64_t>(std::max(routine_ticks, 0));
+
+                if (res <= 0) {
+                    routine_ticks = 32;
+                }
+
+                return res;
+            }
+        };
+
+        std::unique_ptr<Dynarmic::A32::Jit> make_jit(std::unique_ptr<arm_dynarmic_callback> &callback) {
+            Dynarmic::A32::UserConfig config;
+            config.callbacks = callback.get();
+
+            return std::make_unique<Dynarmic::A32::Jit>(config);
+        }
+
+        jit_dynarmic::jit_dynarmic(timing_system *sys, memory_system *mem, disasm *asmdis, hle::lib_manager *mngr)
+            : timing(sys)
+            , mem(mem)
+            , asmdis(asmdis)
+            , lib_mngr(mngr)
+            , fallback_jit(sys, mem, asmdis, mngr)
+            , cb(std::make_unique<arm_dynarmic_callback>(*this))
+            , jit(make_jit(cb)) {
+        }
+
+        jit_dynarmic::~jit_dynarmic() {}
+
+        bool jit_dynarmic::execute_instructions(int num_instructions) {
+            cb->set_routine_ticks(num_instructions);
+            jit->Run();
+        }
+
+        void jit_dynarmic::run() {
+            jit->Run();
+        }
+
+        void jit_dynarmic::stop() {
+        }
+
+        void jit_dynarmic::step() {
+            cb->InterpreterFallback(get_pc(), 1);
+        }
+
+        uint32_t jit_dynarmic::get_reg(size_t idx) {
+            return jit->Regs[idx];
+        }
+
+        uint64_t jit_dynarmic::get_sp() {
+            return jit->Regs[13];
+        }
+
+        uint64_t jit_dynarmic::get_pc() {
+            return jit->Regs[15];
+        }
+
+        uint64_t jit_dynarmic::get_vfp(size_t idx) {
+            return 0;
+        }
+
+        void jit_dynarmic::set_reg(size_t idx, uint32_t val) {
+            jit->Regs[idx] = val;
+        }
+
+        void jit_dynarmic::set_pc(uint64_t val) {
+            jit->Regs[15] = val;
+        }
+
+        void jit_dynarmic::set_sp(uint32_t val) {
+            jit->Regs[13] = val;
+        }
+
+        void jit_dynarmic::set_lr(uint64_t val) {
+            jit->Regs[14] = val;
+        }
+
+        void jit_dynarmic::set_vfp(size_t idx, uint64_t val) {
+        }
+
+        uint32_t jit_dynarmic::get_cpsr() {
+            return jit->Cpsr();
+        }
+
+        void jit_dynarmic::save_context(thread_context &ctx) {
+            ctx.cpsr = get_cpsr();
+            ctx.cpu_registers = jit->Regs;
+            ctx.pc = get_pc();
+            ctx.sp = get_sp();
+        }
+
+        void jit_dynarmic::load_context(const thread_context &ctx) {
+            jit->SetCpsr(ctx.cpsr);
+
+            for (uint8_t i = 0; i < ctx.cpu_registers.size(); i++) {
+                jit->Regs[i] = ctx.cpu_registers[i];
+            }
+
+            set_pc(ctx.pc);
+            set_sp(ctx.sp);
+        }
+
+        void jit_dynarmic::set_entry_point(address ep) {
+        }
+
+        address jit_dynarmic::get_entry_point() {
+        }
+
+        void jit_dynarmic::set_stack_top(address addr) {
+            set_sp(addr);
+        }
+
+        address jit_dynarmic::get_stack_top() {
+            return get_sp();
+        }
+
+        void jit_dynarmic::prepare_rescheduling() {
+        }
+
+        bool jit_dynarmic::is_thumb_mode() {
+            return get_cpsr() & 0x20;
+        }
+    }
+}

--- a/src/emu/core/src/arm/jit_factory.cpp
+++ b/src/emu/core/src/arm/jit_factory.cpp
@@ -19,6 +19,8 @@
  */
 #include <arm/jit_factory.h>
 #include <arm/jit_unicorn.h>
+#include <arm/jit_dynarmic.h>
+
 #include <core_timing.h>
 
 namespace eka2l1 {
@@ -28,10 +30,11 @@ namespace eka2l1 {
             switch (arm_type) {
             case unicorn:
                 return std::make_unique<jit_unicorn>(timing, mem, asmdis, mngr);
+            case dynarmic:
+                return std::make_unique<jit_dynarmic>(timing, mem, asmdis, mngr);
             default:
                 return jitter(nullptr);
             }
         }
     }
 }
-

--- a/src/emu/core/src/arm/jit_unicorn.cpp
+++ b/src/emu/core/src/arm/jit_unicorn.cpp
@@ -51,7 +51,7 @@ void read_hook(uc_engine *uc, uc_mem_type type, uint32_t address, int size, int6
     }
 
     memcpy(&value, eka2l1::ptr<const void>(address).get(jit->get_memory_sys()), size);
-    
+
     const bool read_log = false;
 
     if (read_log)
@@ -84,49 +84,10 @@ void code_hook(uc_engine *uc, uint32_t address, uint32_t size, void *user_data) 
     jit->save_context(context_debug);
     eka2l1::hle::lib_manager *mngr = jit->get_lib_manager();
 
-    /*
-    if (mngr) {
-        // Use this manager to get the address
-        auto sid_correspond = mngr->get_sid(address);
-
-        if (!sid_correspond && thumb_mode(uc)) {
-            sid_correspond = mngr->get_sid(address + 1);
-        }
-
-        if (sid_correspond) {
-            // DO nothing now
-            auto func_name = mngr->get_func_name(sid_correspond.value());
-
-            const bool log_call = true;
-
-            if (log_call) {
-                LOG_INFO("Calling HLE function: {} [0x{:x}]", func_name.value(), address);
-            }
-
-            if (mngr->call_hle(sid_correspond.value())) {
-                uint32_t lr = 0;
-
-                uc_reg_read(uc, UC_ARM_REG_LR, &lr);
-                uc_reg_write(uc, UC_ARM_REG_PC, &lr);
-
-                return;
-            }
-        } else {
-            if (mngr->call_custom_hle(address)) {
-                uint32_t lr = 0;
-
-                uc_reg_read(uc, UC_ARM_REG_LR, &lr);
-                uc_reg_write(uc, UC_ARM_REG_PC, &lr);
-
-                return;
-            }
-        }
-    }*/
-
     const bool log_code = false;
 
     if (log_code) {
-        const uint8_t * code = eka2l1::ptr<const uint8_t>(address).get(jit->get_memory_sys());
+        const uint8_t *code = eka2l1::ptr<const uint8_t>(address).get(jit->get_memory_sys());
         size_t buffer_size = eka2l1::common::GB(4) - address;
         bool thumb = thumb_mode(uc);
         std::string disassembly = jit->get_disasm_sys()->disassemble(code, buffer_size, address, thumb);
@@ -146,14 +107,15 @@ void intr_hook(uc_engine *uc, uint32_t int_no, void *user_data) {
 
     uint32_t imm = 0;
 
-    if (thumb_mode(uc)) {
+    bool thumb = thumb_mode(uc);
+
+    if (thumb) {
         uint16_t svc_inst = 0;
 
         address svca = jit->get_pc() - 2;
         uc_mem_read(uc, svca, &svc_inst, 2);
         imm = svc_inst & 0xff;
-    }
-    else {
+    } else {
         uint32_t svc_inst = 0;
 
         address svca = jit->get_pc() - 4;
@@ -162,10 +124,36 @@ void intr_hook(uc_engine *uc, uint32_t int_no, void *user_data) {
     }
 
     if (imm == 0) {
-        jit->get_lib_manager()->call_hle(*eka2l1::ptr<uint32_t>(jit->get_pc() + 4).get(jit->get_memory_sys()));
+        uint32_t sid = *eka2l1::ptr<uint32_t>(jit->get_pc() + 4).get(jit->get_memory_sys());
+        auto func_name = jit->get_lib_manager()->get_func_name(sid);
+
+        if (func_name) {
+            LOG_INFO("Calling {} [0x{:x}]", *func_name, jit->get_reg(14));
+        }
+
+        jit->get_lib_manager()->call_hle(sid);
         return;
     } else if (imm == 1) {
         jit->get_lib_manager()->call_custom_hle(*eka2l1::ptr<uint32_t>(jit->get_pc() + 4).get(jit->get_memory_sys()));
+        return;
+    } else if (imm == 2) {
+        uint32_t call_addr = jit->get_pc();
+
+        if (call_addr && thumb) {
+            call_addr -= 1;
+        } else {
+            call_addr -= 4;
+        }
+
+        bool res = jit->get_lib_manager()->call_hle(*jit->get_lib_manager()->get_sid(call_addr));
+
+        if (res) {
+            uint32_t lr = 0;
+            uc_reg_read(uc, UC_ARM_REG_LR, &lr);
+
+            jit->set_pc(lr);
+        }
+
         return;
     }
 
@@ -312,7 +300,7 @@ namespace eka2l1 {
 
         uint32_t jit_unicorn::get_reg(size_t idx) {
             uint32_t val = 0;
-            auto treg = UC_ARM_REG_R0 + idx; 
+            auto treg = UC_ARM_REG_R0 + idx;
             auto err = uc_reg_read(engine, treg, &val);
 
             if (err != UC_ERR_OK) {
@@ -442,4 +430,3 @@ namespace eka2l1 {
         }
     }
 }
-

--- a/src/emu/core/src/arm/jit_unicorn.cpp
+++ b/src/emu/core/src/arm/jit_unicorn.cpp
@@ -84,6 +84,7 @@ void code_hook(uc_engine *uc, uint32_t address, uint32_t size, void *user_data) 
     jit->save_context(context_debug);
     eka2l1::hle::lib_manager *mngr = jit->get_lib_manager();
 
+    /*
     if (mngr) {
         // Use this manager to get the address
         auto sid_correspond = mngr->get_sid(address);
@@ -120,7 +121,7 @@ void code_hook(uc_engine *uc, uint32_t address, uint32_t size, void *user_data) 
                 return;
             }
         }
-    }
+    }*/
 
     const bool log_code = false;
 
@@ -158,6 +159,14 @@ void intr_hook(uc_engine *uc, uint32_t int_no, void *user_data) {
         address svca = jit->get_pc() - 4;
         uc_mem_read(uc, svca, &svc_inst, 4);
         imm = svc_inst & 0xffffff;
+    }
+
+    if (imm == 0) {
+        jit->get_lib_manager()->call_hle(*eka2l1::ptr<uint32_t>(jit->get_pc() + 4).get(jit->get_memory_sys()));
+        return;
+    } else if (imm == 1) {
+        jit->get_lib_manager()->call_custom_hle(*eka2l1::ptr<uint32_t>(jit->get_pc() + 4).get(jit->get_memory_sys()));
+        return;
     }
 
     if (!jit->get_lib_manager()->call_svc(imm)) {

--- a/src/emu/core/src/core.cpp
+++ b/src/emu/core/src/core.cpp
@@ -87,8 +87,8 @@ namespace eka2l1 {
             while (ticks < downcount && !exit && kern.crr_thread() != nullptr) {
                 emu_screen_driver->begin_render();
 
-                cpu->execute_instructions(32);
-                ticks += 32;
+                cpu->execute_instructions(2048);
+                ticks += 2048;
 
                 emu_screen_driver->end_render();
             }

--- a/src/emu/core/src/core_api.cpp
+++ b/src/emu/core/src/core_api.cpp
@@ -29,7 +29,7 @@ using namespace eka2l1;
 int create_symbian_system(int win_type, int render_type, int cpu_type) {
     syses.push_back(std::make_unique<eka2l1::system>(win_type == GLFW ? driver::window_type::glfw : driver::window_type::glfw,
         render_type == OPENGL ? driver::driver_type::opengl : driver::driver_type::opengl,
-        cpu_type == CPU_UNICORN ? arm::jitter_arm_type::unicorn : arm::jitter_arm_type::unicorn));
+        cpu_type == CPU_UNICORN ? arm::jitter_arm_type::unicorn : arm::jitter_arm_type::dynarmic));
 
     return (int)syses.size();
 }

--- a/src/emu/core/src/core_kernel.cpp
+++ b/src/emu/core/src/core_kernel.cpp
@@ -109,6 +109,7 @@ namespace eka2l1 {
 
         crr_process_id = uid;
         libmngr->open_e32img(res2);
+        libmngr->patch_hle();
 
         processes.insert(std::make_pair(uid, std::make_shared<process>(this, mem, uid, name, path16, u"", res2)));
 

--- a/src/emu/core/src/core_kernel.cpp
+++ b/src/emu/core/src/core_kernel.cpp
@@ -181,7 +181,8 @@ namespace eka2l1 {
     }
 
     kernel::uid kernel_system::get_id_base_owner(kernel::owner_type owner) const {
-        return owner == kernel::owner_type::process ? crr_process_id : thr_sch->current_thread()->unique_id();
+        return owner == kernel::owner_type::process ? crr_process_id :
+            (owner == kernel::owner_type::thread ? thr_sch->current_thread()->unique_id() : 0xDDDDDDDD);
     }
 
     chunk_ptr kernel_system::create_chunk(std::string name, const address bottom, const address top, const size_t size, prot protection,

--- a/src/emu/core/src/disasm/disasm.cpp
+++ b/src/emu/core/src/disasm/disasm.cpp
@@ -123,5 +123,17 @@ namespace eka2l1 {
 
         return sub;
     }
+
+    /*! \brief Check if the address contains thumb inst*/
+    bool disasm::thumb(uint64_t address) {
+        jitter->set_pc(address);
+        jitter->step();
+
+        if (jitter->is_thumb_mode()) {
+            return true;
+        }
+
+        return false;
+    }
 }
 

--- a/src/emu/core/src/hle/epoc9/cons.cpp
+++ b/src/emu/core/src/hle/epoc9/cons.cpp
@@ -15,8 +15,8 @@ BRIDGE_FUNC(eka2l1::ptr<CConsoleBase>, ConsoleNewL, eka2l1::ptr<TLit> aName, TSi
 	uint32_t write_ptr6 = cons_ptr->iVtable.ptr_address() + 24;
 
     // Overwrite with our own provide
-        (cons_ptr->iVtable.cast<uint32_t>().get(mem))[6] = write_ptr6;
-	sys->get_lib_manager()->custom_funcs.insert(BRIDGE_REGISTER(write_ptr6, CConsoleBaseAdvanceWrite));
+    //(cons_ptr->iVtable.cast<uint32_t>().get(mem))[6] = sys->ge;
+	sys->get_lib_manager()->register_custom_func(BRIDGE_REGISTER(write_ptr6, CConsoleBaseAdvanceWrite));
 
     cons_ptr->iConsoleSize = aSize;
 

--- a/src/emu/core/src/hle/epoc9/user.cpp
+++ b/src/emu/core/src/hle/epoc9/user.cpp
@@ -279,11 +279,6 @@ BRIDGE_FUNC(TInt, UserLeave, TInt aCode) {
 
 BRIDGE_FUNC(eka2l1::ptr<void>, memcpy, eka2l1::ptr<void> dest, eka2l1::ptr<void> src, TInt size) {
     memcpy(dest.get(sys->get_memory_system()), src.get(sys->get_memory_system()), size);
-
-    if (size = 0x1) {
-        LOG_INFO("{}", *src.cast<uint8_t>().get(sys->get_memory_system()));
-    }
-
     return dest;
 }
 

--- a/src/emu/core/src/hle/libmanager.cpp
+++ b/src/emu/core/src/hle/libmanager.cpp
@@ -45,7 +45,60 @@ namespace eka2l1 {
                 register_epoc9(*this);
             }
 
+            stub = kern->create_chunk("", 0, 0x5000, 0x5000, prot::read_write, kernel::chunk_type::disconnected,
+                kernel::chunk_access::code, kernel::chunk_attrib::none, kernel::owner_type::kernel);
+
+            custom_stub = kern->create_chunk("", 0, 0x5000, 0x5000, prot::read_write, kernel::chunk_type::disconnected,
+                kernel::chunk_access::code, kernel::chunk_attrib::none, kernel::owner_type::kernel);
+
+            stub_ptr = stub->base().cast<uint32_t>();
+            custom_stub_ptr = custom_stub->base().cast<uint32_t>();
+
             LOG_INFO("Lib manager initialized, total implemented HLE functions: {}", import_funcs.size());
+        }
+
+        ptr<uint32_t> lib_manager::get_stub(uint32_t id) {
+            auto &res = stubbed.find(id);
+
+            if (res == stubbed.end()) {
+                uint32_t *stub_ptr_real = stub_ptr.get(mem);
+                stub_ptr_real[0] = 0xef000000; // svc #0, never used
+                stub_ptr_real[1] = 0xe1a0f00e; // mov pc, lr
+                stub_ptr_real[2] = id;
+
+                stub_ptr += 12;
+
+                return ptr<uint32_t>(stub_ptr.ptr_address() - 12);
+            }
+
+            return res->second;
+        }
+
+        ptr<uint32_t> lib_manager::do_custom_stub(uint32_t addr) {
+            auto &res = custom_stubbed.find(addr);
+
+            if (res == custom_stubbed.end()) {
+                uint32_t *cstub_ptr_real = custom_stub_ptr.get(mem);
+                cstub_ptr_real[0] = 0xef000001; // svc #1, never used
+                cstub_ptr_real[1] = 0xe1a0f00e; // mov pc, lr
+                cstub_ptr_real[2] = addr;
+                
+                *ptr<uint32_t>(addr).get(mem) = custom_stub_ptr.ptr_address();
+
+                custom_stub_ptr += 12;
+
+                return ptr<uint32_t>(custom_stub_ptr.ptr_address() - 12);
+            }
+
+            ptr<uint32_t> pt = res->second;
+            *ptr<uint32_t>(addr).get(mem) = pt.ptr_address();
+
+            return pt;
+        }
+
+        void lib_manager::register_custom_func(std::pair<address, epoc_import_func> func) {
+            custom_funcs.insert(func);
+            do_custom_stub(func.first);
         }
 
         void lib_manager::shutdown() {
@@ -56,11 +109,11 @@ namespace eka2l1 {
         }
 
         void lib_manager::reset() {
-			func_names.clear();
-			ids.clear();
+            func_names.clear();
+            ids.clear();
             svc_funcs.clear();
-			custom_funcs.clear();
-			import_funcs.clear();
+            custom_funcs.clear();
+            import_funcs.clear();
         }
 
         void lib_manager::load_all_sids(const epocver ver) {

--- a/src/emu/core/src/loader/eka2img.cpp
+++ b/src/emu/core/src/loader/eka2img.cpp
@@ -278,14 +278,8 @@ namespace eka2l1 {
                         LOG_INFO("Importing export addr: 0x{:x}, sid: 0x{:x}, function: {}, writing at: 0x{:x}, ord: {}",
                             val, sid.value(), mngr.get_func_name(sid.value()).value(), me.rt_code_addr + off, ord);
 
-                        uint32_t *imp = img->stub_ptr.get(mem);
-
-                        imp[0] = 0xef000000; // svc #0, never used
-                        imp[1] = 0xe1a0f00e; // mov pc, lr
-                        imp[2] = *sid;
-
-                        write(code_ptr, img->stub_ptr.ptr_address());
-                        img->stub_ptr += 12;
+                        uint32_t addr = mngr.get_stub(*sid).ptr_address();
+                        write(code_ptr, addr);
 
                         continue;
                     }
@@ -312,11 +306,6 @@ namespace eka2l1 {
 
             img->data_chunk = kern->create_chunk("", 0, common::align(img->header.data_size, mem->get_page_size()), common::align(img->header.data_size, mem->get_page_size()), prot::read_write,
                 kernel::chunk_type::normal, kernel::chunk_access::code, kernel::chunk_attrib::none, kernel::owner_type::process);
-
-            img->stub_chunk = kern->create_chunk("", 0, common::align(img->iat.number_imports * 12, mem->get_page_size()), common::align(img->iat.number_imports * 12, mem->get_page_size()), prot::read_write,
-                kernel::chunk_type::normal, kernel::chunk_access::code, kernel::chunk_attrib::none, kernel::owner_type::process);
-
-            img->stub_ptr = img->stub_chunk->base().cast<uint32_t>();
 
             uint32_t rtcode_addr = img->code_chunk->base().ptr_address();
             uint32_t rtdata_addr = img->data_chunk ? img->data_chunk->base().ptr_address() : 0;

--- a/src/emu/core/src/loader/eka2img.cpp
+++ b/src/emu/core/src/loader/eka2img.cpp
@@ -276,12 +276,14 @@ namespace eka2l1 {
 
                     if (sid) {
                         LOG_INFO("Importing export addr: 0x{:x}, sid: 0x{:x}, function: {}, writing at: 0x{:x}, ord: {}",
-                            val, sid.value(), mngr.get_func_name(sid.value()).value(), me.rt_code_addr + off, ord);
+                           export_addr, sid.value(), mngr.get_func_name(sid.value()).value(), me.rt_code_addr + off, ord);
 
-                        uint32_t addr = mngr.get_stub(*sid).ptr_address();
-                        write(code_ptr, addr);
+                        if (mngr.get_hle(*sid)) {
+                            uint32_t impaddr = mngr.get_stub(*sid).ptr_address();
+                            write(code_ptr, impaddr);
 
-                        continue;
+                            continue;
+                        }
                     }
 
                     if (export_addr >= code_start && export_addr <= code_end) {

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -1,11 +1,14 @@
 add_library(miniz miniz/miniz.h miniz/miniz.c)
 target_include_directories(miniz PUBLIC miniz)
 
+set (BOOST_INCLUDEDIR "${CMAKE_CURRENT_SOURCE_DIR}/ext-boost/" CACHE PATH "Boost include directory")
+
 add_subdirectory(freetype)
 add_subdirectory(FRSML)
 add_subdirectory(spdlog)
 add_subdirectory(glfw)
 add_subdirectory(glm)
+add_subdirectory(dynarmic)
 
 set(YAML_CPP_BUILD_TESTS OFF CACHE BOOL "Enable testing" FORCE)
 add_subdirectory(yaml-cpp)


### PR DESCRIPTION
It's slow every slow right now with the way we handle calling LLE function: searching around 100 functions every instruction for HLE implementation.

This PR does:
- Implement Dynarmic backend, expect huge speed boost :D
- Remove the lurking address behavior, instead triggering an SVC call and read the provided ordinal to call correspond SVC functions. This will be much much faster.

This is still a work-in-progress, build might be broken :D  
After this PR, ~Dynarmic will be used default, fallback to Unicorn if there's unimplement instructions.~ (Dynarmic with ARMv5 - s60v5 binary, is really buggy and slow).

You can't enable Dynarmic yet.