### PR TITLE
Fix three ways an app icon fails to decode

### DIFF
--- a/src/emu/ios/Bridge/IosEmulator.mm
+++ b/src/emu/ios/Bridge/IosEmulator.mm
@@ -304,10 +304,12 @@ namespace eka2l1::ios {
             const auto &mask_hdr = parser.sbm_headers[1];
             if (static_cast<std::size_t>(mask_hdr.size_pixels.x) == w
                 && static_cast<std::size_t>(mask_hdr.size_pixels.y) == h) {
-                // TODO: the mask is not applied yet -- deciding whether it is a soft
-                // or a colour-key mask lives in the icon work that follows this port,
-                // so icons render opaque until then.
-                (void)mask_hdr;
+                std::vector<std::uint8_t> mask_rgba(w * h * 4);
+                eka2l1::common::wo_buf_stream mask_dst(mask_rgba.data(), mask_rgba.size());
+                if (eka2l1::epoc::convert_to_rgba8888(fbsserv, parser, 1, mask_dst, true)) {
+                    eka2l1::epoc::apply_icon_mask_alpha(rgba.data(), mask_rgba.data(), w, h,
+                        mask_hdr.bit_per_pixels);
+                }
             }
         }
         return encode_rgba_to_png(rgba.data(), w, h, side);
@@ -332,7 +334,12 @@ namespace eka2l1::ios {
         if (auto *mask_bitmap = icon_pair->second) {
             if (static_cast<std::size_t>(mask_bitmap->header_.size_pixels.x) == w
                 && static_cast<std::size_t>(mask_bitmap->header_.size_pixels.y) == h) {
-                // TODO: see above -- mask application follows with the icon work.
+                std::vector<std::uint8_t> mask_rgba(w * h * 4);
+                eka2l1::common::wo_buf_stream mask_dst(mask_rgba.data(), mask_rgba.size());
+                if (eka2l1::epoc::convert_to_rgba8888(fbsserv, mask_bitmap, mask_dst, true)) {
+                    eka2l1::epoc::apply_icon_mask_alpha(rgba.data(), mask_rgba.data(), w, h,
+                        mask_bitmap->header_.bit_per_pixels);
+                }
             }
         }
         return encode_rgba_to_png(rgba.data(), w, h, side);

--- a/src/emu/loader/src/mbm.cpp
+++ b/src/emu/loader/src/mbm.cpp
@@ -112,6 +112,16 @@ namespace eka2l1::loader {
             }
         } else {
             for (const std::size_t i : index_to_loads) {
+                // A client may ask for a bitmap index this MBM does not have — the
+                // FBS client passes whatever the guest requested. Skip it instead of
+                // indexing the trailer out of bounds; the caller checks the result
+                // with is_header_loaded() and reports not-found. The out-of-bounds
+                // read is silent undefined behaviour with an unhardened libc++ and
+                // an abort with a hardened one.
+                if (i >= trailer.sbm_offsets.size()) {
+                    continue;
+                }
+
                 if (!do_load_header(i))
                     return false;
 

--- a/src/emu/services/include/services/fbs/bitmap.h
+++ b/src/emu/services/include/services/fbs/bitmap.h
@@ -125,4 +125,20 @@ namespace eka2l1::epoc {
     bool convert_to_rgba8888(fbs_server *serv, common::ro_stream &source, common::wo_stream &dest, loader::sbm_header &header, std::int32_t byte_width, const bitmap_file_compression comp, const bool make_standard_mask = false);
     bool convert_to_rgba8888(fbs_server *serv, bitwise_bitmap *bmp, common::wo_stream &dest, const bool make_standard_mask = false);
     bool convert_to_rgba8888(fbs_server *serv, loader::mbm_file &file, const std::size_t index, common::wo_stream &dest, const bool make_standard_mask = false);
+    /**
+     * @brief Composite a Symbian icon mask onto the icon's alpha channel.
+     *
+     * Both buffers must be RGBA8888 of the same dimensions, and the mask must have
+     * been produced by convert_to_rgba8888 with make_standard_mask set. The mask's
+     * polarity is worked out from its colour depth and its content; see the
+     * implementation for the two families involved.
+     *
+     * @param icon_rgba     Icon pixels, alpha channel overwritten in place.
+     * @param mask_rgba     Mask pixels, read only.
+     * @param width         Width in pixels of both buffers.
+     * @param height        Height in pixels of both buffers.
+     * @param mask_bpp      Colour depth the mask was stored at.
+     */
+    void apply_icon_mask_alpha(std::uint8_t *icon_rgba, const std::uint8_t *mask_rgba,
+        const std::size_t width, const std::size_t height, const std::uint32_t mask_bpp);
 }

--- a/src/emu/services/src/fbs/impls/bitmap.cpp
+++ b/src/emu/services/src/fbs/impls/bitmap.cpp
@@ -1583,6 +1583,85 @@ namespace eka2l1 {
             common::ro_buf_stream buf_stream(data.data(), data.size());
             return convert_to_rgba8888(serv, buf_stream, dest, file.sbm_headers[index], -1, static_cast<bitmap_file_compression>(file.sbm_headers[index].compression), make_standard_mask);
         }
+
+        static bool mask_depth_is_soft(const std::uint32_t bpp) {
+            return (bpp > 1) && (bpp <= 8);
+        }
+
+        // The exception: a few S60v2 AIF icons store a *binary* stencil at 8bpp, in
+        // the colour-key polarity the contract above describes, so the soft reading
+        // turns them inside out - the shape goes fully transparent while the backdrop
+        // stays opaque, which reads as a blank icon.
+        // The mask content settles it. An icon's outer frame is transparent by
+        // definition, so a mask that holds only white plus one other level, has a
+        // solid white border and some non-white interior, can only be colour-key.
+        // Masks with a real alpha ramp, with an already-transparent black border, or
+        // fully opaque ones (a full-bleed icon) keep the soft reading.
+        static bool soft_mask_reads_inside_out(const std::uint8_t *mask_rgba, const std::size_t width,
+            const std::size_t height) {
+            static constexpr std::uint8_t WHITE_MIN = 250;
+
+            if ((width < 3) || (height < 3)) {
+                return false;
+            }
+
+            std::uint8_t other_level = 0;
+            bool has_other_level = false;
+
+            for (std::size_t i = 0; i < width * height; i++) {
+                const std::uint8_t level = mask_rgba[i * 4];
+
+                if (level >= WHITE_MIN) {
+                    continue;
+                }
+
+                if (!has_other_level) {
+                    other_level = level;
+                    has_other_level = true;
+                } else if (level != other_level) {
+                    // Three or more levels: a genuine alpha ramp.
+                    return false;
+                }
+            }
+
+            if (!has_other_level) {
+                return false;
+            }
+
+            for (std::size_t x = 0; x < width; x++) {
+                if ((mask_rgba[x * 4] < WHITE_MIN) || (mask_rgba[((height - 1) * width + x) * 4] < WHITE_MIN)) {
+                    return false;
+                }
+            }
+
+            for (std::size_t y = 0; y < height; y++) {
+                if ((mask_rgba[(y * width) * 4] < WHITE_MIN) || (mask_rgba[(y * width + width - 1) * 4] < WHITE_MIN)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        void apply_icon_mask_alpha(std::uint8_t *icon_rgba, const std::uint8_t *mask_rgba,
+            const std::size_t width, const std::size_t height, const std::uint32_t mask_bpp) {
+            if (!icon_rgba || !mask_rgba) {
+                return;
+            }
+
+            const bool soft = mask_depth_is_soft(mask_bpp) && !soft_mask_reads_inside_out(mask_rgba, width, height);
+
+            // A soft mask maps its gray value straight to alpha (white opaque). The
+            // mask is gray-valued, so its red channel carries the luminance directly
+            // and anti-aliased edges are preserved. A colour-key mask instead inverts
+            // the pure-white test that make_standard_mask left in the alpha channel,
+            // so only the white backdrop becomes transparent.
+            for (std::size_t i = 0; i < width * height; i++) {
+                icon_rgba[i * 4 + 3] = soft
+                    ? mask_rgba[i * 4]
+                    : static_cast<std::uint8_t>(255 - mask_rgba[i * 4 + 3]);
+            }
+        }
     }
 
     void fbscli::background_compress_bitmap(service::ipc_context *ctx) {

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -16,7 +16,8 @@ target_link_libraries(ekatests PRIVATE
     epocio
     epockern
     epocloader
-    epocservs)
+    epocservs
+    lunasvg)
 
 # The fixtures are copied next to the executable, and the tests open them by a
 # relative path. Multi-config generators put the executable in a per-config

--- a/src/tests/epoc/CMakeLists.txt
+++ b/src/tests/epoc/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CORE_TEST_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/rsc.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/spi.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/applist/registeration.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/services/fbs/bitmap.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/centralrepo/crebinloader.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/centralrepo/creiniloader.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/utils/sec.cpp

--- a/src/tests/epoc/CMakeLists.txt
+++ b/src/tests/epoc/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CORE_TEST_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/spi.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/applist/registeration.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/fbs/bitmap.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/services/svg_icon.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/centralrepo/crebinloader.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/centralrepo/creiniloader.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/utils/sec.cpp

--- a/src/tests/epoc/loader/mbm.cpp
+++ b/src/tests/epoc/loader/mbm.cpp
@@ -57,3 +57,33 @@ TEST_CASE("mbm_header_trailer_and_single_headers", "mbm_file") {
     REQUIRE(mbmf.sbm_headers[0].bitmap_size == 3545);
     REQUIRE(mbmf.sbm_headers[0].bit_per_pixels == 24);
 }
+
+/**
+ * A client can ask for a bitmap index the file does not have. The header read
+ * must skip it rather than index the trailer out of bounds.
+ */
+TEST_CASE("mbm_out_of_range_index_is_skipped", "mbm_file") {
+    std::ifstream fi("loaderassets/face.mbm", std::ios::binary);
+    REQUIRE(!fi.bad());
+    REQUIRE(!fi.fail());
+
+    std::vector<std::uint8_t> data;
+
+    fi.seekg(0, std::ios::end);
+    const std::uint64_t fsize = fi.tellg();
+
+    data.resize(fsize);
+    fi.seekg(0, std::ios::beg);
+
+    fi.read(reinterpret_cast<char *>(&data[0]), data.size());
+
+    common::ro_buf_stream stream(&data[0], data.size());
+    loader::mbm_file mbmf(reinterpret_cast<common::ro_stream *>(&stream));
+
+    // face.mbm holds a single bitmap, so index 1 is one past the end.
+    mbmf.index_to_loads = { 1 };
+
+    REQUIRE(mbmf.do_read_headers());
+    REQUIRE(mbmf.trailer.count == 1);
+    REQUIRE(!mbmf.is_header_loaded(1));
+}

--- a/src/tests/epoc/services/fbs/bitmap.cpp
+++ b/src/tests/epoc/services/fbs/bitmap.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <services/fbs/bitmap.h>
+
+#include <catch2/catch.hpp>
+
+#include <cstdint>
+#include <vector>
+
+using namespace eka2l1;
+
+namespace {
+    constexpr std::size_t ICON_SIDE = 4;
+
+    // Opaque white icon pixels; only the alpha channel is interesting here.
+    std::vector<std::uint8_t> make_icon() {
+        return std::vector<std::uint8_t>(ICON_SIDE * ICON_SIDE * 4, 0xFF);
+    }
+
+    // A mask converted to RGBA: the grey level lands in every colour channel, and
+    // make_standard_mask has already turned "pure white" into alpha 0xFF.
+    std::vector<std::uint8_t> make_mask(const std::vector<std::uint8_t> &levels) {
+        std::vector<std::uint8_t> mask(ICON_SIDE * ICON_SIDE * 4, 0);
+
+        for (std::size_t i = 0; i < levels.size(); i++) {
+            const std::uint8_t level = levels[i];
+
+            mask[i * 4 + 0] = level;
+            mask[i * 4 + 1] = level;
+            mask[i * 4 + 2] = level;
+            mask[i * 4 + 3] = (level >= 250) ? 0xFF : 0x00;
+        }
+
+        return mask;
+    }
+
+    std::uint8_t alpha_at(const std::vector<std::uint8_t> &rgba, const std::size_t index) {
+        return rgba[index * 4 + 3];
+    }
+}
+
+TEST_CASE("icon_mask_soft_maps_grey_to_alpha", "icon_mask") {
+    // Three levels, no solid white border: a real alpha ramp, so the mask reads
+    // as a soft mask and its grey level becomes the icon's alpha directly.
+    std::vector<std::uint8_t> levels(ICON_SIDE * ICON_SIDE, 128);
+    levels[0] = 0;
+    levels[1] = 255;
+
+    std::vector<std::uint8_t> icon = make_icon();
+    const std::vector<std::uint8_t> mask = make_mask(levels);
+
+    epoc::apply_icon_mask_alpha(icon.data(), mask.data(), ICON_SIDE, ICON_SIDE, 8);
+
+    REQUIRE(alpha_at(icon, 0) == 0);
+    REQUIRE(alpha_at(icon, 1) == 255);
+    REQUIRE(alpha_at(icon, 2) == 128);
+}
+
+TEST_CASE("icon_mask_colour_key_inverts_the_white_backdrop", "icon_mask") {
+    // A colour-key mask is stored at a colour depth, and make_standard_mask has
+    // put "this pixel is the white backdrop" in the alpha channel. Transparency
+    // is therefore the inverse of that.
+    std::vector<std::uint8_t> levels(ICON_SIDE * ICON_SIDE, 0);
+    levels[0] = 255;
+
+    std::vector<std::uint8_t> icon = make_icon();
+    const std::vector<std::uint8_t> mask = make_mask(levels);
+
+    epoc::apply_icon_mask_alpha(icon.data(), mask.data(), ICON_SIDE, ICON_SIDE, 16);
+
+    REQUIRE(alpha_at(icon, 0) == 0);
+    REQUIRE(alpha_at(icon, 1) == 255);
+}
+
+TEST_CASE("icon_mask_binary_stencil_at_low_depth_is_not_soft", "icon_mask") {
+    // The S60v2 case this exists for: a *binary* stencil stored at 8bpp, in the
+    // colour-key polarity. Reading it as a soft mask turns the icon inside out --
+    // the artwork goes transparent and the backdrop stays opaque. A mask with only
+    // white plus one other level, a solid white border and a non-white interior
+    // cannot be anything but colour-key.
+    std::vector<std::uint8_t> levels(ICON_SIDE * ICON_SIDE, 255);
+    levels[ICON_SIDE + 1] = 0;
+    levels[ICON_SIDE + 2] = 0;
+    levels[2 * ICON_SIDE + 1] = 0;
+    levels[2 * ICON_SIDE + 2] = 0;
+
+    std::vector<std::uint8_t> icon = make_icon();
+    const std::vector<std::uint8_t> mask = make_mask(levels);
+
+    epoc::apply_icon_mask_alpha(icon.data(), mask.data(), ICON_SIDE, ICON_SIDE, 8);
+
+    // The white border is the backdrop: transparent. The interior is the artwork.
+    REQUIRE(alpha_at(icon, 0) == 0);
+    REQUIRE(alpha_at(icon, ICON_SIDE + 1) == 255);
+}
+
+TEST_CASE("icon_mask_full_bleed_mask_stays_soft", "icon_mask") {
+    // An entirely white mask is a full-bleed icon, not a stencil: every pixel is
+    // opaque. Classifying it as colour-key would erase the icon.
+    const std::vector<std::uint8_t> levels(ICON_SIDE * ICON_SIDE, 255);
+
+    std::vector<std::uint8_t> icon = make_icon();
+    const std::vector<std::uint8_t> mask = make_mask(levels);
+
+    epoc::apply_icon_mask_alpha(icon.data(), mask.data(), ICON_SIDE, ICON_SIDE, 8);
+
+    for (std::size_t i = 0; i < ICON_SIDE * ICON_SIDE; i++) {
+        REQUIRE(alpha_at(icon, i) == 255);
+    }
+}
+
+TEST_CASE("icon_mask_ignores_missing_buffers", "icon_mask") {
+    std::vector<std::uint8_t> icon = make_icon();
+    const std::vector<std::uint8_t> mask = make_mask(std::vector<std::uint8_t>(ICON_SIDE * ICON_SIDE, 128));
+
+    epoc::apply_icon_mask_alpha(nullptr, mask.data(), ICON_SIDE, ICON_SIDE, 8);
+    epoc::apply_icon_mask_alpha(icon.data(), nullptr, ICON_SIDE, ICON_SIDE, 8);
+
+    REQUIRE(alpha_at(icon, 0) == 255);
+}

--- a/src/tests/epoc/services/svg_icon.cpp
+++ b/src/tests/epoc/services/svg_icon.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// What Symbian app icons need from the vendored lunasvg, pinned down so a bump
+// that drops either capability is caught here rather than by a blank icon on a
+// device. Both cases come from real MIF icons: several S60v3 games store their
+// artwork as a base64 PNG inside the SVG, and the ones exported from Adobe wrap
+// that image in <switch><foreignObject>.
+
+#include <lunasvg.h>
+
+#include <catch2/catch.hpp>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace {
+    // A 2x2 opaque red PNG.
+    constexpr const char *RED_PNG_BASE64 =
+        "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAEUlEQVR4nGP4z8DwH4QZYAwAR8oH+WdZbrcAAAAASUVORK5CYII=";
+
+    std::vector<std::uint8_t> render(const std::string &svg, const int side) {
+        std::unique_ptr<lunasvg::Document> doc = lunasvg::Document::loadFromData(svg);
+        REQUIRE(doc != nullptr);
+
+        std::vector<std::uint8_t> rgba(static_cast<std::size_t>(side) * side * 4, 0);
+        lunasvg::Bitmap bitmap(rgba.data(), side, side, side * 4);
+
+        const float sx = (doc->width() > 0) ? (static_cast<float>(side) / doc->width()) : 1.0f;
+        const float sy = (doc->height() > 0) ? (static_cast<float>(side) / doc->height()) : 1.0f;
+
+        doc->render(bitmap, lunasvg::Matrix{ sx, 0, 0, sy, 0, 0 });
+        bitmap.convertToRGBA();
+
+        return rgba;
+    }
+
+    bool has_opaque_pixel(const std::vector<std::uint8_t> &rgba) {
+        for (std::size_t i = 3; i < rgba.size(); i += 4) {
+            if (rgba[i] != 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
+TEST_CASE("svg_renders_a_data_uri_image", "svg_icon") {
+    const std::string svg = std::string(
+                                "<svg xmlns=\"http://www.w3.org/2000/svg\" "
+                                "xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"8\" height=\"8\">"
+                                "<image width=\"8\" height=\"8\" xlink:href=\"data:image/png;base64,")
+        + RED_PNG_BASE64 + "\"/></svg>";
+
+    REQUIRE(has_opaque_pixel(render(svg, 8)));
+}
+
+TEST_CASE("svg_renders_through_a_switch_element", "svg_icon") {
+    // lunasvg skips an element it does not know together with its whole subtree,
+    // so without <switch> support the image inside is never drawn.
+    const std::string svg = std::string(
+                                "<svg xmlns=\"http://www.w3.org/2000/svg\" "
+                                "xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"8\" height=\"8\">"
+                                "<switch><foreignObject width=\"8\" height=\"8\"/>"
+                                "<image width=\"8\" height=\"8\" xlink:href=\"data:image/png;base64,")
+        + RED_PNG_BASE64 + "\"/></switch></svg>";
+
+    REQUIRE(has_opaque_pixel(render(svg, 8)));
+}


### PR DESCRIPTION
Three fixes to how app icons are decoded, each with tests. They are independent — happy to split if you would rather take them one at a time.

## 1. An MBM bitmap index the file does not have

`mbm_file::do_read_headers()` indexed the trailer with whatever bitmap id the client asked for, without checking it against the bitmap count. Brothers in Arms 3D asks BIA3D.mbm for index 2 when the file holds two bitmaps, so the read goes one past the end — silent undefined behaviour with an unhardened libc++, and an abort with a hardened one, which takes the process down.

The index is skipped instead; the caller already validates with `is_header_loaded()` and reports the bitmap as missing, which the guest handles.

## 2. A binary colour-key icon mask read as an alpha ramp

Symbian puts an icon's transparency in a second bitmap, and how to read it depends on the kind of mask. A soft mask carries a grey ramp that maps straight to alpha; a colour-key mask marks the backdrop, so transparency is the inverse of what `make_standard_mask` left in the alpha channel. Depth decides: 1–8 bpp soft, 12 and up colour-key.

Except for a handful of S60v2 AIF icons, which store a **binary stencil at 8 bpp in the colour-key polarity**. Read as soft masks they come out inside out — the artwork goes fully transparent and the backdrop stays opaque, so the icon renders as a blank or a solid block. The mask content settles it: an icon's outer frame is transparent by definition, so a mask holding only white plus one other level, with a solid white border and a non-white interior, can only be colour-key. Masks with a real ramp, an already-transparent border, or no transparency at all keep the soft reading.

The iOS app list is the caller; when the port went in it was left applying no mask at all, with a TODO pointing here.

## 3. lunasvg 3.5.0

Several S60v3 games store their icon as a base64 PNG embedded in the MIF's SVG, which the pinned 2.3.8 fork cannot render at all — 7Days and 天地道 come up empty on a 5320. 3.5.0 draws data-URI images natively through its bundled plutovg. It is a rewrite, so the old `<switch>` stub is gone with it, and the Adobe-exported icons wrap their `<image>` in `<switch><foreignObject>`; lunasvg skips an element it does not know along with the whole subtree, so `EKA2L1/lunasvg` re-adds `<switch>` on top of 3.5.0.

Worth noting: **the build already expected this version.** The CMake options for 3.5.0 and its plutovg came in with the iOS frontend, but the submodule stayed behind, so master currently sets options for a lunasvg it does not have.

## Tests

Eight cases, 33 assertions, in `ekatests`:

- `src/tests/epoc/loader/mbm.cpp` — asks single-bitmap `face.mbm` for index 1 and requires the header to come back unloaded.
- `src/tests/epoc/services/fbs/bitmap.cpp` — the two mask families, the S60v2 exception, a full-bleed mask that must not be mistaken for a stencil, and the null-buffer guard.
- `src/tests/epoc/services/svg_icon.cpp` — the two capabilities the icons need from lunasvg: a data-URI `<image>`, and the same image inside `<switch>`.

Each one was checked against the bug it covers, not just against the fix:

| Reverted | Result |
|---|---|
| the mask classifier, back to depth alone | the S60v2 stencil case fails |
| the MBM bounds check | the MBM case fails **on an ordinary build**, no sanitizer needed |
| `<switch>` swapped for an element lunasvg does not know | the switch case fails |

`ekatests` goes from 203 assertions in 64 cases to 236 in 72.

## Verification

CI green on all four jobs. Beyond that, on an iPhone simulator against a Nokia 5320 ROM: 7Days' icon goes from an empty placeholder to its artwork, and Brothers in Arms and Final Battle lose the magenta block behind them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PmtUzvBvCsgn9LXAFeWNsb
