### PR TITLE
Decode SVGB text coordinate lists and character data

### DIFF
--- a/src/emu/loader/src/svgb.cpp
+++ b/src/emu/loader/src/svgb.cpp
@@ -56,6 +56,10 @@ namespace eka2l1::loader {
         int is_new_ = 0;
         int wrap_level_ = 0;
 
+        /// Set while the element being closed holds character data, so the closing tag
+        /// is not indented into the text content.
+        bool inline_content_ = false;
+
         std::vector<svgb_convert_error_description> &error_list_;
 
         explicit svgb_decode_state(std::vector<svgb_convert_error_description> &descs)
@@ -109,6 +113,7 @@ namespace eka2l1::loader {
     SVG_ATTR_DECODE_PROTOTYPE(svgb_decode_dash_array);
     SVG_ATTR_DECODE_PROTOTYPE(svgb_decode_un);
     SVG_ATTR_DECODE_PROTOTYPE(svgb_decode_aspect_ratio);
+    SVG_ATTR_DECODE_PROTOTYPE(svgb_decode_coord);
 
     static const svg_attr SVGB_ATTRS[] = {
 
@@ -166,8 +171,8 @@ namespace eka2l1::loader {
         { "letterSpacing", svgb_decode_fail }, /* 45   2D */
         { "cx", svgb_decode_float }, /* 46   2E */
         { "cy", svgb_decode_float }, /* 47   2F */
-        { "y", svgb_decode_float }, /* 48   30 */
-        { "x", svgb_decode_float }, /* 49   31 */
+        { "y", svgb_decode_coord }, /* 48   30 */
+        { "x", svgb_decode_coord }, /* 49   31 */
 
         { "y1", svgb_decode_float }, /* 50   32 */
         { "y2", svgb_decode_float }, /* 51   33 */
@@ -265,6 +270,7 @@ namespace eka2l1::loader {
     };
 
 #define SVG_ELEMENT_SVG 0
+#define SVG_ELEMENT_TEXT 25
 #define SVG_ELEMENT_MEDIA_ANIMATION 47
 
     static const svg_element_attr SVG_ATTR_SVG[] = {
@@ -335,16 +341,48 @@ namespace eka2l1::loader {
         std::string indent(state.wrap_level_, ' ');
         indent += "<" + tag;
 
+        state.inline_content_ = false;
         return out.write_text(indent);
     }
 
     bool xml_close_tag(svgb_decode_state &state, common::wo_stream &out, std::string tag, bool eol) {
         state.wrap_indent(-1);
 
-        std::string indent(state.wrap_level_, ' ');
+        std::string indent(state.inline_content_ ? 0 : state.wrap_level_, ' ');
         indent += "</" + tag + (eol ? ">\xD\xA" : ">") + "\n";
 
+        state.inline_content_ = false;
         return out.write_text(indent);
+    }
+
+    /**
+     * Escapes the characters that may not appear literally in element content.
+     */
+    static std::string xml_escape_text(const std::string &text) {
+        std::string escaped;
+        escaped.reserve(text.size());
+
+        for (const char c : text) {
+            switch (c) {
+            case '&':
+                escaped += "&amp;";
+                break;
+
+            case '<':
+                escaped += "&lt;";
+                break;
+
+            case '>':
+                escaped += "&gt;";
+                break;
+
+            default:
+                escaped += c;
+                break;
+            }
+        }
+
+        return escaped;
     }
 
     /**
@@ -426,7 +464,9 @@ namespace eka2l1::loader {
     }
 
     std::optional<std::string> read_svgb_string_from_stream(common::ro_stream &in) {
-        char len;
+        // Unsigned: the length byte spans the full 0..255 range, and `char` is signed
+        // on the platforms this runs on.
+        std::uint8_t len;
         if (in.read(&len, 1) != 1) {
             return std::nullopt;
         }
@@ -474,6 +514,52 @@ namespace eka2l1::loader {
 
         state.add_error(in, svgb_convert_error_eof);
         return false;
+    }
+
+    /**
+     * Decodes the x/y attributes.
+     *
+     * On <text> these are coordinate *lists* (SVG lets one text element position each
+     * of its glyphs), so the binariser writes a one-byte count in front of the floats.
+     * Everywhere else x/y is a single number with no count. Reading the list form as a
+     * plain float desynchronises the attribute stream and the rest of the icon is lost.
+     */
+    static bool svgb_decode_coord(svgb_decode_state &state, const svg_attr *attr, const svg_element *elem, common::ro_stream &in, common::wo_stream &out) {
+        if (!elem || (elem->code_ != SVG_ELEMENT_TEXT)) {
+            return svgb_read_write_float_attr(state, attr, elem, in, out);
+        }
+
+        std::uint8_t count = 0;
+        if (in.read(&count, 1) != 1) {
+            state.add_error(in, svgb_convert_error_eof);
+            return false;
+        }
+
+        std::string buf;
+
+        for (std::uint8_t i = 0; i < count; i++) {
+            float value;
+            if (!read_f32_from_stream(state, in, &value)) {
+                state.add_error(in, svgb_convert_error_eof);
+                return false;
+            }
+
+            if (i > 0)
+                buf += ' ';
+
+            svgb_fomat_float(&buf, value, true);
+        }
+
+        if (count == 0) {
+            return true;
+        }
+
+        if (!xml_write_attr_no_esc(out, attr->name_, buf)) {
+            state.add_error(in, svgb_convert_error_write_fail);
+            return false;
+        }
+
+        return true;
     }
 
     /**
@@ -1123,18 +1209,24 @@ namespace eka2l1::loader {
                         decode_state.add_error(in, svgb_convert_error_write_fail);
                         return false;
                     }
-                } else if (c == SVG_CDATA) { /*
-                    char * str = read_svgb_string_from_stream(in);
-                    if (str) {
-                        Bool wrap = WRAP_IsEnabled(out);
-                        if (wrap) WRAP_Enable(out, False);
-                        FILE_Puts(out, str);
-                        if (wrap) WRAP_Enable(out, True);
-                        MEM_Free(str);
-                    } else {
-                        return False;
-                        */
-                    decode_state.add_error(in, svgb_convert_error_cdata_ignored);
+                } else if (c == SVG_CDATA) {
+                    // Character data of the enclosing element (a <text> body, in
+                    // practice). It has to be consumed even when it is of no interest:
+                    // leaving the bytes in the stream desynchronises everything after
+                    // it, and the rest of the icon is dropped.
+                    std::optional<std::string> raw = read_svgb_string_from_stream(in);
+                    if (!raw.has_value()) {
+                        decode_state.add_error(in, svgb_convert_error_eof);
+                        return false;
+                    }
+
+                    const std::u16string data(reinterpret_cast<char16_t *>(raw->data()), raw->size() / 2);
+                    if (!out.write_text(xml_escape_text(common::ucs2_to_utf8(data)))) {
+                        decode_state.add_error(in, svgb_convert_error_write_fail);
+                        return false;
+                    }
+
+                    decode_state.inline_content_ = true;
                 } else if (c < COUNT(SVGB_ELEMS)) {
                     const svg_element *elem = SVGB_ELEMS + c;
                     const svg_decode_elem_status s = svgb_decode_element(decode_state, elem, in, out);

--- a/src/tests/epoc/CMakeLists.txt
+++ b/src/tests/epoc/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CORE_TEST_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/nvg.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/rsc.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/spi.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/loader/svgb.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/applist/registeration.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/fbs/bitmap.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/svg_icon.cpp

--- a/src/tests/epoc/loader/svgb.cpp
+++ b/src/tests/epoc/loader/svgb.cpp
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Attribute and character-data decoding in the SVGB-to-SVG converter. Every case
+// is a hand-built minimal SVGB stream, because what matters is only whether the
+// decoder consumes exactly as many bytes as the binariser wrote: one byte read
+// short or long desynchronises the stream and the remainder of the icon is lost,
+// which is how these bugs presented.
+
+#include <catch2/catch.hpp>
+#include <loader/svgb.h>
+
+#include <common/buffer.h>
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+using namespace eka2l1;
+
+namespace {
+    // Stream markers, from the binary format the converter implements.
+    constexpr std::uint32_t SVGB_MAGIC = 0x03FA56CC;
+    constexpr std::uint8_t SVGB_FILE_END = 0xFF;
+    constexpr std::uint8_t SVGB_ELEMENT_END = 0xFE;
+    constexpr std::uint8_t SVGB_CDATA = 0xFD;
+    constexpr std::uint16_t SVGB_ATTR_END = 1000;
+
+    // Element codes, as indexed in the converter's element table.
+    constexpr std::uint8_t ELEM_GROUP = 11;
+    constexpr std::uint8_t ELEM_TEXT = 25;
+    constexpr std::uint8_t ELEM_RECT = 33;
+
+    // Attribute ids.
+    constexpr std::uint16_t ATTR_Y = 48;
+    constexpr std::uint16_t ATTR_X = 49;
+
+    void append16(std::vector<std::uint8_t> &buf, const std::uint16_t value) {
+        buf.push_back(static_cast<std::uint8_t>(value & 0xFF));
+        buf.push_back(static_cast<std::uint8_t>(value >> 8));
+    }
+
+    void append32(std::vector<std::uint8_t> &buf, const std::uint32_t value) {
+        for (int i = 0; i < 4; i++) {
+            buf.push_back(static_cast<std::uint8_t>((value >> (i * 8)) & 0xFF));
+        }
+    }
+
+    void append_float(std::vector<std::uint8_t> &buf, const float value) {
+        std::uint32_t raw = 0;
+        std::memcpy(&raw, &value, sizeof(raw));
+
+        append32(buf, raw);
+    }
+
+    // A length-prefixed string, the one shape the format uses for both character
+    // data and string attributes: a single count byte, then that many bytes.
+    void append_string(std::vector<std::uint8_t> &buf, const std::vector<std::uint8_t> &bytes) {
+        buf.push_back(static_cast<std::uint8_t>(bytes.size()));
+        buf.insert(buf.end(), bytes.begin(), bytes.end());
+    }
+
+    // Character data is stored as UCS-2.
+    void append_cdata(std::vector<std::uint8_t> &buf, const std::u16string &text) {
+        std::vector<std::uint8_t> bytes;
+
+        for (const char16_t c : text) {
+            append16(bytes, static_cast<std::uint16_t>(c));
+        }
+
+        buf.push_back(SVGB_CDATA);
+        append_string(buf, bytes);
+    }
+
+    std::vector<std::uint8_t> begin_svgb() {
+        std::vector<std::uint8_t> buf;
+        append32(buf, SVGB_MAGIC);
+
+        return buf;
+    }
+
+    // Ends the attribute list. The byte that follows decides whether the element
+    // closes immediately or has content, so the caller writes it next.
+    void end_attributes(std::vector<std::uint8_t> &buf) {
+        append16(buf, SVGB_ATTR_END);
+    }
+
+    std::string convert(const std::vector<std::uint8_t> &svgb, const bool expect_success = true) {
+        common::ro_buf_stream in(const_cast<std::uint8_t *>(svgb.data()), svgb.size());
+
+        std::vector<std::uint8_t> out_buf(64 * 1024, 0);
+        common::wo_buf_stream out(out_buf.data(), out_buf.size());
+
+        std::vector<loader::svgb_convert_error_description> errors;
+        const bool ok = loader::convert_svgb_to_svg(in, out, errors);
+        REQUIRE(ok == expect_success);
+
+        return std::string(reinterpret_cast<const char *>(out_buf.data()), static_cast<std::size_t>(out.tell()));
+    }
+}
+
+TEST_CASE("svgb_text_x_is_a_coordinate_list", "svgb_file") {
+    // SVG lets a <text> element place each of its glyphs, so on <text> the x and y
+    // attributes are coordinate lists and the binariser writes a count byte in
+    // front of the floats. Reading them as a bare float leaves the count byte
+    // unconsumed, and every byte after it is interpreted one position out of
+    // phase -- which is what dropped the rest of the icon.
+    std::vector<std::uint8_t> buf = begin_svgb();
+
+    buf.push_back(ELEM_TEXT);
+    append16(buf, ATTR_X);
+    buf.push_back(3);
+    append_float(buf, 10.0f);
+    append_float(buf, 20.0f);
+    append_float(buf, 30.0f);
+    end_attributes(buf);
+    buf.push_back(SVGB_ELEMENT_END);
+    buf.push_back(SVGB_FILE_END);
+
+    const std::string svg = convert(buf);
+
+    REQUIRE(svg.find("x=\"10 20 30\"") != std::string::npos);
+}
+
+TEST_CASE("svgb_text_y_is_a_coordinate_list_too", "svgb_file") {
+    // y takes the same form and is decoded by the same handler; a fix applied to
+    // only one of the pair still desynchronises.
+    std::vector<std::uint8_t> buf = begin_svgb();
+
+    buf.push_back(ELEM_TEXT);
+    append16(buf, ATTR_Y);
+    buf.push_back(2);
+    append_float(buf, 6.25f);
+    append_float(buf, 7.0f);
+    end_attributes(buf);
+    buf.push_back(SVGB_ELEMENT_END);
+    buf.push_back(SVGB_FILE_END);
+
+    const std::string svg = convert(buf);
+
+    REQUIRE(svg.find("y=\"6.25 7\"") != std::string::npos);
+}
+
+TEST_CASE("svgb_non_text_x_stays_a_single_float", "svgb_file") {
+    // Everywhere other than <text>, x is one number with no count in front of it.
+    // Reading a count there would be the same bug in the opposite direction.
+    std::vector<std::uint8_t> buf = begin_svgb();
+
+    buf.push_back(ELEM_RECT);
+    append16(buf, ATTR_X);
+    append_float(buf, 5.0f);
+    end_attributes(buf);
+    buf.push_back(SVGB_ELEMENT_END);
+    buf.push_back(SVGB_FILE_END);
+
+    const std::string svg = convert(buf);
+
+    REQUIRE(svg.find("x=\"5\"") != std::string::npos);
+}
+
+TEST_CASE("svgb_text_coordinate_list_can_be_empty", "svgb_file") {
+    // A count of zero writes no attribute, but the following element must still
+    // decode -- the count byte has been consumed either way.
+    std::vector<std::uint8_t> buf = begin_svgb();
+
+    buf.push_back(ELEM_TEXT);
+    append16(buf, ATTR_X);
+    buf.push_back(0);
+    end_attributes(buf);
+    buf.push_back(SVGB_ELEMENT_END);
+    buf.push_back(ELEM_RECT);
+    end_attributes(buf);
+    buf.push_back(SVGB_ELEMENT_END);
+    buf.push_back(SVGB_FILE_END);
+
+    const std::string svg = convert(buf);
+
+    REQUIRE(svg.find("x=") == std::string::npos);
+    REQUIRE(svg.find("<rect") != std::string::npos);
+}
+
+TEST_CASE("svgb_character_data_is_consumed_and_emitted", "svgb_file") {
+    // The character-data branch used to record "ignored" and return without
+    // reading the string, so the text bytes were decoded as elements and
+    // attributes. The <rect> after it is the witness: it only survives if the
+    // string was consumed.
+    std::vector<std::uint8_t> buf = begin_svgb();
+
+    buf.push_back(ELEM_TEXT);
+    end_attributes(buf);
+    append_cdata(buf, u"Hi");
+    buf.push_back(SVGB_ELEMENT_END);
+    buf.push_back(ELEM_RECT);
+    end_attributes(buf);
+    buf.push_back(SVGB_ELEMENT_END);
+    buf.push_back(SVGB_FILE_END);
+
+    const std::string svg = convert(buf);
+
+    REQUIRE(svg.find(">Hi</text>") != std::string::npos);
+    REQUIRE(svg.find("<rect") != std::string::npos);
+}
+
+TEST_CASE("svgb_character_data_is_not_padded_by_indentation", "svgb_file") {
+    // Whitespace inside a <text> element is content: indenting the closing tag
+    // appends it to the rendered string. It only shows once the element is nested
+    // deep enough to carry indentation, which is where real icons put their text.
+    std::vector<std::uint8_t> buf = begin_svgb();
+
+    buf.push_back(ELEM_GROUP);
+    end_attributes(buf);
+    buf.push_back(ELEM_TEXT);
+    end_attributes(buf);
+    append_cdata(buf, u"Hi");
+    buf.push_back(SVGB_ELEMENT_END);
+    buf.push_back(SVGB_ELEMENT_END);
+    buf.push_back(SVGB_FILE_END);
+
+    const std::string svg = convert(buf);
+
+    REQUIRE(svg.find(">Hi</text>") != std::string::npos);
+}
+
+TEST_CASE("svgb_character_data_is_xml_escaped", "svgb_file") {
+    // The string is copied into element content, so the three characters that
+    // cannot appear there literally have to be escaped or the SVG will not parse.
+    std::vector<std::uint8_t> buf = begin_svgb();
+
+    buf.push_back(ELEM_TEXT);
+    end_attributes(buf);
+    append_cdata(buf, u"a&b<c>d");
+    buf.push_back(SVGB_ELEMENT_END);
+    buf.push_back(SVGB_FILE_END);
+
+    const std::string svg = convert(buf);
+
+    REQUIRE(svg.find("a&amp;b&lt;c&gt;d") != std::string::npos);
+}
+
+TEST_CASE("svgb_string_length_byte_is_unsigned", "svgb_file") {
+    // The length byte spans 0..255. Read into a signed char, anything from 128 up
+    // is negative, and the read length is nowhere near what the binariser wrote.
+    const std::u16string long_text(80, u'x');
+
+    std::vector<std::uint8_t> buf = begin_svgb();
+
+    buf.push_back(ELEM_TEXT);
+    end_attributes(buf);
+    append_cdata(buf, long_text);
+    buf.push_back(SVGB_ELEMENT_END);
+    buf.push_back(ELEM_RECT);
+    end_attributes(buf);
+    buf.push_back(SVGB_ELEMENT_END);
+    buf.push_back(SVGB_FILE_END);
+
+    const std::string svg = convert(buf);
+
+    REQUIRE(svg.find(std::string(80, 'x')) != std::string::npos);
+    REQUIRE(svg.find("<rect") != std::string::npos);
+}
+
+TEST_CASE("svgb_truncated_coordinate_list_fails_cleanly", "svgb_file") {
+    // A count that promises more floats than the stream holds must be reported,
+    // not read past the end of the buffer.
+    std::vector<std::uint8_t> buf = begin_svgb();
+
+    buf.push_back(ELEM_TEXT);
+    append16(buf, ATTR_X);
+    buf.push_back(4);
+    append_float(buf, 1.0f);
+
+    convert(buf, false);
+}


### PR DESCRIPTION
An icon whose MIF holds an ordinary SVGB entry drew as the placeholder, with no debinarised SVG left in the icon cache. The converter desynchronised at the first `<text>` element, reporting attribute id 12288 (`0x3000` — two bytes read out of phase) after emitting `x="7296"` on a 96x96 icon.

Four fixes, all in `src/emu/loader/src/svgb.cpp`:

**x/y on `<text>` are coordinate lists.** SVG lets a `<text>` element place each of its glyphs, so there its `x` and `y` are coordinate *lists*, and the binariser writes a one-byte count in front of the floats exactly as it does for `stroke-dasharray`. Reading them as bare floats leaves that count byte in the stream and every byte after it is one position out of phase. Everywhere other than `<text>`, `x` and `y` stay single numbers with no count.

**Character data has to be consumed.** Fixing the above exposed the `SVG_CDATA` branch, still a commented-out stub from the reference decoder that recorded "ignored" without consuming the string, desynchronising again three bytes later. It now reads the string, converts it from UCS-2 and escapes the three characters that may not appear literally in element content.

**The closing tag of an element holding character data is no longer indented**, because whitespace in that position is part of the rendered string.

**The string length byte is read unsigned.** It spans 0..255, and read into a signed `char` anything from 128 up is a negative length.

### Verification

Converting every SVG-typed entry of every MIF reachable from the emulator's drives — 320 entries across six ROMs and all installed packages — with the old and the new decoder changes only the icon that prompted this. Every other icon converts byte-identically.

Nine new test cases build minimal SVGB streams around the four fixes. Reverting one fix at a time, in a tree with the others intact:

| Fix reverted | Cases that fail |
|---|---|
| x/y as a coordinate list on `<text>` | 3 |
| character data consumed and emitted | 4 |
| string length byte read unsigned | 1 |
| closing tag not indented after content | 1 |

`ekatests` goes from 80 cases / 261 assertions to 89 / 281.

One thing found but deliberately left alone: `svgb_fomat_float`'s trailing-zero trim has two branches that can never be true (`substr(len - 4) == "000"` compares four characters against three), so `5.5` formats as `5.50`. Harmless in SVG, and not this change's business.
