### PR TITLE
Revamped key mapping p1

### DIFF
--- a/src/emu/debugger/include/debugger/imgui_debugger.h
+++ b/src/emu/debugger/include/debugger/imgui_debugger.h
@@ -112,6 +112,8 @@ namespace eka2l1 {
             std::array<std::uint32_t, BIND_NUM> target_key;
             std::array<std::string, BIND_NUM> target_key_name;
             std::map<std::uint32_t, std::string> key_bind_name;
+
+            void reset();
         } key_binder_state;
 
         struct device_wizard {

--- a/src/emu/debugger/resources/local/strings.xml
+++ b/src/emu/debugger/resources/local/strings.xml
@@ -15,6 +15,7 @@
     <string name="warning">Warning</string>
     <string name="cancel">Cancel</string>
     <string name="continue">Continue</string>
+    <string name="reset">Reset</string>
 
     <string name="file_menu_name">File</string>
     <string name="debugger_menu_name">Debugger</string>

--- a/src/emu/drivers/include/drivers/graphics/emu_window.h
+++ b/src/emu/drivers/include/drivers/graphics/emu_window.h
@@ -35,6 +35,8 @@ enum {
     #undef KEY_CODE
 };
 
+const char *number_to_key_name(const int keycode);
+
 namespace eka2l1 {
     /**
      * \brief Contains implementation for driver.

--- a/src/emu/drivers/include/drivers/graphics/emu_window.h
+++ b/src/emu/drivers/include/drivers/graphics/emu_window.h
@@ -29,55 +29,11 @@
 #include <memory>
 #include <string>
 
-#define KEY_TAB 258
-#define KEY_BACKSPACE 259
-#define KEY_LEFT_SHIFT 340
-#define KEY_LEFT_CONTROL 341
-#define KEY_LEFT_ALT 342
-#define KEY_LEFT_SUPER 343
-#define KEY_RIGHT_SHIFT 344
-#define KEY_RIGHT_CONTROL 345
-#define KEY_RIGHT_ALT 346
-#define KEY_RIGHT_SUPER 347
-
-#define KEY_RIGHT 262
-#define KEY_LEFT 263
-#define KEY_DOWN 264
-#define KEY_UP 265
-
-#define KEY_ENTER 257
-#define KEY_ESCAPE 256
-
-#define KEY_NUM0 320
-#define KEY_NUM1 321
-#define KEY_NUM2 322
-#define KEY_NUM3 323
-#define KEY_NUM4 324
-#define KEY_NUM5 325
-#define KEY_NUM6 326
-#define KEY_NUM7 327
-#define KEY_NUM8 328
-#define KEY_NUM9 329
-#define KEY_SLASH 331
-#define KEY_STAR 332
-
-#define KEY_F1 290
-#define KEY_F2 291
-#define KEY_F11 300
-
-#define KEY_A 65
-#define KEY_H 73
-#define KEY_I 74
-#define KEY_K 75
-#define KEY_L 76
-#define KEY_M 77
-#define KEY_N 78
-#define KEY_O 79
-#define KEY_P 80
-#define KEY_Q 81
-#define KEY_R 82
-#define KEY_W 87
-#define KEY_X 88
+enum {
+    #define KEY_CODE(name, key_name, code) name = code,
+    #include <drivers/graphics/keycode.inc>
+    #undef KEY_CODE
+};
 
 namespace eka2l1 {
     /**

--- a/src/emu/drivers/include/drivers/graphics/keycode.inc
+++ b/src/emu/drivers/include/drivers/graphics/keycode.inc
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2021 EKA2L1 Team.
+ * 
+ * This file is part of EKA2L1 project
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEY_CODE
+#define KEY_CODE(name, nice_name, code)
+#endif
+
+KEY_CODE(KEY_TAB, "Tab", 258)
+KEY_CODE(KEY_BACKSPACE, "Backspace", 259)
+KEY_CODE(KEY_LEFT_SHIFT, "Left Shift", 340)
+KEY_CODE(KEY_LEFT_CONTROL, "Left control", 341)
+KEY_CODE(KEY_LEFT_ALT, "Left Alt", 342)
+KEY_CODE(KEY_LEFT_SUPER, "Left Super", 343)
+KEY_CODE(KEY_RIGHT_SHIFT, "Right Shift", 344)
+KEY_CODE(KEY_RIGHT_CONTROL, "Right control", 345)
+KEY_CODE(KEY_RIGHT_ALT, "Right Alt", 346)
+KEY_CODE(KEY_RIGHT_SUPER, "Right Super", 347)
+
+KEY_CODE(KEY_RIGHT, "Right arrow", 262)
+KEY_CODE(KEY_LEFT, "Left arrow", 263)
+KEY_CODE(KEY_DOWN, "Down arrow", 264)
+KEY_CODE(KEY_UP, "Up arrow", 265)
+
+KEY_CODE(KEY_ENTER, "Enter", 257)
+KEY_CODE(KEY_ESCAPE, "Esc", 256)
+
+KEY_CODE(KEY_NUM0, "Numpad 0", 320)
+KEY_CODE(KEY_NUM1, "Numpad 1", 321)
+KEY_CODE(KEY_NUM2, "Numpad 2", 322)
+KEY_CODE(KEY_NUM3, "Numpad 3", 323)
+KEY_CODE(KEY_NUM4, "Numpad 4", 324)
+KEY_CODE(KEY_NUM5, "Numpad 5", 325)
+KEY_CODE(KEY_NUM6, "Numpad 6", 326)
+KEY_CODE(KEY_NUM7, "Numpad 7", 327)
+KEY_CODE(KEY_NUM8, "Numpad 8", 328)
+KEY_CODE(KEY_NUM9, "Numpad 9", 329)
+KEY_CODE(KEY_SLASH, "Slash", 331)
+KEY_CODE(KEY_STAR, "Star", 332)
+
+KEY_CODE(KEY_F1, "F1", 290)
+KEY_CODE(KEY_F2, "F2", 291)
+KEY_CODE(KEY_F11, "F11", 300)
+
+KEY_CODE(KEY_A, "A", 65)
+KEY_CODE(KEY_B, "B", 66)
+KEY_CODE(KEY_C, "C", 67)
+KEY_CODE(KEY_D, "D", 68)
+KEY_CODE(KEY_E, "E", 69)
+KEY_CODE(KEY_F, "F", 70)
+KEY_CODE(KEY_G, "G", 71)
+KEY_CODE(KEY_H, "H", 72)
+KEY_CODE(KEY_I, "I", 73)
+KEY_CODE(KEY_J, "J", 74)
+KEY_CODE(KEY_K, "K", 75)
+KEY_CODE(KEY_L, "L", 76)
+KEY_CODE(KEY_M, "M", 77)
+KEY_CODE(KEY_N, "N", 78)
+KEY_CODE(KEY_O, "O", 79)
+KEY_CODE(KEY_P, "P", 80)
+KEY_CODE(KEY_Q, "Q", 81)
+KEY_CODE(KEY_R, "R", 82)
+KEY_CODE(KEY_S, "S", 83)
+KEY_CODE(KEY_T, "T", 84)
+KEY_CODE(KEY_U, "U", 85)
+KEY_CODE(KEY_V, "V", 86)
+KEY_CODE(KEY_W, "W", 87)
+KEY_CODE(KEY_X, "X", 88)
+KEY_CODE(KEY_Y, "Y", 89)
+KEY_CODE(KEY_Z, "Z", 90)

--- a/src/emu/drivers/src/graphics/emu_window.cpp
+++ b/src/emu/drivers/src/graphics/emu_window.cpp
@@ -20,6 +20,18 @@
 #include <drivers/graphics/backend/emu_window_glfw.h>
 #include <drivers/graphics/emu_window.h>
 
+const char *number_to_key_name(const int keycode) {
+    switch (keycode) {
+    #define KEY_CODE(name, real_name, code) case code: return real_name;
+    #include <drivers/graphics/keycode.inc>
+    #undef KEY_CODE
+    default:
+        break;
+    }
+
+    return nullptr;
+}
+
 namespace eka2l1 {
     namespace drivers {
         std::unique_ptr<emu_window> new_emu_window(const window_api win_type) {

--- a/src/emu/services/include/services/window/common.h
+++ b/src/emu/services/include/services/window/common.h
@@ -649,53 +649,6 @@ namespace eka2l1::epoc {
         key_application_27
     };
 
-    static const std::unordered_map<std::uint32_t, std::uint32_t> scanmap_all = {
-        { KEY_F1, std_key_device_0 },
-        { KEY_F2, std_key_device_1 },
-        { KEY_ENTER, std_key_device_3 },
-        { KEY_SLASH, std_key_hash },
-        { KEY_BACKSPACE, std_key_backspace },
-        { KEY_STAR, '*' },
-        { KEY_NUM0, '0' },
-        { KEY_NUM1, '1' },
-        { KEY_NUM2, '2' },
-        { KEY_NUM3, '3' },
-        { KEY_NUM4, '4' },
-        { KEY_NUM5, '5' },
-        { KEY_NUM6, '6' },
-        { KEY_NUM7, '7' },
-        { KEY_NUM8, '8' },
-        { KEY_NUM9, '9' }
-    };
-
-    static const std::unordered_map<std::uint32_t, std::uint32_t> scanmap_0 = {
-        { KEY_RIGHT, std_key_right_arrow },
-        { KEY_LEFT, std_key_left_arrow },
-        { KEY_DOWN, std_key_down_arrow },
-        { KEY_UP, std_key_up_arrow }
-    };
-
-    static const std::unordered_map<std::uint32_t, std::uint32_t> scanmap_90 = {
-        { KEY_RIGHT, std_key_up_arrow },
-        { KEY_LEFT, std_key_down_arrow },
-        { KEY_DOWN, std_key_right_arrow },
-        { KEY_UP, std_key_left_arrow }
-    };
-
-    static const std::unordered_map<std::uint32_t, std::uint32_t> scanmap_180 = {
-        { KEY_RIGHT, std_key_left_arrow },
-        { KEY_LEFT, std_key_right_arrow },
-        { KEY_DOWN, std_key_up_arrow },
-        { KEY_UP, std_key_down_arrow }
-    };
-
-    static const std::unordered_map<std::uint32_t, std::uint32_t> scanmap_270 = {
-        { KEY_RIGHT, std_key_down_arrow },
-        { KEY_LEFT, std_key_up_arrow },
-        { KEY_DOWN, std_key_left_arrow },
-        { KEY_UP, std_key_right_arrow }
-    };
-
     static constexpr std::uint8_t WS_MAJOR_VER = 1;
     static constexpr std::uint8_t WS_MINOR_VER = 0;
     static constexpr std::uint16_t WS_V6_BUILD_VER = 139;
@@ -704,7 +657,7 @@ namespace eka2l1::epoc {
     static constexpr std::uint64_t WS_DEFAULT_KEYBOARD_REPEAT_NEXT_DELAY = 100000;
 
     key_code map_scancode_to_keycode(std_scan_code scan_code);
-    std_scan_code map_inputcode_to_scancode(int input_code, int ui_rotation);
+    std_scan_code post_processing_scancode(std_scan_code input_code, int ui_rotation);
 
     static constexpr std::uint32_t KEYBIND_TYPE_MOUSE_CODE_BASE = 0x500000;
     

--- a/src/emu/services/include/services/window/window.h
+++ b/src/emu/services/include/services/window/window.h
@@ -317,6 +317,9 @@ namespace eka2l1 {
             epoc::key_map key_input_map;
         } input_mapping;
 
+        void reset_key_mappings();
+        void delete_key_mapping(const std::uint32_t target);
+
     private:
         friend class epoc::window_server_client;
         friend struct epoc::window_key_shipper;
@@ -375,6 +378,7 @@ namespace eka2l1 {
         void init_screens();
         void init_ws_mem();
         void init_repeatable();
+        void init_key_mappings();
         void emit_ws_thread_code();
 
         void make_mouse_event(drivers::input_event &driver_evt_, epoc::event &guest_evt_, epoc::screen *scr);

--- a/src/emu/services/src/fs/files.cpp
+++ b/src/emu/services/src/fs/files.cpp
@@ -514,6 +514,9 @@ namespace eka2l1 {
             ctx->sys->get_io_system()->delete_entry(path);
         }
 
+        // Reset its status, so seek back, this is just in case it got used again
+        vfs_file->seek(0, file_seek_mode::beg);
+
         auto &node_attrib = server<fs_server>()->attribs[vfs_file->file_name()];
         node_attrib.decrement_use(ctx->msg->own_thr->owning_process()->unique_id());
 

--- a/src/emu/services/src/window/common.cpp
+++ b/src/emu/services/src/window/common.cpp
@@ -192,31 +192,45 @@ namespace eka2l1::epoc {
         return key_null;
     }
 
-    std_scan_code map_inputcode_to_scancode(int input_code, int ui_rotation) {
-        auto scanmap = &scanmap_0;
-        switch (ui_rotation) {
-        case 90:
-            scanmap = &scanmap_90;
+    std_scan_code post_processing_scancode(std_scan_code resulted, const int rotation) {
+        const std_scan_code ROUND_ARROW_MAP[] = {
+            std_key_right_arrow,
+            std_key_up_arrow,
+            std_key_left_arrow,
+            std_key_down_arrow
+        };
+
+        // Get the index of the key
+        int index = -1;
+        switch (resulted) {
+        case std_key_right_arrow:
+            index = 0;
             break;
-        case 180:
-            scanmap = &scanmap_180;
+
+        case std_key_up_arrow:
+            index = 1;
             break;
-        case 270:
-            scanmap = &scanmap_270;
+
+        case std_key_left_arrow:
+            index = 2;
+            break;
+
+        case std_key_down_arrow:
+            index = 3;
+            break;
+
+        default:
             break;
         }
 
-        auto it = scanmap->find(input_code);
-        if (it == scanmap->end()) {
-            scanmap = &scanmap_all;
-            it = scanmap->find(input_code);
-            if (it == scanmap->end())
-                return std_key_null;
+        if (index == -1) {
+            return resulted;
         }
-        return static_cast<std_scan_code>(it->second);
+
+        return ROUND_ARROW_MAP[(index + (rotation / 90)) % 4];
     }
 
-    std::optional<std::uint32_t> map_button_to_inputcode(std::map<std::pair<int, int>, std::uint32_t> &map, int controller_id, int button) {
+    std::optional<std::uint32_t> map_button_to_inputcode(button_map &map, int controller_id, int button) {
         auto key = std::make_pair(controller_id, button);
         auto it = map.find(key);
 
@@ -227,7 +241,7 @@ namespace eka2l1::epoc {
         return it->second;
     }
 
-    std::optional<std::uint32_t> map_key_to_inputcode(std::map<std::uint32_t, std::uint32_t> &map, std::uint32_t keycode) {
+    std::optional<std::uint32_t> map_key_to_inputcode(key_map &map, std::uint32_t keycode) {
         auto it = map.find(keycode);
 
         if (it == map.end()) {

--- a/src/emu/services/src/window/io.cpp
+++ b/src/emu/services/src/window/io.cpp
@@ -141,7 +141,7 @@ namespace eka2l1::epoc {
         int ui_rotation = focus->scr->ui_rotation;
 
         for (auto &evt : evts_) {
-            evt.key_evt_.scancode = epoc::map_inputcode_to_scancode(evt.key_evt_.scancode,
+            evt.key_evt_.scancode = epoc::post_processing_scancode(static_cast<epoc::std_scan_code>(evt.key_evt_.scancode),
                 ui_rotation);
 
             bool dont_send_extra_key_event = (evt.type != epoc::event_code::key_down);


### PR DESCRIPTION

- Display mapped keynames
- Same key maps to multiple symbian keys wont trigger undefined behaviour, instead the newest key will be the effective one (no warning display yet)
- Allow reset mapping inside emulator (keybinds are saved when clicking reset)
- Mapping to different key will make the original mapped key ineffective. For example, numpad 5 mapped to numpad 5, if you map symbian numpad 5 to H, your PC numpad 5 will not trigger symbian numpad 5 anymore