### PR TITLE
ci: Build the iOS app

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -257,13 +257,56 @@ jobs:
         path: build/eka2l1-qt-x64.AppImage
       if: matrix.label == 'linux'
 
+  # Both slices are built unsigned. Signing a device build on CI mints a
+  # development certificate per run and Apple caps how many an account may hold,
+  # so a signing CI is a CI that eventually stops working; nothing here needs a
+  # signature to prove the code compiles and links.
+  build-ios:
+    runs-on: macos-latest
+    env:
+      EKA2L1_IOS_CONFIGURATION: Release
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: simulator
+          - label: device
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        submodules: recursive
+
+    # ffmpeg ships no iOS slice, and building one takes longer than the app
+    # itself. The slices differ per platform, so they are cached per label.
+    - name: Cache iOS ffmpeg
+      id: cache-ffmpeg
+      uses: actions/cache@v4
+      with:
+        path: src/external/ffmpeg/ios/${{ matrix.label }}
+        key: ffmpeg-ios-${{ matrix.label }}-${{ hashFiles('.git/modules/src/external/ffmpeg/HEAD') }}
+
+    - name: Build
+      run: ./scripts/build_ios.sh ${{ matrix.label }}
+
+    - name: Compute git short sha
+      id: git_short_sha
+      run: echo "value=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: eka2l1-${{ steps.git_short_sha.outputs.value }}-ios-${{ matrix.label }}
+        path: build/ios-${{ matrix.label }}/src/emu/ios/Release-iphone*/EKA2L1.app
+
   # One check with a stable name for branch protection to require. The matrix
   # job names carry their runner labels, so they change whenever an image is
   # swapped -- a required check pinned to those silently stops applying. This
   # one does not move.
   ci:
     name: CI
-    needs: [build-android, build-desktop]
+    needs: [build-android, build-desktop, build-ios]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -271,8 +314,10 @@ jobs:
       run: |
         echo "android:  ${{ needs.build-android.result }}"
         echo "desktop:  ${{ needs.build-desktop.result }}"
+        echo "ios:      ${{ needs.build-ios.result }}"
         if [ "${{ needs.build-android.result }}" != "success" ] || \
-           [ "${{ needs.build-desktop.result }}" != "success" ]; then
+           [ "${{ needs.build-desktop.result }}" != "success" ] || \
+           [ "${{ needs.build-ios.result }}" != "success" ]; then
           echo "::error::A build or test job did not pass"
           exit 1
         fi


### PR DESCRIPTION
The iOS front end landed in #587, but nothing builds it. It is currently the one target that a change to shared code can break without CI noticing — which is the opposite of what you want from the newest and least-exercised front end.

## What it does

Adds a `build-ios` job on `macos-latest` with two matrix entries, and makes the stable `CI` check require it.

**Both slices are built.** A simulator arm64 binary and a device arm64 binary are not the same target — different SDK, different ABI details — so building only one leaves a real gap.

**Neither is signed.** This is deliberate and worth stating plainly: signing a device build on CI mints a development certificate on every run, and Apple caps how many certificates an account may hold. A signing CI is one that eventually stops working, and then needs someone to go revoke certificates by hand. Nothing here needs a signature to prove the code compiles and links. `scripts/build_ios.sh device` is already an unsigned build, so no new machinery was needed.

**ffmpeg is cached per slice.** It ships no iOS build, and producing one takes longer than the app itself. The cache key follows the same pattern the existing macOS arm64 ffmpeg step uses.

**`roll-release` deliberately does not depend on this job.** It consumes no iOS artifact, and wiring it up would let an unrelated iOS failure hold up a release.

## Verified

Ran the full workflow on my fork — everything green, including both new jobs:

| job | time |
|---|---|
| `build-ios (simulator)` | 23m |
| `build-ios (device)` | 26m |
| `build-desktop (windows)` | 41m |
| `build-android` | 16m |
| `build-desktop (macos)` | 14m |
| `build-desktop (linux)` | 12m |

Those iOS times are with a **cold** ffmpeg cache; both cache entries saved correctly and their key hash matches the one the existing `ffmpeg-arm64` cache computes, so subsequent runs skip that part. Windows at 41m remains the critical path either way, so this does not make the wall-clock wait any longer.

I also built both slices locally first; the device build produces an unsigned arm64 Mach-O.

## One thing for you to decide

This takes the macOS runner jobs per run from one to three, and macOS minutes bill at 10x Linux. That is free for a public repository, but if you would rather not spend the capacity, dropping the `device` entry and keeping only `simulator` is a reasonable trade — say the word and I will trim it.