### PR TITLE
tests: Restore ekatests and run it in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,12 +197,16 @@ jobs:
       if: matrix.label == 'linux'
 
     - name: CMake build
-      run: cmake --build build --config ${{ env.config }} --parallel 4 --target eka2l1_qt
+      run: cmake --build build --config ${{ env.config }} --parallel 4 --target eka2l1_qt ekatests
       if: matrix.label != 'windows'
 
     - name: CMake build
-      run: cmake --build build --config ${{ env.config }} --parallel 4 --target eka2l1_qt updater
+      run: cmake --build build --config ${{ env.config }} --parallel 4 --target eka2l1_qt updater ekatests
       if: matrix.label == 'windows'
+
+    # -C matters on the multi-config Windows generator; it is harmless elsewhere.
+    - name: Run unit tests
+      run: ctest --test-dir build -C ${{ env.config }} --output-on-failure
 
     # linuxdeploy and its plugins are AppImages themselves, and the runner image
     # no longer ships FUSE 2 to mount them.

--- a/src/emu/common/CMakeLists.txt
+++ b/src/emu/common/CMakeLists.txt
@@ -116,7 +116,12 @@ if (ANDROID)
         )
 endif()
 
-target_include_directories(common PUBLIC include)
+set(COMMON_GENERATED_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/include")
+file(MAKE_DIRECTORY "${COMMON_GENERATED_INCLUDE_DIR}/common")
+
+target_include_directories(common PUBLIC
+        "${COMMON_GENERATED_INCLUDE_DIR}"
+        include)
 target_link_libraries(common PUBLIC fmt miniz spdlog)
 target_link_libraries(common PRIVATE pugixml miniupnpc::miniupnpc re2::re2)
 
@@ -145,7 +150,7 @@ execute_process(
 )
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/common/configure.h.in
-        ${CMAKE_CURRENT_SOURCE_DIR}/include/common/configure.h)
+        ${COMMON_GENERATED_INCLUDE_DIR}/common/configure.h)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/common/version.h.in
-        ${CMAKE_CURRENT_SOURCE_DIR}/include/common/version.h)
+        ${COMMON_GENERATED_INCLUDE_DIR}/common/version.h)

--- a/src/emu/common/include/common/pystr.h
+++ b/src/emu/common/include/common/pystr.h
@@ -231,7 +231,16 @@ namespace eka2l1::common {
             // Determine base
             std::basic_string<T> num_str_ = str_;
 
-            if ((num_str_.length() >= 2) && (base == -1)) {
+            if (num_str_.empty()) {
+                return def_;
+            }
+
+            const bool detect_base = (base == -1);
+            if (detect_base) {
+                base = 10;
+            }
+
+            if ((num_str_.length() >= 2) && detect_base) {
                 auto prefix = num_str_.substr(0, 2);
                 bool prefix_found = false;
 
@@ -254,20 +263,16 @@ namespace eka2l1::common {
                         base = 8;
                         prefix_found = true;
                         break;
-
-                    default:
-                        base = 10;
-                        break;
                     }
                 }
 
                 if (prefix_found) {
                     num_str_.erase(num_str_.begin(), num_str_.begin() + 2);
                 }
-            } else {
-                // Default the value
-                if (base == -1)
-                    base = 10;
+            }
+
+            if ((base < 2) || (base > 36) || num_str_.empty()) {
+                return def_;
             }
 
             I num_ = 0;
@@ -276,6 +281,10 @@ namespace eka2l1::common {
             if (num_str_[0] == static_cast<T>('-')) {
                 factor *= -1;
                 num_str_.erase(num_str_.begin(), num_str_.begin() + 1);
+            }
+
+            if (num_str_.empty()) {
+                return def_;
             }
 
             const int len_ = static_cast<const int>(num_str_.length());

--- a/src/emu/common/src/allocator.cpp
+++ b/src/emu/common/src/allocator.cpp
@@ -293,18 +293,19 @@ namespace eka2l1::common {
         }
 
         std::uint32_t start_bit = offset;
-        const std::uint32_t end_bit = offset_end;
-
         std::uint32_t allocated_count = 0;
 
-        while (start_bit < end_bit) {
-            const std::int32_t next_end_bit = static_cast<std::int32_t>(common::min<std::uint32_t>((((start_bit + 32) >> 5) << 5) - 1, end_bit));
-            const std::int32_t ext_count = (next_end_bit - start_bit + 1);
+        while (start_bit <= offset_end) {
+            const std::uint32_t word_index = start_bit >> 5;
+            const std::uint32_t end_bit = common::min<std::uint32_t>(
+                offset_end, (word_index << 5) + 31);
+            const std::uint32_t bit_count = end_bit - start_bit + 1;
+            const std::uint32_t mask = (bit_count == 32)
+                ? 0xFFFFFFFFU
+                : ((1U << bit_count) - 1) << (31 - (end_bit & 31));
 
-            std::uint32_t word_to_scan = (~words_[start_bit >> 5] >> (31 - (next_end_bit & 31))) & ((1 << ext_count) - 1);
-            allocated_count += number_of_set_bits(word_to_scan);
-
-            start_bit = next_end_bit + 1;
+            allocated_count += number_of_set_bits(~words_[word_index] & mask);
+            start_bit = end_bit + 1;
         }
 
         return allocated_count;

--- a/src/emu/common/src/fileutils.cpp
+++ b/src/emu/common/src/fileutils.cpp
@@ -407,7 +407,13 @@ namespace eka2l1::common {
         }
 #endif
 
-        return std::make_unique<standard_dir_iterator>(eka2l1::add_path(path, filter));
+        std::string iterator_path = eka2l1::add_path(path, filter);
+        if (filter.empty() && !iterator_path.empty() &&
+            (iterator_path.back() != '/') && (iterator_path.back() != '\\')) {
+            iterator_path += eka2l1::get_separator();
+        }
+
+        return std::make_unique<standard_dir_iterator>(iterator_path);
     }
     
     std::string find_case_sensitive_file_name(const std::string &folder_path, const std::string &insensitive_name, const file_type type) {

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ add_subdirectory(common)
 
 add_executable(ekatests 
 	tests.cpp
+    platform.cpp
     ${COMMON_TEST_FILES}
     ${CORE_TEST_FILES})
 
@@ -17,10 +18,22 @@ target_link_libraries(ekatests PRIVATE
     epocloader
     epocservs)
 
+# The fixtures are copied next to the executable, and the tests open them by a
+# relative path. Multi-config generators put the executable in a per-config
+# subdirectory, which is not where CTest would otherwise run it from.
 add_test(
   NAME ekatests
   COMMAND ekatests
+  WORKING_DIRECTORY $<TARGET_FILE_DIR:ekatests>
 )
+
+if (WIN32)
+    # SDL2 and the other runtime DLLs are copied next to the frontend, which is
+    # not where the test executable is built, so the loader has to be told.
+    file(TO_NATIVE_PATH "${CMAKE_BINARY_DIR}/bin" EKATESTS_RUNTIME_DLL_DIR)
+    set_tests_properties(ekatests PROPERTIES
+        ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:${EKATESTS_RUNTIME_DLL_DIR}")
+endif()
 
 set(EPOC_LOADER_ASSETS_PATH "${CMAKE_CURRENT_SOURCE_DIR}/epoc/loader/assets/")
 add_assets(ekatests ${EPOC_LOADER_ASSETS_PATH} "loaderassets")

--- a/src/tests/common/allocator.cpp
+++ b/src/tests/common/allocator.cpp
@@ -84,48 +84,41 @@ TEST_CASE("bitmap_alloc_best_fit_multiple_fit", "bitmap_allocator") {
 TEST_CASE("bitmap_count_bit_aligned", "bitmap_allocator") {
     common::bitmap_allocator alloc(32 * 3);
 
-    // Bitmap 1: All bit on
-    alloc.set_word(0, 0xFFFFFFFF);
+    alloc.force_fill(0, 32);
+    alloc.force_fill(32, 12);
+    alloc.force_fill(64, 8);
 
-    // Bitmap 2: 12 bits on
-    alloc.set_word(1, 0xF00F00F0);
-
-    // Bitmap 3: 8 bits on
-    alloc.set_word(2, 0x00F00F00);
-
-    // First bitmap has 52 bits on, plus with bitmap 2 and 3, we got 52
+    // All 32 bits in the first word, 12 in the second and 8 in the third.
     REQUIRE(alloc.allocated_count(0, 32 * 3 - 1) == 52);
 }
 
 TEST_CASE("bitmap_count_unaligned_start", "bitmap_allocator") {
     common::bitmap_allocator alloc(32 * 3);
 
-    // Bitmap 1: Valid bit count starting from bit 6
-    alloc.set_word(0, 0b110011000011);
+    alloc.force_fill(2, 4);
+    alloc.force_fill(32, 12);
+    alloc.force_fill(64, 8);
 
-    // Bitmap 2: 12 bits on
-    alloc.set_word(1, 0xF00F00F0);
-
-    // Bitmap 3: 8 bits on
-    alloc.set_word(2, 0x00F00F00);
-
-    // First bitmap has 4 valid bits on (from offset 2), plus with bitmap 2 and 3, we got 24
+    // Four allocated bits from offset 2, plus 12 and 8 in the next words.
     REQUIRE(alloc.allocated_count(2, 32 * 3 - 3) == 24);
 }
 
 TEST_CASE("bitmap_count_unaligned_start_end", "bitmap_allocator") {
     common::bitmap_allocator alloc(32 * 3);
 
-    // Bitmap 1: Valid bit count starting from bit 6
-    alloc.set_word(0, 0b110011000011);
+    alloc.force_fill(2, 4);
+    alloc.force_fill(32, 12);
+    alloc.force_fill(67, 4);
 
-    // Bitmap 2: 12 bits on
-    alloc.set_word(1, 0xF00F00F0);
-
-    // Bitmap 3: 4 bits valid before offset 68
-    alloc.set_word(2, 0b10101110001111);
-
-    // First bitmap has 4 valid bits on (from offset 2), plus with bitmap 2 and 3 (4 bits before offset 70),
-    // we got 4 + 12 + 4 = 20 bits
+    // Both endpoints are inclusive: 4 + 12 + 4 allocated bits.
     REQUIRE(alloc.allocated_count(2, 70) == 20);
+}
+
+TEST_CASE("bitmap_count_single_bit", "bitmap_allocator") {
+    common::bitmap_allocator alloc(32);
+
+    alloc.force_fill(17, 1);
+
+    REQUIRE(alloc.allocated_count(17, 17) == 1);
+    REQUIRE(alloc.allocated_count(16, 16) == 0);
 }

--- a/src/tests/epoc/services/applist/registeration.cpp
+++ b/src/tests/epoc/services/applist/registeration.cpp
@@ -60,7 +60,7 @@ TEST_CASE("mandatory_check_non_localise", "applist_registeration") {
     apa_app_registry reg;
 
     bool result = read_registeration_info(reinterpret_cast<common::ro_stream *>(&app_info_resource_stream),
-        reg, drive_c);
+        reg, drive_c, true);
 
     REQUIRE(result);
     REQUIRE(common::compare_ignore_case(reg.mandatory_info.app_path.to_std_string(nullptr),

--- a/src/tests/platform.cpp
+++ b/src/tests/platform.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <common/applauncher.h>
+#include <drivers/ui/input_dialog.h>
+
+namespace eka2l1::common {
+    bool launch_browser(const std::string &) {
+        return false;
+    }
+}
+
+namespace eka2l1::drivers::ui {
+    bool open_input_view(const std::u16string &, const int, input_dialog_complete_callback) {
+        return false;
+    }
+
+    void close_input_view() {
+    }
+
+    void show_yes_no_dialog(const std::u16string &, const std::u16string &, const std::u16string &,
+        yes_no_dialog_complete_callback complete_callback) {
+        if (complete_callback) {
+            complete_callback(1);
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #583. Now that CI runs again, this makes it run the unit tests — and fixes what it takes to get there.

## Why

`src/tests/CMakeLists.txt` has registered `ekatests` with CTest for years, but no workflow ever built the target, so it quietly stopped compiling. Reviving it took a build repair and then turned up three shipped bugs in `common/`, each of which had a test that was already asserting the right thing (or, in the allocator's case, asserting the wrong thing in a way that agreed with the bug).

## The build repair

- The applist fixture still passed three arguments to `read_registeration_info`, which grew an `app_path_oldarch` parameter. Passing `true` keeps the fixture's existing expectation rather than weakening it.
- `configure.h` and `version.h` were generated **into the source tree**, so two build trees of one checkout overwrite each other's feature configuration — a scripting-disabled build can end up compiling against a header that says scripting is on. They now go to the `common` target's binary include directory, exported ahead of the source one.
- `ekatests` links services and dispatch code referencing browser launching and host input dialogs, which only the Qt, Android and iOS frontends define. The test target now owns small stubs; the yes/no dialog completes as cancelled rather than leaving an async request pending forever.

## The three bugs

- **`bitmap_allocator::allocated_count()`** shifted by 32 for a full-word range (undefined) and skipped single-bit ranges entirely, because the scan advanced past the end before examining them. The mask is now defined for every width 1..32 and both endpoints are inclusive.
  The existing tests had been written to the opposite convention from the one the allocator documents — building words as if a set bit meant *allocated*, while the allocator treats a zero bit as allocated — so they agreed with the broken implementation. They now allocate through `force_fill()`, the public operation.
- **`basic_pystr::as_int()`** only assigned a base inside the branch that inspects a two-character prefix, and only when the first character was `'0'`. Any other string of length ≥ 2 — `"42"`, every decimal the INI and central-repository readers hand it — reached the digit loop with `base == -1`, compared digits against `'0' + -2`, and returned the caller's default. Decimal is now the default before prefix detection; an empty string, an empty body after a sign or prefix, or a base outside 2..36 returns the default instead of reading past the end.
- **`make_directory_iterator(path, "")`**: on POSIX the standard iterator splits the path it is given into a directory and a filename pattern, so an empty filter lost the last component to the pattern — iterating `z/system/apps` listed `z/system` filtered by the name `apps`. That is how `find_case_sensitive_file_name()`, the recursive copy walker and `delete_folder()` call it, and how the ROM drive and system application folders are scanned.

## Wiring it up

Every desktop job now builds `ekatests` alongside the frontend and runs `ctest -C Release --output-on-failure`. Two things only a real CI run surfaces:

- The fixtures are copied next to the executable, which on a multi-config generator is a per-config subdirectory CTest would not otherwise run from — hence `WORKING_DIRECTORY`.
- On Windows the test executable is not built next to the runtime DLLs the frontend build copies into `bin`, so `ctest` failed with `0xC0000135` until the test's `PATH` was pointed at them. Done as a test property, so `ctest` also works from a plain Windows checkout.

## Verification

Green on all four jobs, `ctest` reporting `100% tests passed` on Windows, macOS and Linux: https://github.com/yeatse/EKA2L1/actions/runs/31942171723

And the gate demonstrably bites — reverting *only* the allocator fix turns all three desktop jobs red with the precise assertions:

```
src/tests/common/allocator.cpp:92: FAILED:
  REQUIRE( alloc.allocated_count(0, 32 * 3 - 1) == 52 )
...
test cases:  64 |  60 passed | 4 failed
assertions: 202 | 198 passed | 4 failed
```

That second run also rules out the boring failure mode where the suite matches zero tests and exits 0.

## One thing left out

The suite cannot be built on a current macOS toolchain at all: SDK 26 no longer declares `stat64`, which `fileutils.cpp` uses on every POSIX target. CI does not catch it because its image is older, and it is unrelated to the tests, so I left it out rather than widening this PR — happy to send it separately if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PmtUzvBvCsgn9LXAFeWNsb
