### PR TITLE
Add default destructor to ETEL subsessions

### DIFF
--- a/src/emu/services/include/services/etel/subsess.h
+++ b/src/emu/services/include/services/etel/subsess.h
@@ -53,6 +53,7 @@ namespace eka2l1 {
 
         virtual void dispatch(service::ipc_context *ctx) = 0;
         virtual etel_subsession_type type() const = 0;
+        virtual ~etel_subsession() = default;
     };
 
     struct etel_phone_subsession : public etel_subsession {


### PR DESCRIPTION
When closing an ETEL session with at least one previously closed subsession the emulator would crash by attempting to close already closed subsessions (Opera Mobile for example crashes the emulator when starting).

This makes it work on macOS at least - as the compiler also produces a warning about that - but I'm not sure whether this patch works on Windows or Linux (or if the emulator crashes on those platforms to begin with!).