### PR TITLE
AppListServer and Miscs

### DIFF
--- a/src/emu/core/include/core/hle/epoc9/pr.h
+++ b/src/emu/core/include/core/hle/epoc9/pr.h
@@ -8,3 +8,7 @@
 #include <ptr.h>
 
 struct RProcess : public RHandleBase {};
+
+BRIDGE_FUNC(void, RProcessType, eka2l1::ptr<RProcess> aProcess);
+
+extern const eka2l1::hle::func_map pr_register_funcs;

--- a/src/emu/core/include/core/hle/epoc9/register.h
+++ b/src/emu/core/include/core/hle/epoc9/register.h
@@ -14,6 +14,7 @@
 #include <epoc9/svc.h>
 #include <epoc9/svr.h>
 #include <epoc9/prop.h>
+#include <epoc9/pr.h>
 
 #include <hle/libmanager.h>
 

--- a/src/emu/core/include/core/hle/epoc9/types.h
+++ b/src/emu/core/include/core/hle/epoc9/types.h
@@ -47,3 +47,9 @@ enum TOwnerType {
 };
 
 using TUid = uint32_t;
+
+struct TUidType {
+    TUid uid1;
+    TUid uid2;
+    TUid uid3;
+};

--- a/src/emu/core/include/core/kernel/thread.h
+++ b/src/emu/core/include/core/kernel/thread.h
@@ -186,7 +186,7 @@ namespace eka2l1 {
             bool operator>=(const thread &rhs);
             bool operator<=(const thread &rhs);
 
-            tls_slot *get_free_tls_slot(uint32_t handle, uint32_t dll_uid);
+            tls_slot *get_tls_slot(uint32_t handle, uint32_t dll_uid);
             void close_tls_slot(tls_slot &slot);
 
             thread_local_data &get_local_data() {

--- a/src/emu/core/include/core/process.h
+++ b/src/emu/core/include/core/process.h
@@ -23,6 +23,8 @@
 #include <loader/eka2img.h>
 #include <string>
 
+#include <tuple>
+
 namespace eka2l1 {
     class kernel_system;
     class memory;
@@ -42,9 +44,12 @@ namespace eka2l1 {
         uint32_t data = 0;
         int data_size = -1;
     };
+    
+    using process_uid_type = std::tuple<uint32_t, uint32_t, uint32_t>;
 
     class process {
         uint32_t uid;
+        
         std::string process_name;
         thread_ptr prthr;
 
@@ -99,6 +104,8 @@ namespace eka2l1 {
 
         // Stop the main process thread
         bool stop();
+
+        process_uid_type get_uid_type();
     };
 }
 

--- a/src/emu/core/include/core/services/applist/applist.h
+++ b/src/emu/core/include/core/services/applist/applist.h
@@ -16,6 +16,7 @@ namespace eka2l1 {
          * request_sts: KErrNotFound if app doesn't exist
         */
         void default_screen_number(service::ipc_context ctx);
+        void app_language(service::ipc_context ctx);
 
     public:
         applist_server(system *sys);

--- a/src/emu/core/include/core/services/context.h
+++ b/src/emu/core/include/core/services/context.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <ipc.h>
+#include <ptr.h>
+
 #include <optional>
 
 namespace eka2l1 {
@@ -19,6 +21,15 @@ namespace eka2l1 {
             void set_request_status(int res);
 
             int flag() const;
+
+            bool write_arg(int idx, uint32_t data);
+            bool write_arg_pkg(int idx, uint8_t *data, uint32_t len);
+
+            // Package an argument, write it to a destination
+            template <typename T>
+            bool write_arg_pkg(int idx, T data) {
+                return write_arg_pkg(idx, reinterpret_cast<uint8_t *>(&data), sizeof(T));
+            }
         };
     }
 }

--- a/src/emu/core/src/hle/epoc9/CMakeLists.txt
+++ b/src/emu/core/src/hle/epoc9/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(epoc9
     ${CORE_INCLUDE_DIR}/hle/epoc9/register.h
     ${CORE_INCLUDE_DIR}/hle/epoc9/svc.h
     ${CORE_INCLUDE_DIR}/hle/epoc9/svr.h
+    ${CORE_INCLUDE_DIR}/hle/epoc9/pr.h
     ${CORE_INCLUDE_DIR}/hle/epoc9/prop.h
     allocator.cpp
     base.cpp
@@ -34,6 +35,7 @@ add_library(epoc9
     register.cpp
     svc.cpp
     svr.cpp
+    pr.cpp
     prop.cpp)
 
 target_include_directories(epoc9 PUBLIC ${CORE_INCLUDE_DIR}/hle)

--- a/src/emu/core/src/hle/epoc9/dll.cpp
+++ b/src/emu/core/src/hle/epoc9/dll.cpp
@@ -5,42 +5,5 @@
 using namespace eka2l1;
 
 eka2l1::kernel::tls_slot *get_tls_slot(eka2l1::system *sys, address addr) {
-    hle::lib_manager *mngr = sys->get_lib_manager();
-    auto &rommap = mngr->get_romimgs_cache();
-
-    auto &dll = std::find_if(rommap.begin(), rommap.end(),
-        [addr](auto &rom) {
-            loader::romimg_ptr romimg = rom.second.img;
-            loader::rom_image_header header = romimg->header;
-
-            if (header.code_address <= addr && addr <= header.code_address + header.code_size) {
-                return true;
-            }
-
-            return false;
-        });
-
-    if (dll != rommap.end()) {
-        return sys->get_kernel_system()->crr_thread()->get_free_tls_slot(addr, dll->second.img->header.code_address);
-    }
-
-    auto &imgmap = mngr->get_e32imgs_cache();
-
-    auto &edll = std::find_if(imgmap.begin(), imgmap.end(),
-        [addr](auto &eimg) {
-            loader::e32img_ptr img = eimg.second.img;
-            loader::eka2img_header header = img->header;
-
-            if (img->rt_code_addr < addr && addr < img->rt_code_addr + header.code_size) {
-                return true;
-            }
-
-            return false;
-        });
-
-    if (edll != imgmap.end()) {
-        return sys->get_kernel_system()->crr_thread()->get_free_tls_slot(addr, edll->second.img->rt_code_addr);
-    }
-
-    return nullptr;
+    return sys->get_kernel_system()->crr_thread()->get_tls_slot(addr, addr);
 }

--- a/src/emu/core/src/hle/epoc9/pr.cpp
+++ b/src/emu/core/src/hle/epoc9/pr.cpp
@@ -1,0 +1,6 @@
+#include <epoc9/pr.h>
+
+using namespace eka2l1;
+
+const eka2l1::hle::func_map pr_register_funcs = {
+};

--- a/src/emu/core/src/hle/epoc9/register.cpp
+++ b/src/emu/core/src/hle/epoc9/register.cpp
@@ -32,6 +32,7 @@ void register_epoc9(eka2l1::hle::lib_manager &mngr) {
     ADD_REGISTERS(mngr, trap_register_funcs);
     ADD_REGISTERS(mngr, svr_register_funcs);
     ADD_REGISTERS(mngr, prop_register_funcs);
+    ADD_REGISTERS(mngr, pr_register_funcs);
 
     ADD_SVC_REGISTERS(mngr, svc_register_funcs);
 

--- a/src/emu/core/src/hle/epoc9/svr.cpp
+++ b/src/emu/core/src/hle/epoc9/svr.cpp
@@ -17,8 +17,9 @@ BRIDGE_FUNC(TInt, RSessionBaseCreateSession, eka2l1::ptr<RSessionBase> aSession,
     }
 
     session_ptr nss = kern->create_session(svr, aAsyncMsgSlot);
-
     aSession.get(mem)->iHandle = nss->unique_id();
+
+    LOG_INFO("Session created, connected to {} witht total of {} async slots.", server_name, aAsyncMsgSlot);
 
     return KErrNone;
 }

--- a/src/emu/core/src/kernel/thread.cpp
+++ b/src/emu/core/src/kernel/thread.cpp
@@ -206,7 +206,7 @@ namespace eka2l1 {
             // :)
         }
 
-        tls_slot *thread::get_free_tls_slot(uint32_t handle, uint32_t dll_uid) {
+        tls_slot *thread::get_tls_slot(uint32_t handle, uint32_t dll_uid) {
             for (uint32_t i = 0; i < ldata.tls_slots.size(); i++) {
                 if (ldata.tls_slots[i].handle = -1) {
                     ldata.tls_slots[i].handle = handle;

--- a/src/emu/core/src/loader/eka2img.cpp
+++ b/src/emu/core/src/loader/eka2img.cpp
@@ -664,6 +664,7 @@ namespace eka2l1 {
         bool load_eka2img(eka2img &img, memory_system *mem, kernel_system *kern, hle::lib_manager &mngr) {
             if (img.header.uid1 == loader::eka2_img_type::dll) {
             }
+
             return import_exe_image(&img, mem, kern, mngr);
         }
     }

--- a/src/emu/core/src/process.cpp
+++ b/src/emu/core/src/process.cpp
@@ -66,5 +66,9 @@ namespace eka2l1 {
     bool process::run() {
         return kern->run_thread(prthr->unique_id());
     }
+
+    process_uid_type process::get_uid_type() {
+        return std::tuple(0x1000007A, 0x100039CE, uid);
+    }
 }
 

--- a/src/emu/core/src/services/applist/applist.cpp
+++ b/src/emu/core/src/services/applist/applist.cpp
@@ -5,10 +5,651 @@
 #include <functional>
 
 namespace eka2l1 {
+    enum TLanguage {
+        /**
+	Enumerated value used for testing - does not represent a language.
+	*/
+        ELangTest = 0,
+
+        /** UK English. */
+        ELangEnglish = 1,
+
+        /** French. */
+        ELangFrench = 2,
+
+        /** German. */
+        ELangGerman = 3,
+
+        /** Spanish. */
+        ELangSpanish = 4,
+
+        /** Italian. */
+        ELangItalian = 5,
+
+        /** Swedish. */
+        ELangSwedish = 6,
+
+        /** Danish. */
+        ELangDanish = 7,
+
+        /** Norwegian. */
+        ELangNorwegian = 8,
+
+        /** Finnish. */
+        ELangFinnish = 9,
+
+        /** American. */
+        ELangAmerican = 10,
+
+        /** Swiss French. */
+        ELangSwissFrench = 11,
+
+        /** Swiss German. */
+        ELangSwissGerman = 12,
+
+        /** Portuguese. */
+        ELangPortuguese = 13,
+
+        /** Turkish. */
+        ELangTurkish = 14,
+
+        /** Icelandic. */
+        ELangIcelandic = 15,
+
+        /** Russian. */
+        ELangRussian = 16,
+
+        /** Hungarian. */
+        ELangHungarian = 17,
+
+        /** Dutch. */
+        ELangDutch = 18,
+
+        /** Belgian Flemish. */
+        ELangBelgianFlemish = 19,
+
+        /** Australian English. */
+        ELangAustralian = 20,
+
+        /** Belgian French. */
+        ELangBelgianFrench = 21,
+
+        /** Austrian German. */
+        ELangAustrian = 22,
+
+        /** New Zealand English. */
+        ELangNewZealand = 23,
+
+        /** International French. */
+        ELangInternationalFrench = 24,
+
+        /** Czech. */
+        ELangCzech = 25,
+
+        /** Slovak. */
+        ELangSlovak = 26,
+
+        /** Polish. */
+        ELangPolish = 27,
+
+        /** Slovenian. */
+        ELangSlovenian = 28,
+
+        /** Taiwanese Chinese. */
+        ELangTaiwanChinese = 29,
+
+        /** Hong Kong Chinese. */
+        ELangHongKongChinese = 30,
+
+        /** Peoples Republic of China's Chinese. */
+        ELangPrcChinese = 31,
+
+        /** Japanese. */
+        ELangJapanese = 32,
+
+        /** Thai. */
+        ELangThai = 33,
+
+        /** Afrikaans. */
+        ELangAfrikaans = 34,
+
+        /** Albanian. */
+        ELangAlbanian = 35,
+
+        /** Amharic. */
+        ELangAmharic = 36,
+
+        /** Arabic. */
+        ELangArabic = 37,
+
+        /** Armenian. */
+        ELangArmenian = 38,
+
+        /** Tagalog. */
+        ELangTagalog = 39,
+
+        /** Belarussian. */
+        ELangBelarussian = 40,
+
+        /** Bengali. */
+        ELangBengali = 41,
+
+        /** Bulgarian. */
+        ELangBulgarian = 42,
+
+        /** Burmese. */
+        ELangBurmese = 43,
+
+        /** Catalan. */
+        ELangCatalan = 44,
+
+        /** Croatian. */
+        ELangCroatian = 45,
+
+        /** Canadian English. */
+        ELangCanadianEnglish = 46,
+
+        /** International English. */
+        ELangInternationalEnglish = 47,
+
+        /** South African English. */
+        ELangSouthAfricanEnglish = 48,
+
+        /** Estonian. */
+        ELangEstonian = 49,
+
+        /** Farsi. */
+        ELangFarsi = 50,
+
+        /** Canadian French. */
+        ELangCanadianFrench = 51,
+
+        /** Gaelic. */
+        ELangScotsGaelic = 52,
+
+        /** Georgian. */
+        ELangGeorgian = 53,
+
+        /** Greek. */
+        ELangGreek = 54,
+
+        /** Cyprus Greek. */
+        ELangCyprusGreek = 55,
+
+        /** Gujarati. */
+        ELangGujarati = 56,
+
+        /** Hebrew. */
+        ELangHebrew = 57,
+
+        /** Hindi. */
+        ELangHindi = 58,
+
+        /** Indonesian. */
+        ELangIndonesian = 59,
+
+        /** Irish. */
+        ELangIrish = 60,
+
+        /** Swiss Italian. */
+        ELangSwissItalian = 61,
+
+        /** Kannada. */
+        ELangKannada = 62,
+
+        /** Kazakh. */
+        ELangKazakh = 63,
+
+        /** Khmer. */
+        ELangKhmer = 64,
+
+        /** Korean. */
+        ELangKorean = 65,
+
+        /** Lao. */
+        ELangLao = 66,
+
+        /** Latvian. */
+        ELangLatvian = 67,
+
+        /** Lithuanian. */
+        ELangLithuanian = 68,
+
+        /** Macedonian. */
+        ELangMacedonian = 69,
+
+        /** Malay. */
+        ELangMalay = 70,
+
+        /** Malayalam. */
+        ELangMalayalam = 71,
+
+        /** Marathi. */
+        ELangMarathi = 72,
+
+        /** Moldavian. */
+        ELangMoldavian = 73,
+
+        /** Mongolian. */
+        ELangMongolian = 74,
+
+        /** Norwegian Nynorsk. */
+        ELangNorwegianNynorsk = 75,
+
+        /** Brazilian Portuguese. */
+        ELangBrazilianPortuguese = 76,
+
+        /** Punjabi. */
+        ELangPunjabi = 77,
+
+        /** Romanian. */
+        ELangRomanian = 78,
+
+        /** Serbian. */
+        ELangSerbian = 79,
+
+        /** Sinhalese. */
+        ELangSinhalese = 80,
+
+        /** Somali. */
+        ELangSomali = 81,
+
+        /** International Spanish. */
+        ELangInternationalSpanish = 82,
+
+        /** American Spanish. */
+        ELangLatinAmericanSpanish = 83,
+
+        /** Swahili. */
+        ELangSwahili = 84,
+
+        /** Finland Swedish. */
+        ELangFinlandSwedish = 85,
+
+        /** Reserved, not in use. */
+        ELangReserved1 = 86, // This enum should not be used for new languages, see INC110543
+
+        /** Tamil. */
+        ELangTamil = 87,
+
+        /** Telugu. */
+        ELangTelugu = 88,
+
+        /** Tibetan. */
+        ELangTibetan = 89,
+
+        /** Tigrinya. */
+        ELangTigrinya = 90,
+
+        /** Cyprus Turkish. */
+        ELangCyprusTurkish = 91,
+
+        /** Turkmen. */
+        ELangTurkmen = 92,
+
+        /** Ukrainian. */
+        ELangUkrainian = 93,
+
+        /** Urdu. */
+        ELangUrdu = 94,
+
+        /** Reserved, not in use. */
+        ELangReserved2 = 95, // This enum should not be used for new languages, see INC110543
+
+        /** Vietnamese. */
+        ELangVietnamese = 96,
+
+        /** Welsh. */
+        ELangWelsh = 97,
+
+        /** Zulu. */
+        ELangZulu = 98,
+
+        /**
+	@deprecated
+	
+	Use of this value is deprecated.
+	*/
+        ELangOther = 99,
+
+        /** English with terms as used by the device manufacturer, if this needs to
+	be distinct from the English used by the UI vendor. */
+        ELangManufacturerEnglish = 100,
+
+        /** South Sotho.
+	
+	A language of Lesotho also called Sesotho. SIL code sot. */
+        ELangSouthSotho = 101,
+
+        /** Basque. */
+        ELangBasque = 102,
+
+        /** Galician. */
+        ELangGalician = 103,
+
+        /** Javanese. */
+        ELangJavanese = 104,
+
+        /** Maithili. */
+        ELangMaithili = 105,
+
+        /** Azerbaijani(Latin alphabet). */
+        ELangAzerbaijani_Latin = 106,
+
+        /** Azerbaijani(Cyrillic alphabet). */
+        ELangAzerbaijani_Cyrillic = 107,
+
+        /** Oriya. */
+        ELangOriya = 108,
+
+        /** Bhojpuri. */
+        ELangBhojpuri = 109,
+
+        /** Sundanese. */
+        ELangSundanese = 110,
+
+        /** Kurdish(Latin alphabet). */
+        ELangKurdish_Latin = 111,
+
+        /** Kurdish(Arabic alphabet). */
+        ELangKurdish_Arabic = 112,
+
+        /** Pashto. */
+        ELangPashto = 113,
+
+        /** Hausa. */
+        ELangHausa = 114,
+
+        /** Oromo. */
+        ELangOromo = 115,
+
+        /** Uzbek(Latin alphabet). */
+        ELangUzbek_Latin = 116,
+
+        /** Uzbek(Cyrillic alphabet). */
+        ELangUzbek_Cyrillic = 117,
+
+        /** Sindhi(Arabic alphabet). */
+        ELangSindhi_Arabic = 118,
+
+        /** Sindhi(using Devanagari script). */
+        ELangSindhi_Devanagari = 119,
+
+        /** Yoruba. */
+        ELangYoruba = 120,
+
+        /** Cebuano. */
+        ELangCebuano = 121,
+
+        /** Igbo. */
+        ELangIgbo = 122,
+
+        /** Malagasy. */
+        ELangMalagasy = 123,
+
+        /** Nepali. */
+        ELangNepali = 124,
+
+        /** Assamese. */
+        ELangAssamese = 125,
+
+        /** Shona. */
+        ELangShona = 126,
+
+        /** Zhuang. */
+        ELangZhuang = 127,
+
+        /** Madurese. */
+        ELangMadurese = 128,
+
+        /** English as appropriate for use in Asia-Pacific regions. */
+        ELangEnglish_Apac = 129,
+
+        /** English as appropriate for use in Taiwan. */
+        ELangEnglish_Taiwan = 157,
+
+        /** English as appropriate for use in Hong Kong. */
+        ELangEnglish_HongKong = 158,
+
+        /** English as appropriate for use in the Peoples Republic of China. */
+        ELangEnglish_Prc = 159,
+
+        /** English as appropriate for use in Japan. */
+        ELangEnglish_Japan = 160,
+
+        /** English as appropriate for use in Thailand. */
+        ELangEnglish_Thailand = 161,
+
+        /** Fulfulde, also known as Fula */
+        ELangFulfulde = 162,
+
+        /** Tamazight. */
+        ELangTamazight = 163,
+
+        /** Bolivian Quechua. */
+        ELangBolivianQuechua = 164,
+
+        /** Peru Quechua. */
+        ELangPeruQuechua = 165,
+
+        /** Ecuador Quechua. */
+        ELangEcuadorQuechua = 166,
+
+        /** Tajik(Cyrillic alphabet). */
+        ELangTajik_Cyrillic = 167,
+
+        /** Tajik(using Perso-Arabic script). */
+        ELangTajik_PersoArabic = 168,
+
+        /** Nyanja, also known as Chichewa or Chewa. */
+        ELangNyanja = 169,
+
+        /** Haitian Creole. */
+        ELangHaitianCreole = 170,
+
+        /** Lombard. */
+        ELangLombard = 171,
+
+        /** Koongo, also known as Kongo or KiKongo. */
+        ELangKoongo = 172,
+
+        /** Akan. */
+        ELangAkan = 173,
+
+        /** Hmong. */
+        ELangHmong = 174,
+
+        /** Yi. */
+        ELangYi = 175,
+
+        /** Tshiluba, also known as Luba-Kasai */
+        ELangTshiluba = 176,
+
+        /** Ilocano, also know as Ilokano or Iloko. */
+        ELangIlocano = 177,
+
+        /** Uyghur. */
+        ELangUyghur = 178,
+
+        /** Neapolitan. */
+        ELangNeapolitan = 179,
+
+        /** Rwanda, also known as Kinyarwanda */
+        ELangRwanda = 180,
+
+        /** Xhosa. */
+        ELangXhosa = 181,
+
+        /** Balochi, also known as Baluchi */
+        ELangBalochi = 182,
+
+        /** Hiligaynon. */
+        ElangHiligaynon = 183,
+
+        /** Minangkabau. */
+        ELangMinangkabau = 184,
+
+        /** Makhuwa. */
+        ELangMakhuwa = 185,
+
+        /** Santali. */
+        ELangSantali = 186,
+
+        /** Gikuyu, sometimes written Kikuyu. */
+        ELangGikuyu = 187,
+
+        /** Mòoré, also known as Mossi or More. */
+        ELangMoore = 188,
+
+        /** Guaraní. */
+        ELangGuarani = 189,
+
+        /** Rundi, also known as Kirundi. */
+        ELangRundi = 190,
+
+        /** Romani(Latin alphabet). */
+        ELangRomani_Latin = 191,
+
+        /** Romani(Cyrillic alphabet). */
+        ELangRomani_Cyrillic = 192,
+
+        /** Tswana. */
+        ELangTswana = 193,
+
+        /** Kanuri. */
+        ELangKanuri = 194,
+
+        /** Kashmiri(using Devanagari script). */
+        ELangKashmiri_Devanagari = 195,
+
+        /** Kashmiri(using Perso-Arabic script). */
+        ELangKashmiri_PersoArabic = 196,
+
+        /** Umbundu. */
+        ELangUmbundu = 197,
+
+        /** Konkani. */
+        ELangKonkani = 198,
+
+        /** Balinese, a language used in Indonesia (Java and Bali). */
+        ELangBalinese = 199,
+
+        /** Northern Sotho. */
+        ELangNorthernSotho = 200,
+
+        /** Wolof. */
+        ELangWolof = 201,
+
+        /** Bemba. */
+        ELangBemba = 202,
+
+        /** Tsonga. */
+        ELangTsonga = 203,
+
+        /** Yiddish. */
+        ELangYiddish = 204,
+
+        /** Kirghiz, also known as Kyrgyz. */
+        ELangKirghiz = 205,
+
+        /** Ganda, also known as Luganda. */
+        ELangGanda = 206,
+
+        /** Soga, also known as Lusoga. */
+        ELangSoga = 207,
+
+        /** Mbundu, also known as Kimbundu. */
+        ELangMbundu = 208,
+
+        /** Bambara. */
+        ELangBambara = 209,
+
+        /** Central Aymara. */
+        ELangCentralAymara = 210,
+
+        /** Zarma. */
+        ELangZarma = 211,
+
+        /** Lingala. */
+        ELangLingala = 212,
+
+        /** Bashkir. */
+        ELangBashkir = 213,
+
+        /** Chuvash. */
+        ELangChuvash = 214,
+
+        /** Swati. */
+        ELangSwati = 215,
+
+        /** Tatar. */
+        ELangTatar = 216,
+
+        /** Southern Ndebele. */
+        ELangSouthernNdebele = 217,
+
+        /** Sardinian. */
+        ELangSardinian = 218,
+
+        /** Scots. */
+        ELangScots = 219,
+
+        /** Meitei, also known as Meithei or Manipuri */
+        ELangMeitei = 220,
+
+        /** Walloon. */
+        ELangWalloon = 221,
+
+        /** Kabardian. */
+        ELangKabardian = 222,
+
+        /** Mazanderani, also know as Mazandarani or Tabri. */
+        ELangMazanderani = 223,
+
+        /** Gilaki. */
+        ELangGilaki = 224,
+
+        /** Shan. */
+        ELangShan = 225,
+
+        /** Luyia. */
+        ELangLuyia = 226,
+
+        /** Luo, also known as Dholuo, a language of Kenya. */
+        ELanguageLuo = 227,
+
+        /** Sukuma, also known as Kisukuma. */
+        ELangSukuma = 228,
+
+        /** Aceh, also known as Achinese. */
+        ELangAceh = 229,
+
+        /** English used in India. */
+        ELangEnglish_India = 230,
+
+        /** Malay as appropriate for use in Asia-Pacific regions. */
+        ELangMalay_Apac = 326,
+
+        /** Indonesian as appropriate for use in Asia-Pacific regions. */
+        ELangIndonesian_Apac = 327,
+
+        /**
+	Indicates the final language in the language downgrade path.
+	
+	@see BaflUtils::NearestLanguageFile
+	@see BaflUtils::GetDowngradePath
+	*/
+        ELangNone = 0xFFFF, // up to 1023 languages * 16 dialects, in 16 bits
+        ELangMaximum = ELangNone // This must always be equal to the last (largest) TLanguage enum.
+    };
+
+
     applist_server::applist_server(system *sys)
         : service::server(sys, "!AppListServer") {
         REGISTER_IPC(applist_server, default_screen_number, 
             EAppListServGetDefaultScreenNumber, "GetDefaultScreenNumber");
+        REGISTER_IPC(applist_server, app_language, 
+            EAppListServApplicationLanguage, "ApplicationLanguageL");
     }
 
     /*! \brief Get the number of screen shared for an app. 
@@ -23,5 +664,10 @@ namespace eka2l1 {
 
         *number.get(tsys->get_memory_system()) = 1;
         ctx.set_request_status(0); // KErrNone
+    }
+
+    void applist_server::app_language(service::ipc_context ctx) {
+        ctx.write_arg_pkg<TLanguage>(1, ELangEnglish);
+        ctx.set_request_status(0);
     }
 }


### PR DESCRIPTION
- Stubbed !AppListServer's AppLanguageL. (returns ELangEnglish.)
- Implement ProcessType SVC call: This SVC call gets an UID tuple (uid1, uid2, uid3).
- App and process id now are corrected (uid3 of E32Image).
- Change the name of TLS function: get_tls_slot now returns the slot of the current handle or create a new one if it doesn't exists. If out of slot, return KErrNoMemory.
- Server can now write and read IPC message easily: pack and write it, or just read it to an std::string or std::u16string.