### PR TITLE
ci: Add one stable check for branch protection to require

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -257,6 +257,26 @@ jobs:
         path: build/eka2l1-qt-x64.AppImage
       if: matrix.label == 'linux'
 
+  # One check with a stable name for branch protection to require. The matrix
+  # job names carry their runner labels, so they change whenever an image is
+  # swapped -- a required check pinned to those silently stops applying. This
+  # one does not move.
+  ci:
+    name: CI
+    needs: [build-android, build-desktop]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check the build and test jobs
+      run: |
+        echo "android:  ${{ needs.build-android.result }}"
+        echo "desktop:  ${{ needs.build-desktop.result }}"
+        if [ "${{ needs.build-android.result }}" != "success" ] || \
+           [ "${{ needs.build-desktop.result }}" != "success" ]; then
+          echo "::error::A build or test job did not pass"
+          exit 1
+        fi
+
   roll-release:
    needs: [build-android, build-desktop]
    runs-on: "ubuntu-latest"


### PR DESCRIPTION
The builds and unit tests run on every pull request, but nothing stops a red one from being merged. #580 went in with all four jobs failing and broke the build for everyone; master is still broken as I write this (the fix is in #587).

## Why not just require the existing checks

Because their names carry the runner label — `build-desktop (ubuntu-latest, linux)` — so they change whenever an image is swapped, which #586 just did for all three desktop platforms. A required check pinned to a name that no longer exists is not enforced, and nothing tells you.

This adds a job named **`CI`** that passes only when the build and test jobs did. One name, and it does not move.

## Enabling it

Settings → Branches → add a rule for `master` → *Require status checks to pass before merging* → pick `CI`. That part needs repository admin, which I do not have.

## About this PR's own red X

It is red for the reason the PR exists: master does not currently build (#580), so every job fails on this branch too. The `CI` job reporting that failure is it working correctly. It will go green once #587 (or an equivalent fix) lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PmtUzvBvCsgn9LXAFeWNsb
