### PR TITLE
ci: Bring the build workflow back to life

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,17 @@
 
 name: C/C++ CI
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
 
 jobs:
   build-android:
@@ -28,249 +38,261 @@ jobs:
         working-directory: ./src/emu/android
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         submodules: recursive
 
     - name: Set up JDK 17
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: '17'
 
     - name: Set up build environment
       run: |
         sudo apt-get update
-        sudo apt-get -y install build-essential libc6-dev g++-multilib
-      
+        sudo apt-get -y install build-essential libc6-dev
+
     - name: Build with Gradle
       run: ./gradlew assembleRelease -PciArg='-DCI=ON'
-    
-    - name: Setup build tool version variable
-      shell: bash
-      run: |
-        BUILD_TOOL_VERSION=$(ls /usr/local/lib/android/sdk/build-tools/ | tail -n 1)
-        echo "BUILD_TOOL_VERSION=$BUILD_TOOL_VERSION" >> $GITHUB_ENV
-        echo Last build tool version is: $BUILD_TOOL_VERSION
-    
-    - name: Sign APK
-      id: sign-android-app
-      uses: r0adkll/sign-android-release@v1.0.4
-      with:
-        releaseDirectory: ./src/emu/android/app/build/outputs/apk/release
-        signingKeyBase64: ${{ secrets.SIGNING_KEY }}
-        alias: ${{ secrets.ALIAS }}
-        keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
-        keyPassword: ${{ secrets.KEY_PASSWORD }}
-      env:
-        BUILD_TOOLS_VERSION: ${{ env.BUILD_TOOL_VERSION }}
-    
+
     - name: Compute git short sha
       id: git_short_sha
-      run: echo "::set-output name=value::$(git rev-parse --short HEAD)"
+      run: echo "value=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
-    - name: Rename APK
+    # Signing secrets are not exposed to pull requests coming from a fork, so the
+    # APK is only signed when they are available. Everything else still runs, and
+    # the unsigned APK is uploaded instead so the build stays verifiable.
+    - name: Sign APK
+      env:
+        SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+        ALIAS: ${{ secrets.ALIAS }}
+        KEY_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
+        KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        APK_NAME: eka2l1-${{ steps.git_short_sha.outputs.value }}.apk
       run: |
-        mv ${{ steps.sign-android-app.outputs.signedReleaseFile }} eka2l1-${{ steps.git_short_sha.outputs.value }}.apk
-        cp eka2l1-${{ steps.git_short_sha.outputs.value }}.apk android-latest.apk
-      working-directory: ${{ github.workspace }}
+        set -e
+        UNSIGNED=app/build/outputs/apk/release/app-release-unsigned.apk
+        OUT="${GITHUB_WORKSPACE}/${APK_NAME}"
+
+        if [ -z "${SIGNING_KEY}" ]; then
+          echo "No signing key available, uploading the unsigned APK."
+          cp "${UNSIGNED}" "${OUT}"
+          exit 0
+        fi
+
+        BUILD_TOOLS_VERSION=$(find "${ANDROID_HOME}/build-tools" -mindepth 1 -maxdepth 1 -printf "%f\n" | sort -V | tail -n 1)
+        echo "Signing with build tools ${BUILD_TOOLS_VERSION}"
+
+        echo "${SIGNING_KEY}" | base64 -d > "${RUNNER_TEMP}/keystore.jks"
+        "${ANDROID_HOME}/build-tools/${BUILD_TOOLS_VERSION}/apksigner" sign \
+          --ks "${RUNNER_TEMP}/keystore.jks" \
+          --ks-pass "pass:${KEY_STORE_PASSWORD}" \
+          --ks-key-alias "${ALIAS}" \
+          --key-pass "pass:${KEY_PASSWORD}" \
+          --out "${OUT}" "${UNSIGNED}"
+        rm -f "${RUNNER_TEMP}/keystore.jks"
 
     - name: Upload APK
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
-        name: eka2l1-${{ steps.git_short_sha.outputs.value }}
+        name: eka2l1-${{ steps.git_short_sha.outputs.value }}-android
         path: eka2l1-${{ steps.git_short_sha.outputs.value }}.apk
 
   build-desktop:
     runs-on: ${{ matrix.os }}
     env:
       cache-version: v1
-      MACOSX_DEPLOYMENT_TARGET: 10.9
+      config: Release
+      MACOSX_DEPLOYMENT_TARGET: 10.15
 
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-20.04, windows-latest]
-        config: [Release]
+        include:
+          - os: windows-latest
+            label: windows
+          - os: macos-15-intel
+            label: macos
+          - os: ubuntu-24.04
+            label: linux
 
     steps:
-    - name: Set up build environment (macos-latest)
-      run: |
-        brew install ccache
-        echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
-        echo "CCACHE_DIR=/tmp/ccache" >> $GITHUB_ENV
-      if: matrix.os == 'macos-latest'
+    - name: Set up build environment (macOS)
+      run: brew install ccache
+      if: matrix.label == 'macos'
 
-    - name: Set up build environment (ubuntu-latest)
+    # Ubuntu ships Qt 5.15 and SDL 2.30, so both come from apt instead of being
+    # installed by aqt / built from source.
+    - name: Set up build environment (Linux)
       run: |
         sudo apt-get update
-        sudo apt-get -y install ccache libgtk-3-dev libpulse-dev libasound2-dev libsdl2-dev pulseaudio gcc-11 g++-11
-        echo "CCACHE_DIR=/tmp/ccache" >> $GITHUB_ENV
-        echo "CC=gcc-11" >> $GITHUB_ENV
-        echo "CXX=g++-11" >> $GITHUB_ENV
-      if: matrix.os == 'ubuntu-20.04'
-  
-    - uses: actions/cache@v1
-      with:
-        path: /tmp/ccache
-        key: ccache-${{ env.cache-version }}-${{ matrix.os }}-${{ matrix.config }}-${{ github.sha }}
-        restore-keys: ccache-${{ env.cache-version }}-${{ matrix.os }}-${{ matrix.config }}-
-      if: matrix.os != 'windows-latest'
+        sudo apt-get -y install ccache libgtk-3-dev libpulse-dev libasound2-dev \
+          libsdl2-dev pulseaudio qtbase5-dev qtbase5-dev-tools qttools5-dev \
+          qttools5-dev-tools libqt5svg5-dev libqt5opengl5-dev
+      if: matrix.label == 'linux'
 
-    - uses: actions/checkout@v2
+    - name: Configure ccache
+      run: echo "CCACHE_DIR=${{ runner.temp }}/ccache" >> "$GITHUB_ENV"
+      if: matrix.label != 'windows'
+
+    - uses: actions/cache@v4
+      with:
+        path: ${{ runner.temp }}/ccache
+        key: ccache-${{ env.cache-version }}-${{ matrix.label }}-${{ github.sha }}
+        restore-keys: ccache-${{ env.cache-version }}-${{ matrix.label }}-
+      if: matrix.label != 'windows'
+
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         submodules: recursive
-          
-    - name: Cache Qt
-      id: cache-qt
-      uses: actions/cache@v1
-      with:
-        path: ../Qt
-        key: ${{ runner.os }}-QtCacheV5
 
-    - name: Install Qt5
-      uses: jurplel/install-qt-action@v2
+    - name: Install Qt5 (macOS)
+      uses: jurplel/install-qt-action@v4
       with:
         version: '5.15.2'
-        cached: ${{ steps.cache-qt.outputs.cache-hit }}
-        tools: ${{ env.QT_INSTALL_TOOLS }}
-      if: matrix.os != 'windows-latest'
-        
+        host: 'mac'
+        target: 'desktop'
+        arch: 'clang_64'
+        cache: true
+      if: matrix.label == 'macos'
+
+    # tools_openssl_x64 ships the OpenSSL 1.1 runtime Qt Network expects on
+    # Windows; it used to be downloaded from a host that no longer resolves.
     - name: Install Qt5 (Windows)
-      uses: jurplel/install-qt-action@v3
+      uses: jurplel/install-qt-action@v4
       with:
         version: '5.15.2'
-        cached: ${{ steps.cache-qt.outputs.cache-hit }}
-        aqtversion: '==3.1.*'
         host: 'windows'
         target: 'desktop'
         arch: 'win64_msvc2019_64'
-      if: matrix.os == 'windows-latest'
+        tools: 'tools_openssl_x64'
+        cache: true
+      if: matrix.label == 'windows'
 
-    - name: Set up SDL 2.0.20 (ubuntu-latest)
-      run: |
-        SDL2VER=2.0.20
-        if [[ ! -e ~/.ccache ]]; then
-          mkdir ~/.ccache
-        fi  
-        cd ~/.ccache
-        if [[ ! -e SDL2-${SDL2VER} ]]; then
-          curl -sLO https://libsdl.org/release/SDL2-${SDL2VER}.tar.gz
-          tar -xzf SDL2-${SDL2VER}.tar.gz
-          cd SDL2-${SDL2VER}
-          ./configure --prefix=/usr/local
-          make && cd ../
-          rm SDL2-${SDL2VER}.tar.gz
-        fi
-        sudo make -C SDL2-${SDL2VER} install
-      if: matrix.os == 'ubuntu-20.04'
+    - name: CMake configure (macOS)
+      run: cmake -B build -DCI=ON -DEKA2L1_ENABLE_SCRIPTING_ABILITY=OFF -DEKA2L1_DEPLOY_DMG=ON -DEKA2L1_ENABLE_UNEXPECTED_EXCEPTION_HANDLER=ON -DEKA2L1_ENABLE_DISCORD_RICH_PRESENCE=ON -DCMAKE_PREFIX_PATH=${{ env.QT_ROOT_DIR }} -DCMAKE_BUILD_TYPE=${{ env.config }}
+      if: matrix.label == 'macos'
 
-    - name: Patch Qt to fix compile error with GCC-11 (ubuntu-latest)
-      run: |
-        sed -i 's/ThreadEngineStarter<void>(ThreadEngine<void> \*_threadEngine)/ThreadEngineStarter(ThreadEngine<void> \*_threadEngine)/' "${{ env.Qt5_DIR }}/include/QtConcurrent/qtconcurrentthreadengine.h"
-      shell: bash
-      if: matrix.os == 'ubuntu-20.04'
-      
-    - name: CMake configure
-      run: cmake -B build -DCI=ON -DEKA2L1_ENABLE_SCRIPTING_ABILITY=OFF -DEKA2L1_DEPLOY_DMG=ON -DEKA2L1_ENABLE_UNEXPECTED_EXCEPTION_HANDLER=ON -DEKA2L1_ENABLE_DISCORD_RICH_PRESENCE=ON -DCMAKE_PREFIX_PATH=${{ env.Qt5_DIR }} -DCMAKE_BUILD_TYPE=${{ matrix.config }}
-      if: matrix.os == 'macos-latest'
+    - name: CMake configure (Windows)
+      run: cmake -B build -DCI=ON -DEKA2L1_ENABLE_UNEXPECTED_EXCEPTION_HANDLER=ON -DEKA2L1_NO_TERMINAL=ON -DEKA2L1_ENABLE_DISCORD_RICH_PRESENCE=ON -DCMAKE_PREFIX_PATH=${{ env.QT_ROOT_DIR }} -DCMAKE_BUILD_TYPE=${{ env.config }}
+      if: matrix.label == 'windows'
 
-    - name: CMake configure
-      run: cmake -B build -DCI=ON -DEKA2L1_ENABLE_UNEXPECTED_EXCEPTION_HANDLER=ON -DEKA2L1_NO_TERMINAL=ON -DEKA2L1_ENABLE_DISCORD_RICH_PRESENCE=ON -DCMAKE_PREFIX_PATH=${{ env.Qt5_DIR }} -DCMAKE_BUILD_TYPE=${{ matrix.config }}
-      if: matrix.os != 'macos-latest'
+    - name: CMake configure (Linux)
+      run: cmake -B build -DCI=ON -DEKA2L1_ENABLE_UNEXPECTED_EXCEPTION_HANDLER=ON -DEKA2L1_NO_TERMINAL=ON -DEKA2L1_ENABLE_DISCORD_RICH_PRESENCE=ON -DCMAKE_BUILD_TYPE=${{ env.config }}
+      if: matrix.label == 'linux'
 
     - name: CMake build
-      run: cmake --build build --config ${{ matrix.config }} --parallel 2 --target eka2l1_qt
-      if: matrix.os != 'windows-latest'
-    
-    - name: CMake build
-      run: cmake --build build --config ${{ matrix.config }} --parallel 2 --target eka2l1_qt updater
-      if: matrix.os == 'windows-latest'
+      run: cmake --build build --config ${{ env.config }} --parallel 4 --target eka2l1_qt
+      if: matrix.label != 'windows'
 
+    - name: CMake build
+      run: cmake --build build --config ${{ env.config }} --parallel 4 --target eka2l1_qt updater
+      if: matrix.label == 'windows'
+
+    # linuxdeploy and its plugins are AppImages themselves, and the runner image
+    # no longer ships FUSE 2 to mount them.
     - name: Generate AppImage
+      env:
+        APPIMAGE_EXTRACT_AND_RUN: 1
       run: |
         chmod u+x scripts/generate_appimage.sh
         ./scripts/generate_appimage.sh
-      if: matrix.os == 'ubuntu-20.04'
+      if: matrix.label == 'linux'
 
     - name: Compute git short sha
       id: git_short_sha
-      run: echo "::set-output name=value::$(git rev-parse --short HEAD)"
-      
+      run: echo "value=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+      shell: bash
+
     - name: Copy OpenSSL binaries
       run: |
-        Invoke-WebRequest https://radrat.vn/eka2l1/roms/build/libcrypto-1_1-x64.dll -OutFile build\bin\libcrypto-1_1.dll
-        Invoke-WebRequest https://radrat.vn/eka2l1/roms/build/libssl-1_1-x64.dll -OutFile build\bin\libssl-1_1.dll
+        $tools = $env:IQTA_TOOLS
+        if (-not $tools) { Write-Warning "Qt tools directory unknown, skipping OpenSSL"; exit 0 }
+        foreach ($dll in @("libcrypto-1_1-x64.dll", "libssl-1_1-x64.dll")) {
+          $src = Get-ChildItem -Path $tools -Filter $dll -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
+          if ($src) {
+            Copy-Item $src.FullName ("build\bin\" + ($dll -replace "-x64", ""))
+          } else {
+            Write-Warning "$dll not found under $tools"
+          }
+        }
       shell: pwsh
-      if: matrix.os == 'windows-latest'
+      if: matrix.label == 'windows'
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
-        name: eka2l1-${{ steps.git_short_sha.outputs.value }}-${{ matrix.os }}
+        name: eka2l1-${{ steps.git_short_sha.outputs.value }}-${{ matrix.label }}
         path: build/bin
-      if: matrix.os != 'ubuntu-20.04'
+      if: matrix.label != 'linux'
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
-        name: eka2l1-${{ steps.git_short_sha.outputs.value }}-${{ matrix.os }}
+        name: eka2l1-${{ steps.git_short_sha.outputs.value }}-${{ matrix.label }}
         path: build/eka2l1-qt-x64.AppImage
-      if: matrix.os == 'ubuntu-20.04'
+      if: matrix.label == 'linux'
 
   roll-release:
    needs: [build-android, build-desktop]
    runs-on: "ubuntu-latest"
-   if: github.ref == 'refs/heads/master'
+   if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+   permissions:
+     contents: write
    steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        submodules: recursive
-    
+
     - name: Compute git short sha
       id: git_short_sha
-      run: echo "::set-output name=value::$(git rev-parse --short HEAD)"
-      
-    - name: Download Windows Artifacts
-      uses: actions/download-artifact@v3
+      run: echo "value=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+    - name: Download Windows artifact
+      uses: actions/download-artifact@v4
       with:
-        name: "eka2l1-${{ steps.git_short_sha.outputs.value }}-windows-latest"
+        name: "eka2l1-${{ steps.git_short_sha.outputs.value }}-windows"
         path: windows-files
 
-    - name: Download MacOS Artifact
-      uses: actions/download-artifact@v3
+    - name: Download macOS artifact
+      uses: actions/download-artifact@v4
       with:
-        name: "eka2l1-${{ steps.git_short_sha.outputs.value }}-macos-latest"
+        name: "eka2l1-${{ steps.git_short_sha.outputs.value }}-macos"
         path: mac-files
-        
-    - name: Download Ubuntu Artifact
-      uses: actions/download-artifact@v3
+
+    - name: Download Linux artifact
+      uses: actions/download-artifact@v4
       with:
-        name: "eka2l1-${{ steps.git_short_sha.outputs.value }}-ubuntu-20.04"
-        
-    - name: Download Android Artifact
-      uses: actions/download-artifact@v3
+        name: "eka2l1-${{ steps.git_short_sha.outputs.value }}-linux"
+
+    - name: Download Android artifact
+      uses: actions/download-artifact@v4
       with:
-        name: "eka2l1-${{ steps.git_short_sha.outputs.value }}"
-        
+        name: "eka2l1-${{ steps.git_short_sha.outputs.value }}-android"
+
     - name: Rename artifacts for release
       run: |
-        (cd windows-files && zip -r ../EKA2L1-Windows-x86_64.zip . && cd ..)
-        (cd mac-files && zip -r ../EKA2L1-MacOS-x86_64.zip . && cd ..)
+        (cd windows-files && zip -r ../EKA2L1-Windows-x86_64.zip .)
+        (cd mac-files && zip -r ../EKA2L1-MacOS-x86_64.zip .)
         mv eka2l1-qt-x64.AppImage EKA2L1-Linux-x86_64.AppImage
         mv eka2l1-${{ steps.git_short_sha.outputs.value }}.apk EKA2L1-Android.apk
 
+    # The release is a rolling one, so the tag has to be moved to the commit
+    # being published before the release itself is updated.
+    - name: Move the rolling tag
+      run: |
+        git tag -f continous
+        git push -f origin refs/tags/continous
+
     - name: Create release
-      uses: "marvinpinto/action-automatic-releases@latest"
+      uses: softprops/action-gh-release@v2
       with:
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: "continous"
+        tag_name: continous
+        name: "Automatic CI builds"
         prerelease: false
-        title: "Automatic CI builds"
         files: |
           EKA2L1-Windows-x86_64.zip
           EKA2L1-MacOS-x86_64.zip
           EKA2L1-Linux-x86_64.AppImage
           EKA2L1-Android.apk
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,8 +129,8 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get -y install ccache libgtk-3-dev libpulse-dev libasound2-dev \
-          libsdl2-dev pulseaudio qtbase5-dev qtbase5-dev-tools qttools5-dev \
-          qttools5-dev-tools libqt5svg5-dev libqt5opengl5-dev
+          libsdl2-dev pulseaudio qtbase5-dev qtbase5-dev-tools qtbase5-private-dev \
+          qttools5-dev qttools5-dev-tools libqt5svg5-dev libqt5opengl5-dev
       if: matrix.label == 'linux'
 
     - name: Configure ccache
@@ -159,8 +159,12 @@ jobs:
         cache: true
       if: matrix.label == 'macos'
 
-    # tools_openssl_x64 ships the OpenSSL 1.1 runtime Qt Network expects on
-    # Windows; it used to be downloaded from a host that no longer resolves.
+    # The Windows build used to copy libcrypto-1_1/libssl-1_1 next to the binary,
+    # from a host that no longer resolves. There is no replacement: Qt dropped
+    # the tools_openssl_x64 package (OpenSSL 1.1 is end of life) and only ships
+    # tools_opensslv3_x64, which Qt 5.15.2 cannot load. Until Qt is bumped, the
+    # Windows artifact has no TLS backend, so the in-app updater cannot reach
+    # api.github.com.
     - name: Install Qt5 (Windows)
       uses: jurplel/install-qt-action@v4
       with:
@@ -168,20 +172,19 @@ jobs:
         host: 'windows'
         target: 'desktop'
         arch: 'win64_msvc2019_64'
-        tools: 'tools_openssl_x64'
         cache: true
       if: matrix.label == 'windows'
 
     - name: CMake configure (macOS)
-      run: cmake -B build -DCI=ON -DEKA2L1_ENABLE_SCRIPTING_ABILITY=OFF -DEKA2L1_DEPLOY_DMG=ON -DEKA2L1_ENABLE_UNEXPECTED_EXCEPTION_HANDLER=ON -DEKA2L1_ENABLE_DISCORD_RICH_PRESENCE=ON -DCMAKE_PREFIX_PATH=${{ env.QT_ROOT_DIR }} -DCMAKE_BUILD_TYPE=${{ env.config }}
+      run: cmake -B build -DCI=ON -DEKA2L1_ENABLE_SCRIPTING_ABILITY=OFF -DEKA2L1_DEPLOY_DMG=ON -DEKA2L1_ENABLE_UNEXPECTED_EXCEPTION_HANDLER=ON -DEKA2L1_ENABLE_DISCORD_RICH_PRESENCE=ON -DCMAKE_PREFIX_PATH=${{ env.QT_ROOT_DIR }} -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=${{ env.config }}
       if: matrix.label == 'macos'
 
     - name: CMake configure (Windows)
-      run: cmake -B build -DCI=ON -DEKA2L1_ENABLE_UNEXPECTED_EXCEPTION_HANDLER=ON -DEKA2L1_NO_TERMINAL=ON -DEKA2L1_ENABLE_DISCORD_RICH_PRESENCE=ON -DCMAKE_PREFIX_PATH=${{ env.QT_ROOT_DIR }} -DCMAKE_BUILD_TYPE=${{ env.config }}
+      run: cmake -B build -DCI=ON -DEKA2L1_ENABLE_UNEXPECTED_EXCEPTION_HANDLER=ON -DEKA2L1_NO_TERMINAL=ON -DEKA2L1_ENABLE_DISCORD_RICH_PRESENCE=ON -DCMAKE_PREFIX_PATH=${{ env.QT_ROOT_DIR }} -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=${{ env.config }}
       if: matrix.label == 'windows'
 
     - name: CMake configure (Linux)
-      run: cmake -B build -DCI=ON -DEKA2L1_ENABLE_UNEXPECTED_EXCEPTION_HANDLER=ON -DEKA2L1_NO_TERMINAL=ON -DEKA2L1_ENABLE_DISCORD_RICH_PRESENCE=ON -DCMAKE_BUILD_TYPE=${{ env.config }}
+      run: cmake -B build -DCI=ON -DEKA2L1_ENABLE_UNEXPECTED_EXCEPTION_HANDLER=ON -DEKA2L1_NO_TERMINAL=ON -DEKA2L1_ENABLE_DISCORD_RICH_PRESENCE=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=${{ env.config }}
       if: matrix.label == 'linux'
 
     - name: CMake build
@@ -206,21 +209,6 @@ jobs:
       id: git_short_sha
       run: echo "value=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
       shell: bash
-
-    - name: Copy OpenSSL binaries
-      run: |
-        $tools = $env:IQTA_TOOLS
-        if (-not $tools) { Write-Warning "Qt tools directory unknown, skipping OpenSSL"; exit 0 }
-        foreach ($dll in @("libcrypto-1_1-x64.dll", "libssl-1_1-x64.dll")) {
-          $src = Get-ChildItem -Path $tools -Filter $dll -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
-          if ($src) {
-            Copy-Item $src.FullName ("build\bin\" + ($dll -replace "-x64", ""))
-          } else {
-            Write-Warning "$dll not found under $tools"
-          }
-        }
-      shell: pwsh
-      if: matrix.label == 'windows'
 
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows-latest
+          - os: windows-2022
             label: windows
           - os: macos-15-intel
             label: macos
@@ -149,6 +149,15 @@ jobs:
         fetch-depth: 0
         submodules: recursive
 
+    # The vendored dependencies cannot be configured by CMake 4: capstone sets
+    # CMP0048 to OLD and glm, fmt, spdlog and dynarmic still declare
+    # cmake_minimum_required(VERSION <3.5). Pinning keeps the build reproducible
+    # as runner images move on; drop it once those submodules are updated.
+    - name: Pin CMake
+      uses: lukka/get-cmake@v4.4.2
+      with:
+        cmakeVersion: '3.31.6'
+
     - name: Install Qt5 (macOS)
       uses: jurplel/install-qt-action@v4
       with:
@@ -176,15 +185,15 @@ jobs:
       if: matrix.label == 'windows'
 
     - name: CMake configure (macOS)
-      run: cmake -B build -DCI=ON -DEKA2L1_ENABLE_SCRIPTING_ABILITY=OFF -DEKA2L1_DEPLOY_DMG=ON -DEKA2L1_ENABLE_UNEXPECTED_EXCEPTION_HANDLER=ON -DEKA2L1_ENABLE_DISCORD_RICH_PRESENCE=ON -DCMAKE_PREFIX_PATH=${{ env.QT_ROOT_DIR }} -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=${{ env.config }}
+      run: cmake -B build -DCI=ON -DEKA2L1_ENABLE_SCRIPTING_ABILITY=OFF -DEKA2L1_DEPLOY_DMG=ON -DEKA2L1_ENABLE_UNEXPECTED_EXCEPTION_HANDLER=ON -DEKA2L1_ENABLE_DISCORD_RICH_PRESENCE=ON -DCMAKE_PREFIX_PATH=${{ env.QT_ROOT_DIR }} -DCMAKE_BUILD_TYPE=${{ env.config }}
       if: matrix.label == 'macos'
 
     - name: CMake configure (Windows)
-      run: cmake -B build -DCI=ON -DEKA2L1_ENABLE_UNEXPECTED_EXCEPTION_HANDLER=ON -DEKA2L1_NO_TERMINAL=ON -DEKA2L1_ENABLE_DISCORD_RICH_PRESENCE=ON -DCMAKE_PREFIX_PATH=${{ env.QT_ROOT_DIR }} -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=${{ env.config }}
+      run: cmake -B build -DCI=ON -DEKA2L1_ENABLE_UNEXPECTED_EXCEPTION_HANDLER=ON -DEKA2L1_NO_TERMINAL=ON -DEKA2L1_ENABLE_DISCORD_RICH_PRESENCE=ON -DCMAKE_PREFIX_PATH=${{ env.QT_ROOT_DIR }} -DCMAKE_BUILD_TYPE=${{ env.config }}
       if: matrix.label == 'windows'
 
     - name: CMake configure (Linux)
-      run: cmake -B build -DCI=ON -DEKA2L1_ENABLE_UNEXPECTED_EXCEPTION_HANDLER=ON -DEKA2L1_NO_TERMINAL=ON -DEKA2L1_ENABLE_DISCORD_RICH_PRESENCE=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=${{ env.config }}
+      run: cmake -B build -DCI=ON -DEKA2L1_ENABLE_UNEXPECTED_EXCEPTION_HANDLER=ON -DEKA2L1_NO_TERMINAL=ON -DEKA2L1_ENABLE_DISCORD_RICH_PRESENCE=ON -DCMAKE_BUILD_TYPE=${{ env.config }}
       if: matrix.label == 'linux'
 
     - name: CMake build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,12 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compile_options(-Wno-error)
 endif()
 
+if (APPLE)
+    # The bundled boost (pulled in by dynarmic) still uses std::unary_function,
+    # which libc++ no longer declares in C++17 and later modes.
+    add_compile_definitions(_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION=1)
+endif()
+
 if (EKA2L1_BUILD_VULKAN_BACKEND)
     set (BUILD_WITH_VULKAN 1)
 else()

--- a/src/emu/drivers/CMakeLists.txt
+++ b/src/emu/drivers/CMakeLists.txt
@@ -160,6 +160,12 @@ target_include_directories(miniBAE_EMU
     PRIVATE include/drivers/audio/backend/minibae ${MINIBAE_INTERNAL_INCLUDE_DIRS})
 target_link_libraries(miniBAE_EMU PRIVATE common)
 
+# miniBAE is old C that assigns integers to pointers and calls functions before
+# declaring them. Clang 16 turned both into errors by default.
+if (NOT MSVC)
+    target_compile_options(miniBAE_EMU PRIVATE -Wno-int-conversion -Wno-implicit-function-declaration)
+endif()
+
 target_link_libraries(drivers PRIVATE common cubeb ffmpeg glad glm miniBAE_EMU)
 if (NOT ANDROID)
     target_link_libraries(drivers PRIVATE SDL2)


### PR DESCRIPTION
## Why

CI has not produced a build in months, and the failure is easy to miss because it happens before any step runs. Every job dies in *Set up job*:

```
##[error]This request has been automatically failed because it uses a deprecated
version of `actions/upload-artifact: v1`
##[error]... a deprecated version of `actions/cache: v1`
```

Last master run: [31083801253](https://github.com/EKA2L1/EKA2L1/actions/runs/31083801253) (2026-08-06). Every retained run before it failed the same way. So pull request authors currently see a red X that says nothing about their change.

Fixing the action versions alone is not enough — the rest of the workflow rotted alongside them:

- `ubuntu-20.04` and `macos-13` runner images are retired, and `macos-latest` is now arm64, which open-source Qt 5.15.2 has no binaries for.
- `windows-latest` moved to Visual Studio 2026 in June 2026.
- `::set-output` was removed.
- The signing and release actions are unmaintained and pinned to Node versions Actions no longer runs.
- The host serving the Windows OpenSSL DLLs (`radrat.vn`) no longer resolves.
- The vendored dependency tree cannot be configured by CMake 4, which the macOS and Windows images now ship.
- The macOS build no longer compiles at all against a current toolchain.

## What changed

**Workflow**

- `checkout` / `setup-java` / `cache` / `upload-artifact` / `download-artifact` → v4; `::set-output` → `$GITHUB_OUTPUT`.
- Linux: `ubuntu-24.04`, with Qt 5.15 and SDL 2 from apt. That removes the aqt install, the SDL 2.0.20 source build and the GCC-11 Qt patch. `qtbase5-private-dev` is needed for the `qpa/` header `displaywidget.cpp` includes. AppImage generation gets `APPIMAGE_EXTRACT_AND_RUN=1` because the image no longer ships FUSE 2.
- macOS: `macos-15-intel`, keeping the x86_64 build and Qt 5.15.2. Deployment target 10.9 → 10.15, as C++20 requires.
- Windows: `windows-2022`, which matches the `win64_msvc2019_64` Qt binaries and is supported for another three years.
- CMake pinned to 3.31.6 on every platform. CMake 4 refuses capstone's `cmake_policy(SET CMP0048 OLD)` outright, and glm, fmt, spdlog and dynarmic still declare a minimum below 3.5. `CMAKE_POLICY_VERSION_MINIMUM` only covers the latter.
- The Windows OpenSSL copy step is dropped, see the open question below.
- APK signing is done inline with `apksigner`. When the secrets are absent — every pull request from a fork — the build still runs and uploads an unsigned APK instead of failing.
- The rolling release is published with `softprops/action-gh-release`, moving the `continous` tag first, and only on a push to `master`.
- Artifacts are named by platform rather than by runner image, so the release job no longer needs editing whenever an image is renamed. Added a concurrency group so superseded pull request runs are cancelled.

**Source (2 commits, both required to build at all)**

- The bundled boost, reached through dynarmic's precompiled header, uses `std::unary_function`, which libc++ no longer declares in C++17 and later modes → the libc++ escape hatch is enabled for Apple targets.
- miniBAE assigns longs to `XPTR` and calls undeclared functions, both errors by default since Clang 16 → the two diagnostics are demoted for that target only.

## Verification

All four jobs green, with artifacts, on a fork: https://github.com/yeatse/EKA2L1/actions/runs/31935443699

It took four rounds to get there — each fix uncovered the next failure, which is roughly what one expects after this long without a working build.

**Two paths could not be exercised outside this repository, and are worth watching on the first master run:**

1. **The APK signing branch.** Fork builds have no secrets, so only the unsigned path ran (confirmed in the log). The signed path first executes on a push to `master` here.
2. **`roll-release`.** It only runs on a push to `master`. Specifically: the job force-moves the `continous` tag with `GITHUB_TOKEN`, which will fail if that tag is protected. `softprops/action-gh-release` overwrites same-named assets by default but does not move tags itself, hence the separate step.

## Two things for you to decide

- **Windows has no TLS backend now.** Qt retired `tools_openssl_x64` along with OpenSSL 1.1, and Qt 5.15.2 cannot load the OpenSSL 3 package that replaced it, so there is no drop-in source for `libcrypto-1_1`/`libssl-1_1`. The in-app updater therefore cannot reach api.github.com. Shipping the v3 DLLs instead would only hide it. The real fix is a Qt bump — happy to follow up if you want that.
- **The CMake 3.31 and Visual Studio 2022 pins are a holding action**, and should come off once the vendored submodules configure under CMake 4.

This is the first of a few infrastructure changes I would like to contribute before sending any behavioural ones; running `ekatests` under `ctest` is the natural next step, since the target is registered but never built by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PmtUzvBvCsgn9LXAFeWNsb
