### PR TITLE
fix(package): propagate silent flag to legacy SIS installer so ROM stubs aren't marked removable

### DIFF
--- a/src/emu/package/include/package/sis_v1_installer.h
+++ b/src/emu/package/include/package/sis_v1_installer.h
@@ -29,5 +29,5 @@ namespace eka2l1::loader {
      */
     bool install_sis_old(const std::u16string &path, io_system *io, drive_number drive, package::object &info,
         choose_lang_func choose_lang_cb, var_value_resolver_func resolver_cb, progress_changed_callback progress_cb,
-        cancel_requested_callback cancel_cb);
+        cancel_requested_callback cancel_cb, const bool stub = false);
 }

--- a/src/emu/package/src/manager.cpp
+++ b/src/emu/package/src/manager.cpp
@@ -573,7 +573,7 @@ namespace eka2l1 {
                 final_obj.file_major_version = 5;
                 final_obj.file_minor_version = 4;
 
-                if (!loader::install_sis_old(path, sys, drive, final_obj, choose_lang, var_resolver, progress_cb, cancel_cb)) {
+                if (!loader::install_sis_old(path, sys, drive, final_obj, choose_lang, var_resolver, progress_cb, cancel_cb, silent)) {
                     return package::installation_result_invalid;
                 }
 

--- a/src/emu/package/src/sis_v1_installer.cpp
+++ b/src/emu/package/src/sis_v1_installer.cpp
@@ -202,7 +202,7 @@ namespace eka2l1::loader {
         }
 
         info.current_drives = info.drives;
-        info.is_removable = true;
+        info.is_removable = !stub;
 
         language choosen_language = language::en;
         std::size_t choosen_language_index = 0;


### PR DESCRIPTION
On the N70 (and some other S60v2 ROMs), *.sis files located in the Z:\system\install\ folder are marked as removable via the Package Manager. This PR resolves this issue.