### PR TITLE
Fix four path decoding bugs in the NVG converter

### DIFF
--- a/src/emu/loader/src/nvg.cpp
+++ b/src/emu/loader/src/nvg.cpp
@@ -325,19 +325,29 @@ namespace eka2l1::loader {
             { VG_LCCWARC_TO, 'A' },
             { VG_SCCWARC_TO, 'A' },
             { VG_LCWARC_TO, 'A' },
-            { VG_SCCWARC_TO, 'A' }
+            { VG_SCWARC_TO, 'A' }
         };
 
         T values[6];
 
         for (std::uint8_t segment_type: segment_types) {
-            if (segment_type == VG_CLOSE_PATH) {
-                break;
+            // Bit 0 is the absolute/relative flag (VG_ABSOLUTE=0, VG_RELATIVE=1);
+            // the command itself lives in the remaining bits. Strip the flag
+            // before matching the command so relative segments (odd values) are
+            // dispatched to the same handler as their absolute counterparts.
+            const std::uint8_t base_type = segment_type & ~1;
+
+            if (base_type == VG_CLOSE_PATH) {
+                // Close the current subpath and keep going: a single VGPath can
+                // hold several closed contours (glyph outlines, holes...), and
+                // bailing out here dropped every segment behind the first one.
+                direction += "Z ";
+                continue;
             }
 
-            auto correspond_find_res = CORRESPOND_SVG_CMD_CHAR.find(static_cast<vg_path_segment_type>(segment_type & ~1));
+            auto correspond_find_res = CORRESPOND_SVG_CMD_CHAR.find(static_cast<vg_path_segment_type>(base_type));
             if (correspond_find_res == CORRESPOND_SVG_CMD_CHAR.end()) {
-                errors.emplace_back(NVG_UNKNOWN_PATH_SEGMENT_TYPE, in.tell(), segment_type & ~1);
+                errors.emplace_back(NVG_UNKNOWN_PATH_SEGMENT_TYPE, in.tell(), base_type);
                 continue;
             }
 
@@ -347,7 +357,7 @@ namespace eka2l1::loader {
                 result_char_res = static_cast<char>(std::tolower(result_char_res));
             }
 
-            switch (segment_type) {
+            switch (base_type) {
             case VG_HLINE_TO:
             case VG_VLINE_TO: {
                 T to_pos = 0;
@@ -377,8 +387,8 @@ namespace eka2l1::loader {
             case VG_SCWARC_TO:
             case VG_LCCWARC_TO:
             case VG_LCWARC_TO: {
-                const bool is_counterclock_wise = (segment_type == VG_SCCWARC_TO) || (segment_type == VG_LCCWARC_TO);
-                const bool is_small = (segment_type == VG_SCWARC_TO) || (segment_type == VG_SCCWARC_TO);
+                const bool is_counterclock_wise = (base_type == VG_SCCWARC_TO) || (base_type == VG_LCCWARC_TO);
+                const bool is_small = (base_type == VG_SCWARC_TO) || (base_type == VG_SCCWARC_TO);
 
                 if (in.read(values, ELEM_T_SIZE * 5) != ELEM_T_SIZE * 5) {
                     errors.emplace_back(NVG_READ_COMMAND_DATA_FAILED, in.tell());
@@ -448,12 +458,17 @@ namespace eka2l1::loader {
 
         std::string direction;
 
+        // Path coordinates are OpenVG S15.16/S11.4 fixed-point, i.e. *signed*.
+        // Reading them unsigned turns every negative value (relative segments
+        // moving left/up, or absolute coordinates left of the origin) into a
+        // huge positive one — e.g. -22 in S15.16 comes out as 65514 — which
+        // blows up the path bounds and wrecks the rendered icon.
         if (state.path_datatype_ == NVG_PATH_THIRTYTWO_BIT_DECODING) {
             if ((in.tell() % 4) != 0) {
                 in.seek(4 - (in.tell() % 4), common::seek_where::cur);
             }
 
-            if (!nvg_generate_direction<std::uint32_t>(in, direction, errors, segment_types, 1.0f / 65536.0f)) {
+            if (!nvg_generate_direction<std::int32_t>(in, direction, errors, segment_types, 1.0f / 65536.0f)) {
                 return false;
             }
         } else {
@@ -467,7 +482,7 @@ namespace eka2l1::loader {
                 scale = 1.0f / 16.0f;
             }
             
-            if (!nvg_generate_direction<std::uint16_t>(in, direction, errors, segment_types, scale)) {
+            if (!nvg_generate_direction<std::int16_t>(in, direction, errors, segment_types, scale)) {
                 return false;
             }
         }

--- a/src/tests/epoc/CMakeLists.txt
+++ b/src/tests/epoc/CMakeLists.txt
@@ -4,6 +4,7 @@ set(CORE_TEST_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/e32img.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/mbm.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/mif.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/loader/nvg.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/rsc.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/spi.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/applist/registeration.cpp

--- a/src/tests/epoc/loader/nvg.cpp
+++ b/src/tests/epoc/loader/nvg.cpp
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Path decoding in the NVG-to-SVG converter. Each case is built as a minimal
+// direct-command NVG file holding a single filled path, because the interesting
+// behaviour is entirely in how the path segment list and its coordinates are
+// read. The shapes come from real Symbian^3 firmware icons.
+
+#include <catch2/catch.hpp>
+#include <loader/nvg.h>
+
+#include <common/buffer.h>
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+using namespace eka2l1;
+
+namespace {
+    // Offsets the converter reads the header at.
+    constexpr std::size_t NVG_HEADER_SIZE = 52;
+    constexpr std::size_t OFF_VERSION = 3;
+    constexpr std::size_t OFF_HEADER_SIZE = 4;
+    constexpr std::size_t OFF_PATH_DATATYPE = 26;
+    constexpr std::size_t OFF_VIEWPORT = 36;
+
+    constexpr std::uint16_t PATH_SIXTEEN_BIT = 2;
+    constexpr std::uint16_t PATH_THIRTYTWO_BIT = 3;
+
+    // VGPathSegment values, already shifted: bit 0 is the absolute/relative flag.
+    constexpr std::uint8_t SEG_CLOSE_PATH = 0 << 1;
+    constexpr std::uint8_t SEG_MOVE_TO = 1 << 1;
+    constexpr std::uint8_t SEG_SCWARC_TO = 10 << 1;
+    constexpr std::uint8_t SEG_RELATIVE = 1;
+
+    void put16(std::vector<std::uint8_t> &buf, const std::size_t at, const std::uint16_t value) {
+        buf[at] = static_cast<std::uint8_t>(value & 0xFF);
+        buf[at + 1] = static_cast<std::uint8_t>(value >> 8);
+    }
+
+    void append16(std::vector<std::uint8_t> &buf, const std::int16_t value) {
+        const std::uint16_t raw = static_cast<std::uint16_t>(value);
+
+        buf.push_back(static_cast<std::uint8_t>(raw & 0xFF));
+        buf.push_back(static_cast<std::uint8_t>(raw >> 8));
+    }
+
+    void append32(std::vector<std::uint8_t> &buf, const std::int32_t value) {
+        const std::uint32_t raw = static_cast<std::uint32_t>(value);
+
+        for (int i = 0; i < 4; i++) {
+            buf.push_back(static_cast<std::uint8_t>((raw >> (i * 8)) & 0xFF));
+        }
+    }
+
+    // Builds a direct-command NVG file with one DRAW_PATH command. Version 1, so
+    // neither the command block nor the offset vector needs the version 2 padding.
+    //
+    //   0   signature, version, header size, type
+    //   26  path data type
+    //   36  viewport (x, y, w, h)
+    //   52  offset vector: count, then one offset pointing at the path data
+    //   56  command block: count, then the DRAW_PATH command
+    //   62  path data: segment count, segment types, padding, coordinates
+    std::vector<std::uint8_t> make_nvg(const std::vector<std::uint8_t> &segments,
+        const std::vector<std::int32_t> &coords, const std::uint16_t datatype) {
+        std::vector<std::uint8_t> buf(NVG_HEADER_SIZE, 0);
+
+        std::memcpy(buf.data(), "nvg", 3);
+        buf[OFF_VERSION] = 1;
+        put16(buf, OFF_HEADER_SIZE, static_cast<std::uint16_t>(NVG_HEADER_SIZE));
+        put16(buf, OFF_PATH_DATATYPE, datatype);
+
+        const float viewport[4] = { 0.0f, 0.0f, 96.0f, 96.0f };
+        std::memcpy(buf.data() + OFF_VIEWPORT, viewport, sizeof(viewport));
+
+        // Offset vector: one entry, filled in once the data position is known.
+        buf.resize(NVG_HEADER_SIZE + 4, 0);
+        put16(buf, NVG_HEADER_SIZE, 1);
+
+        // Command block: one DRAW_PATH (opcode 7) with the fill bit set, reading
+        // entry 0 of the offset vector.
+        const std::uint32_t command = (7u << 24) | 0x00020000u;
+        buf.resize(NVG_HEADER_SIZE + 6, 0);
+        put16(buf, NVG_HEADER_SIZE + 4, 1);
+
+        for (int i = 0; i < 4; i++) {
+            buf.push_back(static_cast<std::uint8_t>((command >> (i * 8)) & 0xFF));
+        }
+
+        put16(buf, NVG_HEADER_SIZE + 2, static_cast<std::uint16_t>(buf.size()));
+
+        append16(buf, static_cast<std::int16_t>(segments.size()));
+        buf.insert(buf.end(), segments.begin(), segments.end());
+
+        // The converter aligns to the coordinate size before reading them.
+        const std::size_t align = (datatype == PATH_THIRTYTWO_BIT) ? 4 : 2;
+        while ((buf.size() % align) != 0) {
+            buf.push_back(0);
+        }
+
+        for (const std::int32_t coord : coords) {
+            if (datatype == PATH_THIRTYTWO_BIT) {
+                append32(buf, coord);
+            } else {
+                append16(buf, static_cast<std::int16_t>(coord));
+            }
+        }
+
+        return buf;
+    }
+
+    std::string convert(std::vector<std::uint8_t> nvg) {
+        common::ro_buf_stream in(nvg.data(), nvg.size());
+
+        std::vector<std::uint8_t> out_buf(64 * 1024, 0);
+        common::wo_buf_stream out(out_buf.data(), out_buf.size());
+
+        std::vector<loader::nvg_convert_error_description> errors;
+        REQUIRE(loader::convert_nvg_to_svg(in, out, errors));
+
+        return std::string(reinterpret_cast<const char *>(out_buf.data()), static_cast<std::size_t>(out.tell()));
+    }
+
+    std::size_t count_of(const std::string &haystack, const char needle) {
+        std::size_t total = 0;
+
+        for (const char c : haystack) {
+            if (c == needle) {
+                total++;
+            }
+        }
+
+        return total;
+    }
+}
+
+TEST_CASE("nvg_path_coordinates_decode_as_signed", "nvg_file") {
+    // S11.4 fixed-point, so -352 is -22. Read unsigned it becomes 65184, i.e.
+    // 4074 after scaling -- a coordinate far outside the 96x96 viewBox, which is
+    // what left firmware icons truncated or blank.
+    const std::string svg = convert(make_nvg({ SEG_MOVE_TO }, { -352, 16 }, PATH_SIXTEEN_BIT));
+
+    REQUIRE(svg.find("M -22 1") != std::string::npos);
+    REQUIRE(svg.find("4074") == std::string::npos);
+}
+
+TEST_CASE("nvg_path_coordinates_decode_as_signed_at_32_bit", "nvg_file") {
+    // The same for S15.16, which is a separate instantiation of the decoder.
+    const std::string svg = convert(make_nvg({ SEG_MOVE_TO }, { -22 * 65536, 65536 }, PATH_THIRTYTWO_BIT));
+
+    REQUIRE(svg.find("M -22 1") != std::string::npos);
+    REQUIRE(svg.find("65514") == std::string::npos);
+}
+
+TEST_CASE("nvg_close_path_does_not_end_the_path", "nvg_file") {
+    // A single VGPath routinely holds several closed contours -- glyph outlines,
+    // holes, multi-part shapes. Treating the first VG_CLOSE_PATH as the end of
+    // the segment list dropped everything behind it.
+    const std::vector<std::uint8_t> segments = { SEG_MOVE_TO, SEG_CLOSE_PATH, SEG_MOVE_TO };
+    const std::string svg = convert(make_nvg(segments, { 16, 32, 48, 64 }, PATH_SIXTEEN_BIT));
+
+    REQUIRE(count_of(svg, 'M') == 2);
+    REQUIRE(svg.find("M 1 2") != std::string::npos);
+    REQUIRE(svg.find("M 3 4") != std::string::npos);
+}
+
+TEST_CASE("nvg_small_clockwise_arc_is_a_known_segment", "nvg_file") {
+    // VG_SCWARC_TO was missing from the command table (VG_SCCWARC_TO was listed
+    // twice), so it was reported as an unknown segment and skipped -- without
+    // consuming its five coordinates. Every segment after it then read the
+    // wrong values, which is worse than losing the arc alone: here the move
+    // that follows would pick up the arc's first two coordinates instead.
+    const std::vector<std::uint8_t> segments = { SEG_SCWARC_TO, SEG_MOVE_TO };
+    const std::string svg = convert(make_nvg(segments, { 16, 16, 0, 32, 48, 64, 80 }, PATH_SIXTEEN_BIT));
+
+    // Small arc, so the large-arc flag is 0; clockwise, so the sweep flag is 1.
+    REQUIRE(svg.find("A 1 1, 0, 0 1, 2 3") != std::string::npos);
+    REQUIRE(svg.find("M 4 5") != std::string::npos);
+}
+
+TEST_CASE("nvg_relative_segment_is_dispatched_by_its_base_command", "nvg_file") {
+    // Bit 0 marks a relative segment. Switching on the raw value sent every one
+    // of them to the unreachable default, which abandons the whole path.
+    const std::string svg = convert(make_nvg({ SEG_MOVE_TO | SEG_RELATIVE }, { 16, 32 }, PATH_SIXTEEN_BIT));
+
+    REQUIRE(svg.find("m 1 2") != std::string::npos);
+}


### PR DESCRIPTION
Symbian^3 firmware ships its UI icons as NVG. On an X7 (rm-707) most of them decoded wrong: Gallery showed only its top-left corner, Camera lost half the lens, Clock/Files/FM radio were missing a chunk, Calendar drew "2" where the device shows "12", the Web globe came out blank.

All four bugs are in `nvg_generate_direction`, and none of them fails loudly — the command loop ignores the path handler's return value, so every one of them surfaces as a partly-drawn icon rather than an error.

## The four

**Coordinates are signed.** OpenVG path coordinates are S15.16 and S11.4 fixed-point, but the decoder was instantiated with `uint32_t`/`uint16_t`. Every negative coordinate became a huge positive one. Gallery's path carried `a 11 5, 0, 0 0, 65514 0` — 65514 is -22 read unsigned — and bounds that large on a 96x96 viewBox wreck the whole icon.

**A close-path segment ended the path.** `VG_CLOSE_PATH` broke out of the segment loop instead of closing the subpath and continuing, so everything behind the first closed contour was dropped. A single VGPath routinely holds several: glyph outlines, holes, multi-part shapes. The unconditional `Z` appended at the end left the truncated output still parsing as a valid path, which is why this degraded silently rather than erroring.

**Relative segments went to the unreachable default.** Bit 0 of a segment type is the absolute/relative flag. The lookup for the command character already masked it off, but the `switch` dispatched on the raw value, so every relative segment (an odd value) fell through to `default: assert(false); return false;`. Release builds have the assert compiled out and just abandon the rest of the path; Debug builds abort. The arc flag comparisons had the same problem and now read the masked base type too.

**`VG_SCWARC_TO` was not in the command table.** `VG_SCCWARC_TO` appears twice in its place. A small clockwise arc therefore matched nothing and took the unknown-segment path — which `continue`s *without* consuming the segment's five coordinates. Every later segment in the same path then read the wrong values, which is worse than losing the arc alone.

## Tests

`src/tests/epoc/loader/nvg.cpp` builds a minimal direct-command NVG file per case. That is the whole fixture: the behaviour under test is entirely in how the segment list and its coordinates are read, so no asset file is needed and each case states its own input inline.

Every case was checked against a tree with **only its own fix reverted**, and fails there:

| Fix reverted | Failing cases |
|---|---|
| signed decoding | `nvg_path_coordinates_decode_as_signed`, `..._at_32_bit` (2) |
| close-path continues | `nvg_close_path_does_not_end_the_path` (1) |
| dispatch on base type | `nvg_relative_segment_is_dispatched_by_its_base_command` (1) |
| arc command table | `nvg_small_clockwise_arc_is_a_known_segment` (1) |

`ekatests` goes from 236 assertions / 72 cases to **251 / 77**.

## Scope

Decoder only. Two other Symbian^3 icon problems I have fixes for are deliberately left out because they need the FBS server and are not unit-testable the same way — NVG extended bitmaps blitted guest-side, and skin item overrides accumulating instead of replacing. Those belong in their own PR, along with the NVG colour plane. Happy to send them next if this shape works for you.