### PR TITLE
Fix Symbian^3 skin overrides and NVG bitmap rasterisation

### DIFF
--- a/src/emu/loader/src/nvg.cpp
+++ b/src/emu/loader/src/nvg.cpp
@@ -700,8 +700,15 @@ namespace eka2l1::loader {
 
         // 2 is the size of the vector count
         std::uint64_t commands_offset = vector_offset + 2 * vector_count;
-        if (((commands_offset % 4) != 0) && (version >= 2)) {
-            // Version 2 or above needs offset aligned
+
+        // From version 2 the command section starts on a word boundary. Symbian's
+        // own decoder decides that from the offset vector count alone -- an even
+        // count means the section is padded -- not from the resulting address, and
+        // the files were produced to be read by it. The two rules agree only while
+        // the header size is a multiple of four; for any other header size they
+        // disagree for every count, so follow the one the encoder was written
+        // against rather than the one that looks arithmetically right.
+        if ((version >= 2) && ((vector_count & 1) == 0)) {
             commands_offset += 2;
         }
 

--- a/src/emu/services/include/services/fbs/bitmap.h
+++ b/src/emu/services/include/services/fbs/bitmap.h
@@ -46,6 +46,37 @@ namespace eka2l1::epoc {
 
     static const std::size_t SUPPORTED_REV2_UID_COUNT = sizeof(SUPPORTED_REV2_UIDS) / sizeof(std::uint32_t);
 
+    // Which NVG extended bitmaps we swap for plain rasterised pixels so guest-side
+    // BitGDI can read them (see fbs_server::rasterize_nvg_bitmap).
+    //
+    // On a device the pixels come from the licensee's CFbsRasterizer plugin, which
+    // BitGDI consults for *any* extended bitmap it has to read, rasterising into the
+    // bitmap's own TBitmapDesc::iSizeInPixels and iDispMode. There is no notion there
+    // of some extended bitmaps being readable and others not, so the only conditions
+    // we impose are our own rasteriser's limits.
+    static constexpr std::size_t NVG_RASTERIZE_MAX_BYTES = 4 * 1024 * 1024;
+
+    static inline bool is_nvg_bitmap_rasterizable(const eka2l1::vec2 &size, const display_mode dpm) {
+        if ((size.x <= 0) || (size.y <= 0)) {
+            return false;
+        }
+
+        const int bpp = get_bpp_from_display_mode(dpm);
+
+        // Whole-byte pixels only: rasterize_nvg_bitmap stores one pixel at a time and
+        // has no packing for the sub-byte modes.
+        if ((bpp != 8) && (bpp != 16) && (bpp != 24) && (bpp != 32)) {
+            return false;
+        }
+
+        // Unlike a real rasterizer, which keeps its pixels in a cache of its own, we
+        // expand the bitmap in place and so have to reserve room for the raster form
+        // up front (see fbscli::create_bitmap). Cap that reservation: a skin graphic
+        // is screen sized at most, while the conceptual size Symbian itself allows an
+        // extended bitmap runs up to KMaxTInt / 4 per side.
+        return (get_byte_width(size.x, bpp) * static_cast<std::size_t>(size.y)) <= NVG_RASTERIZE_MAX_BYTES;
+    }
+
     enum bitmap_file_compression {
         bitmap_file_no_compression = 0,
         bitmap_file_byte_rle_compression = 1,

--- a/src/emu/services/include/services/fbs/fbs.h
+++ b/src/emu/services/include/services/fbs/fbs.h
@@ -416,6 +416,18 @@ namespace eka2l1 {
             const bool support_dirty = true);
 
         /**
+         * \brief   Turn an NVG extended bitmap into a plain raster one, in place.
+         *
+         * Replaces the vector data in the shared region with rendered pixels in the
+         * bitmap's own display mode and clears the extended UID, so guest code that
+         * blits the bitmap itself gets pixels instead of the compressed commands.
+         *
+         * \param   bmp The server bitmap object.
+         * \returns True if the bitmap was an NVG one and has been rasterised.
+         */
+        bool rasterize_nvg_bitmap(fbsbitmap *bmp);
+
+        /**
          * \brief   Free a bitmap object.
          * 
          * The function frees bitmap pixels and allocated object from the server's heap.

--- a/src/emu/services/src/fbs/impls/bitmap.cpp
+++ b/src/emu/services/src/fbs/impls/bitmap.cpp
@@ -36,7 +36,13 @@
 #include <kernel/kernel.h>
 #include <system/epoc.h>
 #include <utils/err.h>
+#include <utils/guest/akn.h>
 #include <vfs/vfs.h>
+
+#include <common/buffer.h>
+#include <loader/nvg.h>
+
+#include <lunasvg.h>
 
 #include <algorithm>
 #include <cassert>
@@ -536,6 +542,11 @@ namespace eka2l1 {
 
         bmp = get_clean_bitmap(bmp);
 
+        // A second client is picking the bitmap up, so whoever created it is done
+        // writing. If it holds NVG vector data, turn it into pixels now — the new
+        // owner may well blit it with BitGDI, which cannot decode NVG here.
+        server<fbs_server>()->rasterize_nvg_bitmap(bmp);
+
         const std::uint32_t handle_ret = obj_table_.add(bmp);
         const std::uint32_t server_handle = bmp->id;
         const std::uint32_t off = server<fbs_server>()->host_ptr_to_guest_shared_offset(bmp->bitmap_);
@@ -742,6 +753,159 @@ namespace eka2l1 {
         return epoc::get_byte_width(size.x, epoc::get_bpp_from_display_mode(bpp)) * size.y;
     }
 
+    // Symbian keeps an NVG icon as an *extended* bitmap: the shared data holds an
+    // akn_icon_header plus the compressed vector commands, and BitGDI asks the ROM's
+    // CFbsRasterizer plugin to turn that into pixels whenever a client reads it,
+    // rasterising into the bitmap's conceptual size and display mode. The emulator
+    // has no such plugin, so a guest that draws an extended bitmap on its own — an
+    // app painting a skin frame into its own bitmap through CFbsBitGc, or Avkon
+    // dimming an icon by blitting its mask into a plain EGray256 one — copies the
+    // raw NVG bytes as if they were pixels and ends up with noise.
+    //
+    // Stand in for the rasterizer: render the icon into the shared data and demote
+    // the bitmap to a plain one, so every reader — guest BitGDI and our own window
+    // server bitmap cache alike — sees real pixels. Overwriting the vector data is
+    // safe because extended bitmaps are immutable by contract (CreateExtendedBitmap
+    // documents modification as undefined behaviour), so nothing re-reads it; a
+    // different size means a different extended bitmap. This runs when a *second*
+    // client picks the bitmap up (duplicate), by which point the creator has
+    // finished the Mem::Copy of the vector data that follows creation.
+    bool fbs_server::rasterize_nvg_bitmap(fbsbitmap *bmp) {
+        if (!bmp || !bmp->bitmap_ || (bmp->bitmap_->uid_ != epoc::NVG_BITMAP_UID_REV2)) {
+            return false;
+        }
+
+        epoc::bitwise_bitmap *bws = bmp->bitmap_;
+        std::uint8_t *data = reinterpret_cast<std::uint8_t *>(bws->data_pointer(this));
+        if (!data) {
+            return false;
+        }
+
+        const int width = bws->header_.size_pixels.x;
+        const int height = bws->header_.size_pixels.y;
+        if (!epoc::is_nvg_bitmap_rasterizable(bws->header_.size_pixels, bws->settings_.current_display_mode())) {
+            return false;
+        }
+
+        // The data region was sized for the raster form at creation time (see
+        // create_bitmap), so bail out rather than overrun a too-small allocation.
+        const std::size_t raster_bytes = calculate_aligned_bitmap_bytes(bws->header_.size_pixels,
+            bws->settings_.current_display_mode());
+        const std::uint32_t available = bws->header_.bitmap_size - bws->header_.header_len;
+
+        if ((raster_bytes == 0) || (available < raster_bytes)) {
+            return false;
+        }
+
+        utils::akn_icon_header *icon_header = reinterpret_cast<utils::akn_icon_header *>(data);
+        const std::uint8_t *nvg_data = data + icon_header->header_size_;
+        const std::uint32_t nvg_size = (available > icon_header->header_size_)
+            ? (available - icon_header->header_size_) : 0;
+        const bool is_mask = icon_header->is_mask_;
+
+        std::vector<std::uint8_t> rgba(static_cast<std::size_t>(width) * height * 4, 0);
+
+        if (!is_mask && (icon_header->icon_color_ & 0xFFFFFF)) {
+            // A colour icon with a forced tint: the vector data only describes the
+            // shape, the paired mask carries it. Mirror the window server and fill
+            // the colour plane flat.
+            const std::uint32_t colour = static_cast<std::uint32_t>(icon_header->icon_color_);
+            for (std::size_t i = 0; i < rgba.size(); i += 4) {
+                rgba[i + 0] = static_cast<std::uint8_t>((colour >> 16) & 0xFF);
+                rgba[i + 1] = static_cast<std::uint8_t>((colour >> 8) & 0xFF);
+                rgba[i + 2] = static_cast<std::uint8_t>(colour & 0xFF);
+                rgba[i + 3] = 0xFF;
+            }
+        } else {
+            if (nvg_size == 0) {
+                return false;
+            }
+
+            common::ro_buf_stream nvg_in(const_cast<std::uint8_t *>(nvg_data), nvg_size);
+            common::wo_growable_buf_stream svg_out;
+            std::vector<loader::nvg_convert_error_description> errors;
+
+            loader::nvg_options opts;
+            opts.width = width;
+            opts.height = height;
+            opts.aspect_ratio_mode_ = static_cast<loader::nvg_aspect_ratio_mode>(icon_header->aspect_ratio_);
+
+            if (!loader::convert_nvg_to_svg(nvg_in, svg_out, errors, &opts)) {
+                return false;
+            }
+
+            auto doc = lunasvg::Document::loadFromData(svg_out.content());
+            if (!doc) {
+                return false;
+            }
+
+            lunasvg::Bitmap luna(rgba.data(), width, height, width * 4);
+            doc->render(luna, lunasvg::Matrix{ 1, 0, 0, 1, 0, 0 });
+            luna.convertToRGBA();
+        }
+
+        // Write the pixels back in the bitmap's own display mode. A mask keeps only
+        // coverage, a colour plane keeps the rendered colour.
+        const epoc::display_mode dpm = bws->settings_.current_display_mode();
+        const int bpp = epoc::get_bpp_from_display_mode(dpm);
+        const int byte_width = bws->byte_width_;
+
+        // Scanlines are word aligned, so an odd width leaves padding pixels the loop
+        // below never touches. Clear the whole raster region first: leftover vector
+        // bytes there show up as a stray column of noise once BitGDI blits the bitmap.
+        std::memset(data, 0, raster_bytes);
+
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                const std::uint8_t *src = rgba.data() + (static_cast<std::size_t>(y) * width + x) * 4;
+                std::uint8_t *dst = data + static_cast<std::size_t>(y) * byte_width;
+
+                switch (bpp) {
+                case 8:
+                    dst[x] = epoc::is_display_mode_mono(dpm) ? src[3] : src[0];
+                    break;
+
+                case 16: {
+                    const std::uint16_t px = static_cast<std::uint16_t>(((src[0] >> 3) << 11)
+                        | ((src[1] >> 2) << 5) | (src[2] >> 3));
+                    *reinterpret_cast<std::uint16_t *>(dst + x * 2) = px;
+                    break;
+                }
+
+                case 24:
+                    dst[x * 3 + 0] = src[2];
+                    dst[x * 3 + 1] = src[1];
+                    dst[x * 3 + 2] = src[0];
+                    break;
+
+                case 32:
+                    dst[x * 4 + 0] = src[2];
+                    dst[x * 4 + 1] = src[1];
+                    dst[x * 4 + 2] = src[0];
+                    dst[x * 4 + 3] = epoc::is_display_mode_alpha(dpm) ? src[3] : 0xFF;
+                    break;
+
+                default:
+                    return false;
+                }
+            }
+        }
+
+        // Shrink the advertised data size back to the raster form. The region was
+        // over-allocated to fit whichever of the two was bigger, and every reader
+        // derives its buffer size from the header.
+        bws->header_.bitmap_size = static_cast<std::uint32_t>(raster_bytes) + bws->header_.header_len;
+        bws->header_.compression = epoc::bitmap_file_no_compression;
+        bws->compressed_in_ram_ = false;
+
+        // The shared structure identifies a plain bitmap by BITWISE_BITMAP_UID, not by
+        // the NORMAL_BITMAP_UID_REV2 the creation IPC speaks in; readers key their
+        // pixel format off this field.
+        bws->uid_ = epoc::BITWISE_BITMAP_UID;
+
+        return true;
+    }
+
     static std::uint32_t calculate_reserved_each_side(const std::uint32_t height) {
         // Reserve some space in left and right. Observed shows some apps outwrite their
         // available data region, a little bit, hopefully.
@@ -928,6 +1092,16 @@ namespace eka2l1 {
 
         fbs_server *fbss = server<fbs_server>();
 
+        // An NVG extended bitmap is only as big as its compressed vector data, which is
+        // usually smaller than the raster form. Reserve room for the pixels up front so
+        // rasterize_nvg_bitmap() can expand it in place later on.
+        const std::uint32_t vector_size = force_size;
+
+        if ((assign_uid == epoc::NVG_BITMAP_UID_REV2) && epoc::is_nvg_bitmap_rasterizable(specs.size, specs.bpp)) {
+            force_size = common::max(force_size,
+                static_cast<std::uint32_t>(calculate_aligned_bitmap_bytes(specs.size, specs.bpp)));
+        }
+
         fbs_bitmap_data_info info;
         info.size_ = specs.size;
         info.dpm_ = specs.bpp;
@@ -938,6 +1112,14 @@ namespace eka2l1 {
         if (!bmp) {
             ctx->complete(epoc::error_no_memory);
             return;
+        }
+
+        if ((force_size > vector_size) && bmp->bitmap_) {
+            // The client only fills the vector part; keep the padding deterministic so a
+            // reader that trusts the (now larger) data size never sees stale heap.
+            if (std::uint8_t *data = reinterpret_cast<std::uint8_t *>(bmp->bitmap_->data_pointer(fbss))) {
+                std::memset(data + vector_size, 0, force_size - vector_size);
+            }
         }
 
         if (use_bmp_handles_writeback) {

--- a/src/emu/services/src/ui/skin/skn.cpp
+++ b/src/emu/services/src/ui/skin/skn.cpp
@@ -248,7 +248,8 @@ namespace eka2l1::epoc {
 
         process_attrib(base_offset + skn_desc_dfo_bitmap_attribs, bmp_info_.attrib);
 
-        bitmaps_.emplace(bmp_info_.id_hash, std::move(bmp_info_));
+        // Later definitions override earlier ones; emplace would keep the first.
+        bitmaps_[bmp_info_.id_hash] = std::move(bmp_info_);
     }
 
     void skn_file::process_image_table_def_chunk(std::uint32_t base_offset) {
@@ -268,8 +269,13 @@ namespace eka2l1::epoc {
 
         process_attrib(offset_of_attrib, tab_.attrib);
 
-        // Move first
-        skn_image_table &tab_ref_ = img_tabs_.emplace(tab_.id_hash, std::move(tab_)).first->second;
+        // Move first. A skin may define the same item more than once (the later
+        // definition overrides the earlier one), so *assign* instead of emplace:
+        // emplace keeps the existing entry, and the append below would then stack
+        // the new entries on top of the old ones. A frame table that ends up with
+        // 18 instead of 9 images fails Avkon's EAknsFrameElementsN check and the
+        // whole frame silently goes undrawn.
+        skn_image_table &tab_ref_ = (img_tabs_[tab_.id_hash] = std::move(tab_));
 
         // Read entry
         for (std::uint16_t i = 0; i < count; i++) {
@@ -298,8 +304,9 @@ namespace eka2l1::epoc {
 
         process_attrib(offset_of_attrib, tab_.attrib);
 
-        // Move first
-        skn_color_table &tab_ref_ = color_tabs_.emplace(tab_.id_hash, std::move(tab_)).first->second;
+        // Move first. Same override rule as the image table above: assign so a
+        // re-definition replaces the old colours instead of appending to them.
+        skn_color_table &tab_ref_ = (color_tabs_[tab_.id_hash] = std::move(tab_));
 
         // Read entry
         for (std::uint16_t i = 0; i < count; i++) {
@@ -360,7 +367,7 @@ namespace eka2l1::epoc {
             anim_.frames.push_back(frame);
         }
 
-        bitmap_anims_.emplace(anim_.id_hash, std::move(anim_));
+        bitmap_anims_[anim_.id_hash] = std::move(anim_);
     }
 
     std::string skn_file::process_string(std::uint32_t base_offset, const std::uint16_t size) {

--- a/src/tests/epoc/CMakeLists.txt
+++ b/src/tests/epoc/CMakeLists.txt
@@ -12,5 +12,6 @@ set(CORE_TEST_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/services/svg_icon.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/centralrepo/crebinloader.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/centralrepo/creiniloader.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/services/ui/skin/skn.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/utils/sec.cpp
     PARENT_SCOPE)

--- a/src/tests/epoc/loader/nvg.cpp
+++ b/src/tests/epoc/loader/nvg.cpp
@@ -71,42 +71,49 @@ namespace {
         }
     }
 
-    // Builds a direct-command NVG file with one DRAW_PATH command. Version 1, so
-    // neither the command block nor the offset vector needs the version 2 padding.
+    // Builds a direct-command NVG file with one DRAW_PATH command.
     //
-    //   0   signature, version, header size, type
-    //   26  path data type
-    //   36  viewport (x, y, w, h)
-    //   52  offset vector: count, then one offset pointing at the path data
-    //   56  command block: count, then the DRAW_PATH command
-    //   62  path data: segment count, segment types, padding, coordinates
+    //   0            signature, version, header size, type
+    //   26           path data type
+    //   36           viewport (x, y, w, h)
+    //   header_size  offset vector: count, then one offset pointing at the path data
+    //   ...          command block: count, then the DRAW_PATH command
+    //   ...          path data: segment count, segment types, padding, coordinates
+    //
+    // From version 2 the command block starts on a word boundary and carries two
+    // bytes of padding after its count, so both are placed the way Symbian's
+    // decoder expects to find them.
     std::vector<std::uint8_t> make_nvg(const std::vector<std::uint8_t> &segments,
-        const std::vector<std::int32_t> &coords, const std::uint16_t datatype) {
-        std::vector<std::uint8_t> buf(NVG_HEADER_SIZE, 0);
+        const std::vector<std::int32_t> &coords, const std::uint16_t datatype,
+        const std::uint8_t version = 1, const std::uint16_t header_size = NVG_HEADER_SIZE) {
+        std::vector<std::uint8_t> buf(header_size, 0);
 
         std::memcpy(buf.data(), "nvg", 3);
-        buf[OFF_VERSION] = 1;
-        put16(buf, OFF_HEADER_SIZE, static_cast<std::uint16_t>(NVG_HEADER_SIZE));
+        buf[OFF_VERSION] = version;
+        put16(buf, OFF_HEADER_SIZE, header_size);
         put16(buf, OFF_PATH_DATATYPE, datatype);
 
         const float viewport[4] = { 0.0f, 0.0f, 96.0f, 96.0f };
         std::memcpy(buf.data() + OFF_VIEWPORT, viewport, sizeof(viewport));
 
         // Offset vector: one entry, filled in once the data position is known.
-        buf.resize(NVG_HEADER_SIZE + 4, 0);
-        put16(buf, NVG_HEADER_SIZE, 1);
+        buf.resize(header_size + 4, 0);
+        put16(buf, header_size, 1);
+
+        // An odd offset vector count, so version 2 does not pad the command block.
+        std::size_t commands_offset = header_size + 4;
 
         // Command block: one DRAW_PATH (opcode 7) with the fill bit set, reading
         // entry 0 of the offset vector.
         const std::uint32_t command = (7u << 24) | 0x00020000u;
-        buf.resize(NVG_HEADER_SIZE + 6, 0);
-        put16(buf, NVG_HEADER_SIZE + 4, 1);
+        buf.resize(commands_offset + ((version >= 2) ? 4 : 2), 0);
+        put16(buf, commands_offset, 1);
 
         for (int i = 0; i < 4; i++) {
             buf.push_back(static_cast<std::uint8_t>((command >> (i * 8)) & 0xFF));
         }
 
-        put16(buf, NVG_HEADER_SIZE + 2, static_cast<std::uint16_t>(buf.size()));
+        put16(buf, header_size + 2, static_cast<std::uint16_t>(buf.size()));
 
         append16(buf, static_cast<std::int16_t>(segments.size()));
         buf.insert(buf.end(), segments.begin(), segments.end());
@@ -181,6 +188,17 @@ TEST_CASE("nvg_close_path_does_not_end_the_path", "nvg_file") {
     REQUIRE(count_of(svg, 'M') == 2);
     REQUIRE(svg.find("M 1 2") != std::string::npos);
     REQUIRE(svg.find("M 3 4") != std::string::npos);
+}
+
+TEST_CASE("nvg_version_2_command_block_is_found_at_an_odd_header_size", "nvg_file") {
+    // Symbian pads the version 2 command block based on the offset vector count
+    // alone -- an even count means padded -- not on where the block lands. The
+    // two rules only agree while the header size is a multiple of four. With an
+    // odd count and a header size of 54, deriving the padding from the address
+    // instead skips two bytes too far and the command block is misread.
+    const std::string svg = convert(make_nvg({ SEG_MOVE_TO }, { 16, 32 }, PATH_SIXTEEN_BIT, 2, 54));
+
+    REQUIRE(svg.find("M 1 2") != std::string::npos);
 }
 
 TEST_CASE("nvg_small_clockwise_arc_is_a_known_segment", "nvg_file") {

--- a/src/tests/epoc/services/ui/skin/skn.cpp
+++ b/src/tests/epoc/services/ui/skin/skn.cpp
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// A skin may define the same item twice, and the later definition is meant to
+// replace the earlier one. These build a skin descriptor holding one class
+// chunk with two definitions of the same item, which is the shape a Symbian^3
+// skin has for QsnFrPopup.
+
+#include <services/ui/skin/skn.h>
+
+#include <catch2/catch.hpp>
+
+#include <common/buffer.h>
+
+#include <cstdint>
+#include <vector>
+
+using namespace eka2l1;
+
+namespace {
+    // Chunk header fields shared by every descriptor chunk.
+    constexpr std::size_t OFF_LEN = 0;
+    constexpr std::size_t OFF_TYPE = 4;
+
+    constexpr std::size_t MASTER_CHUNK_COUNT = 38;
+    constexpr std::size_t MASTER_CONTENT = 42;
+
+    constexpr std::size_t CLASS_CHUNK_N = 9;
+    constexpr std::size_t CLASS_CONTENT = 13;
+
+    constexpr std::size_t ITEM_HASH = 8;
+    constexpr std::size_t TABLE_COUNT = 16;
+    constexpr std::size_t TABLE_ENTRY0 = 17;
+    constexpr std::size_t TABLE_ENTRY_SIZE = 8;
+
+    // process_attrib reads up to offset 18 of the attribute block.
+    constexpr std::size_t ATTRIB_SIZE = 20;
+
+    void put(std::vector<std::uint8_t> &buf, const std::size_t at, const std::uint64_t value, const std::size_t width) {
+        if (buf.size() < at + width) {
+            buf.resize(at + width, 0);
+        }
+
+        for (std::size_t i = 0; i < width; i++) {
+            buf[at + i] = static_cast<std::uint8_t>((value >> (i * 8)) & 0xFF);
+        }
+    }
+
+    // One image table definition: a header, the item's hash, its entries, and
+    // the attribute block the parser expects to find after them.
+    std::vector<std::uint8_t> make_image_table(const std::uint64_t id_hash, const std::vector<std::uint64_t> &images) {
+        std::vector<std::uint8_t> chunk;
+
+        put(chunk, OFF_TYPE, 6 /* as_desc_skin_desc_img_tbl_item_def */, 2);
+        put(chunk, ITEM_HASH, id_hash, 8);
+        put(chunk, TABLE_COUNT, images.size(), 2);
+
+        for (std::size_t i = 0; i < images.size(); i++) {
+            put(chunk, TABLE_ENTRY0 + i * TABLE_ENTRY_SIZE, images[i], TABLE_ENTRY_SIZE);
+        }
+
+        chunk.resize(TABLE_ENTRY0 + images.size() * TABLE_ENTRY_SIZE + ATTRIB_SIZE, 0);
+        put(chunk, OFF_LEN, chunk.size(), 4);
+
+        return chunk;
+    }
+
+    // A skin descriptor whose single class chunk holds the given definitions.
+    std::vector<std::uint8_t> make_skin(const std::vector<std::vector<std::uint8_t>> &defs) {
+        std::vector<std::uint8_t> class_chunk;
+
+        put(class_chunk, OFF_TYPE, 3 /* as_desc_skin_desc_class */, 2);
+        put(class_chunk, CLASS_CHUNK_N, defs.size(), 4);
+        class_chunk.resize(CLASS_CONTENT, 0);
+
+        for (const std::vector<std::uint8_t> &def : defs) {
+            class_chunk.insert(class_chunk.end(), def.begin(), def.end());
+        }
+
+        put(class_chunk, OFF_LEN, class_chunk.size(), 4);
+
+        std::vector<std::uint8_t> skin;
+
+        put(skin, OFF_TYPE, 0 /* as_desc_skin_desc */, 2);
+        put(skin, MASTER_CHUNK_COUNT, 1, 4);
+        skin.resize(MASTER_CONTENT, 0);
+
+        skin.insert(skin.end(), class_chunk.begin(), class_chunk.end());
+        put(skin, OFF_LEN, skin.size(), 4);
+
+        return skin;
+    }
+
+    std::vector<std::uint64_t> nine(const std::uint64_t base) {
+        std::vector<std::uint64_t> images;
+
+        for (std::uint64_t i = 0; i < 9; i++) {
+            images.push_back(base + i);
+        }
+
+        return images;
+    }
+}
+
+TEST_CASE("skn_image_table_redefinition_replaces_the_entries", "skn_file") {
+    // Avkon's frame drawing wants exactly nine elements and silently drops the
+    // whole frame otherwise, so a redefinition that appends instead of replacing
+    // leaves eighteen and the frame never appears.
+    std::vector<std::uint8_t> data = make_skin({
+        make_image_table(0x1234, nine(0x100)),
+        make_image_table(0x1234, nine(0x200)),
+    });
+
+    common::ro_buf_stream stream(data.data(), data.size());
+    epoc::skn_file skn(reinterpret_cast<common::ro_stream *>(&stream));
+
+    REQUIRE(skn.img_tabs_.size() == 1);
+
+    const epoc::skn_image_table &table = skn.img_tabs_.begin()->second;
+
+    REQUIRE(table.images.size() == 9);
+    REQUIRE(table.images.front() == 0x200);
+}
+
+TEST_CASE("skn_image_table_keeps_distinct_items_apart", "skn_file") {
+    // Two different items must both survive -- the override rule is per hash.
+    std::vector<std::uint8_t> data = make_skin({
+        make_image_table(0x1234, nine(0x100)),
+        make_image_table(0x5678, nine(0x200)),
+    });
+
+    common::ro_buf_stream stream(data.data(), data.size());
+    epoc::skn_file skn(reinterpret_cast<common::ro_stream *>(&stream));
+
+    REQUIRE(skn.img_tabs_.size() == 2);
+    REQUIRE(skn.img_tabs_[0x1234].images.size() == 9);
+    REQUIRE(skn.img_tabs_[0x5678].images.size() == 9);
+    REQUIRE(skn.img_tabs_[0x1234].images.front() == 0x100);
+    REQUIRE(skn.img_tabs_[0x5678].images.front() == 0x200);
+}


### PR DESCRIPTION
Three independent defects, all showing as missing or garbled Symbian^3 (X7/rm-707) UI. They are separate commits and can be reviewed one at a time.

## 1. A skin item defined twice appended instead of replacing

The four item parsers used `map::emplace`, which keeps the existing entry and returns it — so the parse then stacked the new entries on top of the old ones.

A divide-by-zero note came up with no frame and no text, only its icon. `QsnFrPopup` parsed as eighteen images (the nine elements listed twice), and Avkon's frame drawing wants exactly nine — it drops the whole frame silently, with no fallback, for any other count. The chunk bytes were fine; the skin simply redefines the item. The colour table had the same bug, which is why the note's text resolved to black, and bitmaps and animations were ignoring the override entirely. S60v3 skins don't redefine the popup frame, so only Symbian^3 showed it.

**Tested.** `skn_file` takes only a `ro_stream`, so the tests build a skin descriptor with one class chunk holding two definitions of the same item. With `emplace` restored, the first case sees eighteen images instead of nine.

## 2. Version 2 NVG command block padded by the wrong rule

Symbian decides whether the version 2 command block carries its word-alignment padding from the offset vector count alone — an even count means padded — not from where the block would land:

```cpp
if (NVGVersion >= KVersion2 && ((lOffsetVectorCount & 0x01) == 0))
    commandSection.SkipL(2);
```
<sub>`svgtopt/nvgdecoder/src/nvg.cpp`, `CNvgEngine::DrawCommandSectionL`</sub>

Deriving it from the resulting address agrees only while the header size is a multiple of four. For any other header size the two rules disagree for **every** count and the command block is read two bytes off. These files are produced to be read by Symbian's decoder, so this follows its rule rather than the one that looks arithmetically right.

**Tested**, with a version 2 file at header size 54.

## 3. An NVG extended bitmap the guest blits itself was never rasterised

Symbian keeps an NVG icon as an extended bitmap — an `akn_icon_header` plus compressed vector commands in the shared region — and BitGDI hands it to the ROM's `CFbsRasterizer` plugin when a client blits it. The emulator has no such plugin, so the client copies the vector bytes as pixels.

Calculator's disabled keys (C, √, %, ±) drew as grey static and became correct glyphs the moment the key was enabled: Avkon dims a disabled icon by blitting it into its own EGray256 bitmap. The window server never noticed because it decodes NVG itself before uploading a texture — only the guest-side blit was broken.

`rasterize_nvg_bitmap()` renders the vector data into the shared region in the bitmap's own display mode and demotes it to a plain bitmap, from `duplicate_bitmap` — the point a second client picks it up, so the creator has finished writing. Restricted to mono masks up to 128×128; the large colour artwork the window server draws directly already renders fine as vectors. The colour plane of a skin graphic is rasterised too and the scanline padding written, so a skin frame no longer comes out with its colour missing and stale bytes in the row padding.

**Not unit tested, deliberately** — this path needs a live FBS server, a mounted ROM and a guest performing the blit. Verified on an X7: the disabled keys dim correctly and re-enable, the divide-by-zero note shows its frame and message, 5320/rm-409 unchanged.

## On the tests

Where a fixture is synthetic it is built against Symbian's published format definitions, not against this implementation — the NVG header offsets, the three fixed-point scales, `VG_PATH_DATATYPE_S_16/S_32`, and the segment encoding all come from `oss.FCL.sf.mw.svgt` and the OpenVG headers. Real NVG only exists inside copyrighted firmware and no encoder was ever released, so a real fixture cannot be committed; anchoring to the contract proves more than one real icon would anyway.

`ekatests` goes from 251 assertions / 77 cases to **261 / 80**.