### PR TITLE
system: Don't initialise the user side when no device is set up

### DIFF
--- a/src/emu/system/src/epoc.cpp
+++ b/src/emu/system/src/epoc.cpp
@@ -1136,6 +1136,16 @@ namespace eka2l1 {
     }
 
     void system_impl::initialize_user_parties() {
+        // The dispatcher is created by setup_outsider(), which set_device() only
+        // reaches once the ROM has loaded. Without a device -- a fresh install,
+        // or a configured device whose ROM is missing -- there is nothing to
+        // initialise, and register_functions() would call through a null
+        // dispatcher. Every frontend calls this unconditionally.
+        if (!dispatcher_) {
+            LOG_ERROR(SYSTEM, "No device has been set up, skipping user-side initialisation");
+            return;
+        }
+
         get_lib_manager()->load_patch_libraries(PATCH_FOLDER_PATH);
         dispatch::libraries::register_functions(kern_.get(), dispatcher_.get());
 


### PR DESCRIPTION
## Why

Starting the emulator with no device installed — a fresh install, or a configured device whose ROM is missing — crashes immediately:

```
Thread 9 'Symbian OS thread' EXC_BAD_ACCESS (code=1, address=0x10)
  eka2l1::dispatch::dispatcher::patch_libraries(...)
  eka2l1::dispatch::libraries::register_functions(...)
  eka2l1::system_impl::initialize_user_parties()
  eka2l1::desktop::emulator::stage_two()
```

`set_device()` returns early when `load_rom()` fails, so `setup_outsider()` — which creates the dispatcher — never runs and `dispatcher_` stays null. Every frontend then calls `initialize_user_parties()` unconditionally right after, and `register_functions()` calls straight through the null pointer: the faulting instruction is `ldr x0, [x0, #0x10]`, loading `this->libmngr_`, which is why the fault address is `0x10`.

## Fix

Bail out with an error instead of dereferencing. Done in the shared layer, so the Qt, Android and iOS frontends are all covered.

## Verification

Reproduced with a macOS build on a machine with no ROM for the configured device, and confirmed the same crash in the **x86_64** artifact from CI as well as a local arm64 build — this is not architecture specific. With the guard, the application starts and stays up instead of dying a few seconds in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PmtUzvBvCsgn9LXAFeWNsb
