### PR TITLE
Render CJK text through the device's linked typefaces, and read imported fonts

### DIFF
--- a/src/emu/loader/src/gdr.cpp
+++ b/src/emu/loader/src/gdr.cpp
@@ -156,6 +156,16 @@ namespace eka2l1::loader::gdr {
         }
     }
 
+    // The first three words and the checksum are written as literal constants by
+    // fnttran (bitmapfonttools/src/FNTRECRD.CPP, FontStoreFile::ExternalizeHeader),
+    // and their values are in bitmapfonttools/inc/UID.H. They are what says a file
+    // is a font store at all -- without checking them, any file at all is parsed
+    // as one, and a stream of unrelated bytes walks the parser through counts and
+    // offsets that mean nothing.
+    static constexpr std::uint32_t GDR_STORE_WRITE_ONCE_LAYOUT_UID = 268435511; // KStoreWriteOnceLayoutUid
+    static constexpr std::uint32_t GDR_FONT_STORE_FILE_UID = 268435513; // KFontStoreFileUid
+    static constexpr std::uint32_t GDR_FONT_STORE_FILE_CHECKSUM = 0x47393853; // KFontStoreFileChecksum
+
     bool parse_store_header(common::ro_stream *stream, header &the_header) {
         std::size_t read = 0;
 
@@ -174,6 +184,12 @@ namespace eka2l1::loader::gdr {
             + sizeof(the_header.collection_uid_) + sizeof(the_header.pixel_aspect_ratio_) + sizeof(the_header.id_offset_2_);
 
         if (read != size_of_beginning_header) {
+            return false;
+        }
+
+        if ((the_header.store_write_once_layout_uid_ != GDR_STORE_WRITE_ONCE_LAYOUT_UID)
+            || (the_header.font_store_file_uid_ != GDR_FONT_STORE_FILE_UID)
+            || (the_header.font_store_file_checksum_ != GDR_FONT_STORE_FILE_CHECKSUM)) {
             return false;
         }
 

--- a/src/emu/services/CMakeLists.txt
+++ b/src/emu/services/CMakeLists.txt
@@ -61,6 +61,7 @@ add_library(epocservs
         include/services/fbs/adapter/font_adapter.h
         include/services/fbs/adapter/freetype_font_adapter.h
         include/services/fbs/adapter/gdr_font_adapter.h
+        include/services/fbs/adapter/linked_font_adapter.h
         include/services/fbs/adapter/stb_font_adapter.h
         include/services/fbs/bitmap.h
         include/services/fbs/compress_queue.h
@@ -68,6 +69,7 @@ add_library(epocservs
         include/services/fbs/font.h
         include/services/fbs/font_atlas.h
         include/services/fbs/font_store.h
+        include/services/fbs/linked_font_config.h
         include/services/fbs/palette.h
         include/services/featmgr/featmgr.h
         include/services/fs/sec.h
@@ -209,6 +211,7 @@ add_library(epocservs
         src/fbs/adapter/font_adapter.cpp
         src/fbs/adapter/freetype_font_adapter.cpp
         src/fbs/adapter/gdr_font_adapter.cpp
+        src/fbs/adapter/linked_font_adapter.cpp
         src/fbs/adapter/stb_font_adapter.cpp
         src/fbs/compress_queue.cpp
         src/fbs/fbs.cpp
@@ -216,6 +219,7 @@ add_library(epocservs
         src/fbs/impls/bitmap.cpp
         src/fbs/impls/font.cpp
         src/fbs/impls/font_store.cpp
+        src/fbs/impls/linked_font_config.cpp
         src/featmgr/featmgr.cpp
         src/fs/dirs.cpp
         src/fs/drives.cpp

--- a/src/emu/services/include/services/fbs/adapter/font_adapter.h
+++ b/src/emu/services/include/services/fbs/adapter/font_adapter.h
@@ -45,11 +45,12 @@ namespace eka2l1::epoc::adapter {
      * \brief Base class for adapter.
      */
     class font_file_adapter_base {
-    protected:
-        virtual std::uint32_t get_glyph_advance(const std::size_t face_index, const std::uint32_t codepoint, const std::uint32_t metric_identifier, const bool vertical = false) = 0;
-
     public:
         virtual ~font_file_adapter_base() {}
+
+        // Public so that an adapter presenting other adapters as one typeface
+        // (see linked_font_file_adapter) can forward this per glyph.
+        virtual std::uint32_t get_glyph_advance(const std::size_t face_index, const std::uint32_t codepoint, const std::uint32_t metric_identifier, const bool vertical = false) = 0;
 
         virtual bool is_valid() = 0;
         virtual bool vectorizable() const = 0;
@@ -59,6 +60,14 @@ namespace eka2l1::epoc::adapter {
 
         virtual bool get_face_attrib(const std::size_t idx, open_font_face_attrib &face_attrib) = 0;
 
+        /**
+         * @brief Rasterize one glyph.
+         *
+         * @param bmp_type In, the format the caller would like, or
+         *                 default_glyph_bitmap for whatever suits the adapter.
+         *                 Out, the format it really produced -- an adapter is
+         *                 free to ignore the request.
+         */
         virtual std::uint8_t *get_glyph_bitmap(const std::size_t idx, std::uint32_t code, const std::uint32_t metric_identifier,
             int *rasterized_width, int *rasterized_height, std::uint32_t &total_size, epoc::glyph_bitmap_type *bmp_type,
             open_font_character_metric &character_metric)
@@ -163,6 +172,27 @@ namespace eka2l1::epoc::adapter {
             return 8;
         }
     };
+
+    /**
+     * @brief Number of words a monochrome glyph of this size can ever need.
+     */
+    std::size_t monochrome_glyph_word_count(const std::int32_t width, const std::int32_t height);
+
+    /**
+     * @brief Encode 1 bit per pixel scanlines the way Symbian wants a
+     *        monochrome glyph bitmap.
+     *
+     * A run is a mode bit -- 0 for "the single scanline that follows repeats",
+     * 1 for "this many scanlines follow verbatim" -- then a four bit count,
+     * then the scanline bits, everything least significant bit first. The
+     * source is packed the same way, row major, `width * height` bits.
+     *
+     * @param dest Buffer of at least monochrome_glyph_word_count() words,
+     *             zeroed.
+     * @returns The number of bits written.
+     */
+    std::uint32_t compress_monochrome_glyph(const std::uint32_t *source, const std::int32_t width,
+        const std::int32_t height, std::uint32_t *dest);
 
     enum class font_file_adapter_kind {
         none,

--- a/src/emu/services/include/services/fbs/adapter/freetype_font_adapter.h
+++ b/src/emu/services/include/services/fbs/adapter/freetype_font_adapter.h
@@ -83,6 +83,10 @@ namespace eka2l1::epoc::adapter {
            return antialised_glyph_bitmap;
        }
 
+       // Glyphs this adapter rendered as monochrome, which unlike the
+       // antialiased ones are its own allocations rather than FreeType's.
+       std::vector<std::uint8_t *> owned_monochrome_bitmaps_;
+
        bool does_glyph_exist(std::size_t idx, std::uint32_t code, const std::uint32_t metric_identifier) override;
 
        std::size_t count() override;

--- a/src/emu/services/include/services/fbs/adapter/linked_font_adapter.h
+++ b/src/emu/services/include/services/fbs/adapter/linked_font_adapter.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <services/fbs/adapter/font_adapter.h>
+
+#include <unordered_map>
+#include <vector>
+
+namespace eka2l1::epoc::adapter {
+    /**
+     * @brief A typeface assembled from faces belonging to other font files.
+     *
+     * This is the S60 linked font: a Chinese/Japanese/Korean variant ships a
+     * Latin typeface and a CJK typeface as separate files, plus a link.ini
+     * describing how to present them as one typeface. A glyph is taken from
+     * the first component that has it, so Latin text keeps the look of the
+     * Latin font while CJK text -- absent from it -- comes from the CJK font.
+     *
+     * The component flagged CANONICAL in link.ini supplies everything that is
+     * not per-glyph: the typeface attributes, the metrics and the supported
+     * sizes. Anything reached through a character code is dispatched instead.
+     */
+    /**
+     * @brief Can a glyph a component produces be handed over as one from the
+     *        face it is backing?
+     *
+     * The same format always can. Antialiased output can be converted down to
+     * the monochrome one Symbian's older devices are limited to; the other way
+     * around is not implemented, and no imported font asks for it.
+     */
+    bool can_present_glyph_as(const glyph_bitmap_type component_type, const glyph_bitmap_type face_type);
+
+    class linked_font_file_adapter : public font_file_adapter_base {
+    public:
+        struct component {
+            font_file_adapter_base *adapter_;
+            std::size_t face_index_;
+        };
+
+    private:
+        // In link.ini order, which is also the order glyphs are looked up in.
+        std::vector<component> components_;
+        std::size_t canonical_;
+        open_font_face_attrib attrib_;
+
+        // Glyph bitmaps must be released through the component that produced
+        // them: free_glyph_bitmap() only gets the pointer back, and the gdr and
+        // stb adapters really do own that memory. A bitmap this adapter
+        // converted itself is marked with OWNED_BY_LINK.
+        static constexpr std::size_t OWNED_BY_LINK = static_cast<std::size_t>(-1);
+        std::unordered_map<std::uint8_t *, std::size_t> bitmap_owners_;
+
+        // A metric identifier only means something to the adapter that issued
+        // it -- a pixel size to FreeType, an index into the face's bitmaps to
+        // gdr -- so the canonical's identifier is remembered alongside the one
+        // each component uses for that same size. Filled in by
+        // get_nearest_supported_metric, which is where the size is still known.
+        std::unordered_map<std::uint32_t, std::vector<std::uint32_t>> metric_identifiers_;
+
+        const component &canonical() const {
+            return components_[canonical_];
+        }
+
+        // How `component_index` addresses the size the canonical calls
+        // `metric_identifier`.
+        std::uint32_t metric_for(const std::size_t component_index, const std::uint32_t metric_identifier) const;
+
+        // The component that renders `code`, falling back to the canonical one
+        // when no component covers it (so the caller still gets .notdef rather
+        // than nothing).
+        std::size_t component_index_for(const std::uint32_t code, const std::uint32_t metric_identifier);
+
+    public:
+        explicit linked_font_file_adapter(std::vector<component> components, const std::size_t canonical,
+            const open_font_face_attrib &attrib);
+
+        bool is_valid() override;
+        bool vectorizable() const override;
+        std::size_t count() override;
+
+        std::uint32_t line_gap(const std::size_t idx, const std::uint32_t metric_identifier) override;
+        bool get_face_attrib(const std::size_t idx, open_font_face_attrib &face_attrib) override;
+
+        std::uint8_t *get_glyph_bitmap(const std::size_t idx, std::uint32_t code, const std::uint32_t metric_identifier,
+            int *rasterized_width, int *rasterized_height, std::uint32_t &total_size, epoc::glyph_bitmap_type *bmp_type,
+            open_font_character_metric &character_metric) override;
+
+        void free_glyph_bitmap(std::uint8_t *data) override;
+        glyph_bitmap_type get_output_bitmap_type() const override;
+
+        bool does_glyph_exist(std::size_t idx, std::uint32_t code, const std::uint32_t metric_identifier) override;
+        bool has_character(const std::size_t face_index, const std::int32_t codepoint, const std::uint32_t metric_identifier) override;
+
+        std::uint32_t get_glyph_advance(const std::size_t face_index, const std::uint32_t codepoint,
+            const std::uint32_t metric_identifier, const bool vertical = false) override;
+
+        std::int32_t begin_get_atlas(std::uint8_t *atlas_ptr, const eka2l1::vec2 atlas_size) override;
+        bool get_glyph_atlas(const std::int32_t handle, const std::size_t idx, const char16_t start_code, int *unicode_point,
+            const char16_t num_code, const std::uint32_t metric_identifier, character_info *info) override;
+        void end_get_atlas(const std::int32_t handle) override;
+        std::uint8_t get_atlas_bitmap_bits_per_pixel() override;
+
+        std::optional<open_font_metrics> get_metric_with_uid(const std::size_t face_index, const std::uint32_t uid,
+            std::uint32_t *metric_identifier) override;
+        std::optional<open_font_metrics> get_nearest_supported_metric(const std::size_t face_index,
+            const std::uint16_t targeted_font_size, std::uint32_t *metric_identifier, bool is_design_font_size) override;
+
+        bool get_table_content(const std::size_t face_index, const std::uint32_t tag4, std::uint8_t *dest,
+            std::uint32_t &dest_size) override;
+
+        // make_text_shape() is deliberately not overridden: the base walks the
+        // text calling get_glyph_advance(), so inheriting it gives shaping the
+        // per-component advances rather than the canonical font's .notdef.
+    };
+}

--- a/src/emu/services/include/services/fbs/fbs.h
+++ b/src/emu/services/include/services/fbs/fbs.h
@@ -318,6 +318,10 @@ namespace std {
 namespace eka2l1 {
     class io_system;
 
+    namespace common {
+        class ro_stream;
+    }
+
     enum fbs_load_data_err {
         fbs_load_data_err_none,
         fbs_load_data_err_out_of_mem,
@@ -369,6 +373,7 @@ namespace eka2l1 {
         epoc::font_store persistent_font_store;
 
         void load_fonts(eka2l1::io_system *io);
+        void load_custom_fonts(const std::string &storage);
         void load_linked_fonts(eka2l1::io_system *io);
 
         std::atomic<service::uid> connection_id_counter{ 0x1234 }; // Easier to debug
@@ -383,6 +388,7 @@ namespace eka2l1 {
         void load_linked_fonts_from_directory(eka2l1::io_system *io, const std::u16string &fonts_folder_path);
         void initialize_server();
 
+        bool add_font(common::ro_stream &stream, const std::string &name, const bool user_font = false);
         bool add_single_font(eka2l1::io_system *io, const std::u16string &path);
 
     public:

--- a/src/emu/services/include/services/fbs/fbs.h
+++ b/src/emu/services/include/services/fbs/fbs.h
@@ -369,6 +369,7 @@ namespace eka2l1 {
         epoc::font_store persistent_font_store;
 
         void load_fonts(eka2l1::io_system *io);
+        void load_linked_fonts(eka2l1::io_system *io);
 
         std::atomic<service::uid> connection_id_counter{ 0x1234 }; // Easier to debug
 
@@ -379,6 +380,7 @@ namespace eka2l1 {
 
     protected:
         void load_fonts_from_directory(eka2l1::io_system *io, eka2l1::directory *dir);
+        void load_linked_fonts_from_directory(eka2l1::io_system *io, const std::u16string &fonts_folder_path);
         void initialize_server();
 
         bool add_single_font(eka2l1::io_system *io, const std::u16string &path);

--- a/src/emu/services/include/services/fbs/font_store.h
+++ b/src/emu/services/include/services/fbs/font_store.h
@@ -41,6 +41,10 @@ namespace eka2l1::epoc {
         epoc::open_font_metrics metrics;
 
         std::uint32_t metric_identifier;
+
+        // Imported by the user into <storage>/fonts rather than shipped by the
+        // device; see font_store::attach_user_font_fallbacks.
+        bool user_font = false;
     };
 
     /**
@@ -75,7 +79,8 @@ namespace eka2l1::epoc {
          * @brief Add every face of a font file to the store.
          * @returns True if the file was one this adapter kind can read.
          */
-        bool add_fonts(std::vector<std::uint8_t> &buf, const epoc::adapter::font_file_adapter_kind adapter_kind);
+        bool add_fonts(std::vector<std::uint8_t> &buf, const epoc::adapter::font_file_adapter_kind adapter_kind,
+            const bool user_font = false);
 
         /**
          * @brief Present faces already in the store as one linked typeface.
@@ -88,6 +93,21 @@ namespace eka2l1::epoc {
          */
         bool add_linked_font(const std::u16string &name, const std::vector<std::u16string> &component_names,
             const std::size_t canonical);
+
+        /**
+         * @brief Let the fonts the user imported stand in for glyphs the
+         *        device's own fonts do not have.
+         *
+         * A CJK variant ships a link.ini pairing its Latin typeface with a CJK
+         * one; a Latin-only ROM ships neither the font nor the link, so an
+         * imported font would sit in the store unused -- nothing asks for it by
+         * name, and nothing about a request says which script it is about to
+         * draw. Every device face is therefore given the imported fonts as
+         * trailing components of a linked typeface, which is the same
+         * arrangement link.ini describes, with the device's own face canonical
+         * so nothing about its appearance or metrics changes.
+         */
+        void attach_user_font_fallbacks();
 
         open_font_info *seek_the_open_font(epoc::font_spec_base &spec);
         open_font_info *seek_the_font_by_uid(const epoc::uid the_uid, epoc::open_font_metrics &target_metric, std::uint32_t *metric_identifier = nullptr);

--- a/src/emu/services/include/services/fbs/font_store.h
+++ b/src/emu/services/include/services/fbs/font_store.h
@@ -43,6 +43,14 @@ namespace eka2l1::epoc {
         std::uint32_t metric_identifier;
     };
 
+    /**
+     * @brief Score a candidate face against a request, higher being better.
+     *
+     * Port of CFontStore's MatchFontSpecsInPixels. Exposed for tests.
+     */
+    int match_font_spec(const open_font_face_attrib &candidate, const std::u16string &candidate_name,
+        const epoc::font_spec_base &spec, const std::int32_t candidate_height);
+
     // A set of fonts
     class font_store {
         std::vector<open_font_info> open_font_store;
@@ -50,6 +58,10 @@ namespace eka2l1::epoc {
         std::vector<epoc::typeface_support> typefaces;
 
         eka2l1::io_system *io;
+
+        // Linked typefaces occupy the front of open_font_store; see
+        // add_linked_font.
+        std::size_t linked_font_count_ = 0;
 
     protected:
         void folder_change_callback(const std::u16string &path, int action);
@@ -59,7 +71,23 @@ namespace eka2l1::epoc {
             : io(io) {
         }
 
-        void add_fonts(std::vector<std::uint8_t> &buf, const epoc::adapter::font_file_adapter_kind adapter_kind);
+        /**
+         * @brief Add every face of a font file to the store.
+         * @returns True if the file was one this adapter kind can read.
+         */
+        bool add_fonts(std::vector<std::uint8_t> &buf, const epoc::adapter::font_file_adapter_kind adapter_kind);
+
+        /**
+         * @brief Present faces already in the store as one linked typeface.
+         *
+         * Mirrors the S60 linked font that a CJK variant declares in link.ini:
+         * `component_names` are face names in lookup order and `canonical` is
+         * the index of the one that lends the typeface its attributes.
+         *
+         * @returns True if every component was found and the typeface was added.
+         */
+        bool add_linked_font(const std::u16string &name, const std::vector<std::u16string> &component_names,
+            const std::size_t canonical);
 
         open_font_info *seek_the_open_font(epoc::font_spec_base &spec);
         open_font_info *seek_the_font_by_uid(const epoc::uid the_uid, epoc::open_font_metrics &target_metric, std::uint32_t *metric_identifier = nullptr);

--- a/src/emu/services/include/services/fbs/linked_font_config.h
+++ b/src/emu/services/include/services/fbs/linked_font_config.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace eka2l1::epoc {
+    /**
+     * @brief One typeface that link.ini asks to be assembled from others.
+     */
+    struct linked_font_spec {
+        std::u16string name;
+        std::vector<std::u16string> component_names;
+        std::size_t canonical = 0;
+    };
+
+    /**
+     * @brief Read a font folder's link.ini, whatever it is encoded in.
+     *
+     * The file ships as UTF-16LE with a byte order mark; anything else is taken
+     * for UTF-8.
+     */
+    std::u16string decode_linked_font_config(const std::uint8_t *data, const std::size_t size);
+
+    /**
+     * @brief Parse link.ini into the typefaces it describes.
+     *
+     * A line reads, colon separated:
+     *
+     *   <component typeface>:GROUP<n>:CANONICAL<0|1>:REGULAR:SN<style>:FN<linked typeface>:
+     *
+     * Lines are grouped by their FN field, which names the typeface being
+     * assembled, and keep the order they appear in -- that is the order glyphs
+     * are looked up in, and the file lists the Latin component first so that
+     * Latin text keeps its own font and everything else falls to the CJK one.
+     *
+     * The variant sections ([SCHR_LINK_START] and friends) are not honoured:
+     * S60 builds the one its feature flags select, while EKA2L1 has no variant
+     * flags and instead lets the font store drop the typefaces whose components
+     * this ROM does not ship.
+     */
+    std::vector<linked_font_spec> parse_linked_font_config(const std::u16string &content);
+}

--- a/src/emu/services/src/fbs/adapter/font_adapter.cpp
+++ b/src/emu/services/src/fbs/adapter/font_adapter.cpp
@@ -21,9 +21,109 @@
 #include <services/fbs/adapter/freetype_font_adapter.h>
 #include <services/fbs/adapter/gdr_font_adapter.h>
 #include <services/fbs/adapter/stb_font_adapter.h>
+#include <common/bytes.h>
 #include <common/log.h>
 
 namespace eka2l1::epoc::adapter {
+
+    std::size_t monochrome_glyph_word_count(const std::int32_t width, const std::int32_t height) {
+        // Enough for the scanline bits even when nothing compresses, plus room
+        // for the run headers.
+        return ((static_cast<std::uint32_t>(width * height) + 31) >> 5) + 5;
+    }
+
+    std::uint32_t compress_monochrome_glyph(const std::uint32_t *src, const std::int32_t width,
+        const std::int32_t height, std::uint32_t *dest) {
+        std::int32_t total_line_processed_so_far = 0;
+        std::uint32_t total_bit_write = 0;
+
+#define WRITE_BIT_32(bit)                                                               \
+    dest[(total_bit_write >> 5)] |= ((bit & 1) << (total_bit_write & 31)); \
+    total_bit_write++
+
+        auto compare_line_equal = [&](std::uint32_t p_l1, std::uint32_t p_l2, const std::uint32_t n) -> bool {
+            std::uint32_t left = n;
+
+            while (left > 0) {
+                std::uint32_t to_read = std::min<std::uint32_t>(left, 32);
+
+                std::uint32_t pos1 = (p_l1 * width + n - left);
+                std::uint32_t pos2 = (p_l2 * width + n - left);
+
+                std::uint32_t maximum_1 = 32U - (pos1 & 31);
+                std::uint32_t maximum_2 = 32U - (pos2 & 31);
+
+                std::uint32_t part1read = std::min<std::uint32_t>(maximum_1, to_read);
+                std::uint32_t part2read = std::min<std::uint32_t>(maximum_2, to_read);
+
+                // common::extract_bits numbers bits from one, so a zero based
+                // position has to be handed over as p + 1. Passing zero shifts
+                // by an underflowed count, which is how identical scanlines
+                // used to compare unequal and every glyph ended up written out
+                // in full.
+                std::uint32_t l1p = common::extract_bits(src[pos1 >> 5], (pos1 & 31) + 1, part1read) | ((maximum_1 < to_read) ? (common::extract_bits(src[(pos1 >> 5) + 1], 1, to_read - maximum_1) << part1read) : 0);
+
+                std::uint32_t l2p = common::extract_bits(src[pos2 >> 5], (pos2 & 31) + 1, part2read) | ((maximum_2 < to_read) ? (common::extract_bits(src[(pos2 >> 5) + 1], 1, to_read - maximum_2) << part2read) : 0);
+
+                if (l1p != l2p) {
+                    return false;
+                }
+
+                left -= to_read;
+            }
+
+            return true;
+        };
+
+        while (total_line_processed_so_far < height) {
+            bool mode = false;
+            std::int8_t count = 2;
+
+            if (total_line_processed_so_far == (height - 1)) {
+                count = 1;
+                mode = false;
+            } else {
+                mode = compare_line_equal(total_line_processed_so_far, total_line_processed_so_far + 1, width);
+
+                bool got_in = false;
+
+                while ((count < 15) && (total_line_processed_so_far + count < height) && (compare_line_equal(total_line_processed_so_far + (mode ? 0 : (count - 1)), total_line_processed_so_far + count, width) == mode)) {
+                    count++;
+                    got_in = true;
+                }
+
+                if (got_in) {
+                    count--;
+                }
+            }
+
+            WRITE_BIT_32(mode ? 0 : 1); // Repeat mode if line equal
+
+            // Write the repeat count
+            WRITE_BIT_32(count & 1);
+            WRITE_BIT_32((count >> 1) & 1);
+            WRITE_BIT_32((count >> 2) & 1);
+            WRITE_BIT_32((count >> 3) & 1);
+
+            // Write the line content
+            std::uint32_t loc = total_line_processed_so_far * width;
+
+            for (std::size_t j = 0; j < (mode ? 1 : count); j++) {
+                for (std::size_t i = 0; i < width; i++) {
+                    // Give up being fast lol
+                    WRITE_BIT_32((src[(loc + i) >> 5] >> ((loc + i) & 31)) & 1);
+                }
+
+                loc += width;
+            }
+
+            total_line_processed_so_far += count;
+        }
+#undef WRITE_BIT_32
+
+        return total_bit_write;
+    }
+
     bool font_file_adapter_base::make_text_shape(const std::size_t face_index, const open_font_shaping_parameter &params, const std::u16string &text, const std::uint32_t metric_identifier, open_font_shaping_header &shaping_header, std::uint8_t *shaping_data) {
         if (params.text_range_[0] > params.text_range_[1]) {
             LOG_ERROR(SERVICE_FBS, "Text start position is larger than text end position in shaping parameter!");

--- a/src/emu/services/src/fbs/adapter/freetype_font_adapter.cpp
+++ b/src/emu/services/src/fbs/adapter/freetype_font_adapter.cpp
@@ -232,7 +232,12 @@ namespace eka2l1::epoc::adapter {
             return nullptr;
         }
 
-        auto err = FT_Load_Glyph(face, glyph_index, FT_LOAD_RENDER);
+        // A caller backing a monochrome face asks for that format; FreeType's
+        // own monochrome rasteriser, hinted, is far kinder to small CJK glyphs
+        // than thresholding a grey one would be.
+        const bool want_monochrome = bmp_type && (*bmp_type == glyph_bitmap_type::monochrome_glyph_bitmap);
+
+        auto err = FT_Load_Glyph(face, glyph_index, FT_LOAD_RENDER | (want_monochrome ? FT_LOAD_TARGET_MONO : 0));
         if (err) {
             LOG_ERROR(SERVICE_FBS, "Failed to load glyph for face to get glyph bitmap, error: {}", FT_Error_String(err));
             return nullptr;
@@ -249,10 +254,14 @@ namespace eka2l1::epoc::adapter {
             *rasterized_height = static_cast<int>(bitmap.rows);
         }
 
+        const glyph_bitmap_type produced = (bitmap.pixel_mode == FT_PIXEL_MODE_MONO)
+            ? glyph_bitmap_type::monochrome_glyph_bitmap
+            : glyph_bitmap_type::antialised_glyph_bitmap;
+
         total_size = bitmap.width * bitmap.rows;
 
         if (bmp_type) {
-            *bmp_type = glyph_bitmap_type::antialised_glyph_bitmap;
+            *bmp_type = produced;
         }
 
         character_metric.width = ft_convention_to_int_pixel(glyph->metrics.width);
@@ -263,12 +272,62 @@ namespace eka2l1::epoc::adapter {
         character_metric.vertical_bearing_x = ft_convention_to_int_pixel(glyph->metrics.vertBearingX);
         character_metric.vertical_bearing_y = ft_convention_to_int_pixel(glyph->metrics.vertBearingY);
         character_metric.vertical_advance = ft_convention_to_int_pixel(glyph->metrics.vertAdvance);
-        character_metric.bitmap_type = glyph_bitmap_type::antialised_glyph_bitmap;
+        character_metric.bitmap_type = produced;
 
-        return bitmap.buffer;
+        if (produced != glyph_bitmap_type::monochrome_glyph_bitmap) {
+            return bitmap.buffer;
+        }
+
+        const std::int32_t width = static_cast<std::int32_t>(bitmap.width);
+        const std::int32_t height = static_cast<std::int32_t>(bitmap.rows);
+
+        // Hinting grid-fits a monochrome glyph, so the bitmap is not the size
+        // the outline metrics describe. The client decodes the runs using these
+        // metrics, and reading a glyph as wider than it was encoded walks off
+        // the end of the shared chunk, so report what was actually rasterised.
+        character_metric.width = static_cast<std::int16_t>(width);
+        character_metric.height = static_cast<std::int16_t>(height);
+        character_metric.horizontal_bearing_x = static_cast<std::int16_t>(glyph->bitmap_left);
+        character_metric.horizontal_bearing_y = static_cast<std::int16_t>(glyph->bitmap_top);
+
+        // FreeType packs a monochrome row most significant bit first and pads
+        // it to whole bytes; a Symbian glyph is one run of bits, least
+        // significant first, run-length encoded from there.
+
+        std::vector<std::uint32_t> bits((static_cast<std::size_t>(width) * height + 31) >> 5, 0);
+
+        for (std::int32_t y = 0; y < height; y++) {
+            const std::uint8_t *row = bitmap.buffer + static_cast<std::ptrdiff_t>(y) * bitmap.pitch;
+
+            for (std::int32_t x = 0; x < width; x++) {
+                if (row[x >> 3] & (0x80 >> (x & 7))) {
+                    const std::int32_t index = y * width + x;
+                    bits[index >> 5] |= (1u << (index & 31));
+                }
+            }
+        }
+
+        const std::size_t word_count = monochrome_glyph_word_count(width, height);
+        std::uint32_t *compressed = new std::uint32_t[word_count];
+        std::fill(compressed, compressed + word_count, 0);
+
+        total_size = ((compress_monochrome_glyph(bits.data(), width, height, compressed) + 31) >> 5) * 4;
+
+        std::uint8_t *result = reinterpret_cast<std::uint8_t *>(compressed);
+        owned_monochrome_bitmaps_.push_back(result);
+
+        return result;
     }
 
     void freetype_font_adapter::free_glyph_bitmap(std::uint8_t *data) {
+        // Antialiased glyphs live in FreeType's own slot and are replaced by
+        // the next load; only the monochrome ones are ours to release.
+        auto owned = std::find(owned_monochrome_bitmaps_.begin(), owned_monochrome_bitmaps_.end(), data);
+
+        if (owned != owned_monochrome_bitmaps_.end()) {
+            owned_monochrome_bitmaps_.erase(owned);
+            delete[] reinterpret_cast<std::uint32_t *>(data);
+        }
     }
 
     std::int32_t freetype_font_adapter::begin_get_atlas(std::uint8_t *atlas_ptr, const eka2l1::vec2 atlas_size) {

--- a/src/emu/services/src/fbs/adapter/gdr_font_adapter.cpp
+++ b/src/emu/services/src/fbs/adapter/gdr_font_adapter.cpp
@@ -169,93 +169,14 @@ namespace eka2l1::epoc::adapter {
         const std::int16_t target_width = the_char->metric_->move_in_pixels_ - the_char->metric_->left_adj_in_pixels_ - the_char->metric_->right_adjust_in_pixels_;
         const std::int16_t target_height = the_char->metric_->height_in_pixels_;
 
-        // RLE this baby! Alloc this big to gurantee compressed data will always fit. If the compression is bad
+        // Alloc this big to gurantee compressed data will always fit. If the compression is bad
         // we also add 5 more words. in case compression is not effective at all.
-        const std::size_t total_compressed_word = ((static_cast<std::uint32_t>(target_width * target_height) + 31) >> 5) + 5;
+        const std::size_t total_compressed_word = monochrome_glyph_word_count(target_width, target_height);
         std::uint32_t *compressed_bitmap = new std::uint32_t[total_compressed_word];
         std::fill(compressed_bitmap, compressed_bitmap + total_compressed_word, 0);
 
-        std::int16_t total_line_processed_so_far = 0;
-        std::uint32_t total_bit_write = 0;
-
-#define WRITE_BIT_32(bit)                                                               \
-    compressed_bitmap[(total_bit_write >> 5)] |= ((bit & 1) << (total_bit_write & 31)); \
-    total_bit_write++
-
-        auto compare_line_equal = [&](std::uint32_t p_l1, std::uint32_t p_l2, const std::uint32_t n) -> bool {
-            std::uint32_t left = n;
-
-            while (left > 0) {
-                std::uint32_t to_read = std::min<std::uint32_t>(left, 32);
-
-                std::uint32_t pos1 = (p_l1 * target_width + n - left);
-                std::uint32_t pos2 = (p_l2 * target_width + n - left);
-
-                std::uint32_t maximum_1 = 32U - (pos1 & 31);
-                std::uint32_t maximum_2 = 32U - (pos2 & 31);
-
-                std::uint32_t part1read = std::min<std::uint32_t>(maximum_1, to_read);
-                std::uint32_t part2read = std::min<std::uint32_t>(maximum_2, to_read);
-
-                std::uint32_t l1p = common::extract_bits(src[pos1 >> 5], (pos1 & 31), part1read) | ((maximum_1 < to_read) ? (common::extract_bits(src[(pos1 >> 5) + 1], 0, to_read - maximum_1) << part1read) : 0);
-
-                std::uint32_t l2p = common::extract_bits(src[pos2 >> 5], (pos2 & 31), part2read) | ((maximum_2 < to_read) ? (common::extract_bits(src[(pos2 >> 5) + 1], 0, to_read - maximum_2) << part2read) : 0);
-
-                if (l1p != l2p) {
-                    return false;
-                }
-
-                left -= to_read;
-            }
-
-            return true;
-        };
-
-        while (total_line_processed_so_far < target_height) {
-            bool mode = false;
-            std::int8_t count = 2;
-
-            if (total_line_processed_so_far == (target_height - 1)) {
-                count = 1;
-                mode = false;
-            } else {
-                mode = compare_line_equal(total_line_processed_so_far, total_line_processed_so_far + 1, target_width);
-
-                bool got_in = false;
-
-                while ((count < 15) && (total_line_processed_so_far + count < target_height) && (compare_line_equal(total_line_processed_so_far + (mode ? 0 : (count - 1)), total_line_processed_so_far + count, target_width) == mode)) {
-                    count++;
-                    got_in = true;
-                }
-
-                if (got_in) {
-                    count--;
-                }
-            }
-
-            WRITE_BIT_32(mode ? 0 : 1); // Repeat mode if line equal
-
-            // Write the repeat count
-            WRITE_BIT_32(count & 1);
-            WRITE_BIT_32((count >> 1) & 1);
-            WRITE_BIT_32((count >> 2) & 1);
-            WRITE_BIT_32((count >> 3) & 1);
-
-            // Write the line content
-            std::uint32_t loc = total_line_processed_so_far * target_width;
-
-            for (std::size_t j = 0; j < (mode ? 1 : count); j++) {
-                for (std::size_t i = 0; i < target_width; i++) {
-                    // Give up being fast lol
-                    WRITE_BIT_32((src[(loc + i) >> 5] >> ((loc + i) & 31)) & 1);
-                }
-
-                loc += target_width;
-            }
-
-            total_line_processed_so_far += count;
-        }
-#undef WRITE_BIT_32
+        const std::uint32_t total_bit_write = compress_monochrome_glyph(src, target_width, target_height,
+            compressed_bitmap);
 
         if (bmp_type)
             *bmp_type = epoc::glyph_bitmap_type::monochrome_glyph_bitmap;

--- a/src/emu/services/src/fbs/adapter/linked_font_adapter.cpp
+++ b/src/emu/services/src/fbs/adapter/linked_font_adapter.cpp
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <services/fbs/adapter/linked_font_adapter.h>
+
+#include <vector>
+
+namespace eka2l1::epoc::adapter {
+    bool can_present_glyph_as(const glyph_bitmap_type component_type, const glyph_bitmap_type face_type) {
+        return (component_type == face_type)
+            || ((face_type == monochrome_glyph_bitmap) && (component_type == antialised_glyph_bitmap));
+    }
+
+    // Threshold an 8 bit per pixel glyph and encode it the way a monochrome
+    // face's own glyphs arrive, so a face whose device only understands those
+    // can still be backed by an imported TrueType font.
+    static std::uint8_t *to_monochrome_glyph(const std::uint8_t *gray, const std::int32_t width,
+        const std::int32_t height, std::uint32_t &total_size) {
+        std::vector<std::uint32_t> bits((static_cast<std::size_t>(width) * height + 31) >> 5, 0);
+
+        for (std::int32_t i = 0; i < width * height; i++) {
+            if (gray[i] >= 0x80) {
+                bits[i >> 5] |= (1u << (i & 31));
+            }
+        }
+
+        const std::size_t word_count = monochrome_glyph_word_count(width, height);
+        std::uint32_t *compressed = new std::uint32_t[word_count];
+        std::fill(compressed, compressed + word_count, 0);
+
+        const std::uint32_t written = compress_monochrome_glyph(bits.data(), width, height, compressed);
+        total_size = ((written + 31) >> 5) * 4;
+
+        return reinterpret_cast<std::uint8_t *>(compressed);
+    }
+    linked_font_file_adapter::linked_font_file_adapter(std::vector<component> components, const std::size_t canonical,
+        const open_font_face_attrib &attrib)
+        : components_(std::move(components))
+        , canonical_(canonical)
+        , attrib_(attrib) {
+    }
+
+    std::uint32_t linked_font_file_adapter::metric_for(const std::size_t component_index,
+        const std::uint32_t metric_identifier) const {
+        auto translated = metric_identifiers_.find(metric_identifier);
+
+        if ((translated == metric_identifiers_.end()) || (component_index >= translated->second.size())) {
+            return metric_identifier;
+        }
+
+        return translated->second[component_index];
+    }
+
+    std::size_t linked_font_file_adapter::component_index_for(const std::uint32_t code,
+        const std::uint32_t metric_identifier) {
+        // A code with the high bit set is already a glyph index, which only
+        // means anything to the face it was taken from. Those come back from
+        // shaping, which the canonical component performs.
+        if (!(code & 0x80000000)) {
+            for (std::size_t i = 0; i < components_.size(); i++) {
+                if (components_[i].adapter_->has_character(components_[i].face_index_, static_cast<std::int32_t>(code),
+                        metric_for(i, metric_identifier))) {
+                    return i;
+                }
+            }
+        }
+
+        return canonical_;
+    }
+
+    bool linked_font_file_adapter::is_valid() {
+        return !components_.empty();
+    }
+
+    bool linked_font_file_adapter::vectorizable() const {
+        return components_[canonical_].adapter_->vectorizable();
+    }
+
+    std::size_t linked_font_file_adapter::count() {
+        return 1;
+    }
+
+    std::uint32_t linked_font_file_adapter::line_gap(const std::size_t idx, const std::uint32_t metric_identifier) {
+        return canonical().adapter_->line_gap(canonical().face_index_, metric_identifier);
+    }
+
+    bool linked_font_file_adapter::get_face_attrib(const std::size_t idx, open_font_face_attrib &face_attrib) {
+        if (idx != 0) {
+            return false;
+        }
+
+        face_attrib = attrib_;
+        return true;
+    }
+
+    std::uint8_t *linked_font_file_adapter::get_glyph_bitmap(const std::size_t idx, std::uint32_t code,
+        const std::uint32_t metric_identifier, int *rasterized_width, int *rasterized_height, std::uint32_t &total_size,
+        epoc::glyph_bitmap_type *bmp_type, open_font_character_metric &character_metric) {
+        const std::size_t index = component_index_for(code, metric_identifier);
+        const component &comp = components_[index];
+
+        int width = 0;
+        int height = 0;
+
+        // Ask for the format the face declares. A component that can render it
+        // -- FreeType has its own monochrome rasteriser, and a hinted glyph
+        // beats a thresholded one at the sizes these devices use -- gives it
+        // back directly.
+        glyph_bitmap_type produced = get_output_bitmap_type();
+
+        std::uint8_t *result = comp.adapter_->get_glyph_bitmap(comp.face_index_, code,
+            metric_for(index, metric_identifier), &width, &height, total_size, &produced, character_metric);
+
+        if (rasterized_width) {
+            *rasterized_width = width;
+        }
+
+        if (rasterized_height) {
+            *rasterized_height = height;
+        }
+
+        if (!result) {
+            return nullptr;
+        }
+
+        // A component that ignored the request has to be converted instead:
+        // the guest reads a glyph in the format the font as a whole declares,
+        // and 8 bit per pixel data read as monochrome runs draws as streaks.
+        if ((produced != get_output_bitmap_type()) && (width > 0) && (height > 0)) {
+            std::uint8_t *converted = to_monochrome_glyph(result, width, height, total_size);
+            comp.adapter_->free_glyph_bitmap(result);
+
+            produced = monochrome_glyph_bitmap;
+            character_metric.bitmap_type = produced;
+            result = converted;
+
+            bitmap_owners_[result] = OWNED_BY_LINK;
+        } else {
+            bitmap_owners_[result] = index;
+        }
+
+        if (bmp_type) {
+            *bmp_type = produced;
+        }
+
+        return result;
+    }
+
+    void linked_font_file_adapter::free_glyph_bitmap(std::uint8_t *data) {
+        auto owner = bitmap_owners_.find(data);
+
+        if (owner == bitmap_owners_.end()) {
+            canonical().adapter_->free_glyph_bitmap(data);
+            return;
+        }
+
+        const std::size_t index = owner->second;
+        bitmap_owners_.erase(owner);
+
+        if (index == OWNED_BY_LINK) {
+            delete[] reinterpret_cast<std::uint32_t *>(data);
+            return;
+        }
+
+        components_[index].adapter_->free_glyph_bitmap(data);
+    }
+
+    glyph_bitmap_type linked_font_file_adapter::get_output_bitmap_type() const {
+        return components_[canonical_].adapter_->get_output_bitmap_type();
+    }
+
+    bool linked_font_file_adapter::does_glyph_exist(std::size_t idx, std::uint32_t code, const std::uint32_t metric_identifier) {
+        const std::size_t index = component_index_for(code, metric_identifier);
+        return components_[index].adapter_->does_glyph_exist(components_[index].face_index_, code,
+            metric_for(index, metric_identifier));
+    }
+
+    bool linked_font_file_adapter::has_character(const std::size_t face_index, const std::int32_t codepoint,
+        const std::uint32_t metric_identifier) {
+        for (std::size_t i = 0; i < components_.size(); i++) {
+            if (components_[i].adapter_->has_character(components_[i].face_index_, codepoint,
+                    metric_for(i, metric_identifier))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    std::uint32_t linked_font_file_adapter::get_glyph_advance(const std::size_t face_index, const std::uint32_t codepoint,
+        const std::uint32_t metric_identifier, const bool vertical) {
+        const std::size_t index = component_index_for(codepoint, metric_identifier);
+        return components_[index].adapter_->get_glyph_advance(components_[index].face_index_, codepoint,
+            metric_for(index, metric_identifier), vertical);
+    }
+
+    std::int32_t linked_font_file_adapter::begin_get_atlas(std::uint8_t *atlas_ptr, const eka2l1::vec2 atlas_size) {
+        // The packing state belongs to one adapter, so an atlas can only be
+        // built from the canonical component. Nothing in the font store uses
+        // this path (only the Qt button-map overlay does, with its own font).
+        return canonical().adapter_->begin_get_atlas(atlas_ptr, atlas_size);
+    }
+
+    bool linked_font_file_adapter::get_glyph_atlas(const std::int32_t handle, const std::size_t idx, const char16_t start_code,
+        int *unicode_point, const char16_t num_code, const std::uint32_t metric_identifier, character_info *info) {
+        return canonical().adapter_->get_glyph_atlas(handle, canonical().face_index_, start_code, unicode_point, num_code,
+            metric_identifier, info);
+    }
+
+    void linked_font_file_adapter::end_get_atlas(const std::int32_t handle) {
+        canonical().adapter_->end_get_atlas(handle);
+    }
+
+    std::uint8_t linked_font_file_adapter::get_atlas_bitmap_bits_per_pixel() {
+        return canonical().adapter_->get_atlas_bitmap_bits_per_pixel();
+    }
+
+    std::optional<open_font_metrics> linked_font_file_adapter::get_metric_with_uid(const std::size_t face_index,
+        const std::uint32_t uid, std::uint32_t *metric_identifier) {
+        return canonical().adapter_->get_metric_with_uid(canonical().face_index_, uid, metric_identifier);
+    }
+
+    std::optional<open_font_metrics> linked_font_file_adapter::get_nearest_supported_metric(const std::size_t face_index,
+        const std::uint16_t targeted_font_size, std::uint32_t *metric_identifier, bool is_design_font_size) {
+        std::uint32_t canonical_identifier = 0;
+        std::optional<open_font_metrics> metrics = canonical().adapter_->get_nearest_supported_metric(
+            canonical().face_index_, targeted_font_size, &canonical_identifier, is_design_font_size);
+
+        if (!metrics.has_value()) {
+            return metrics;
+        }
+
+        // Ask every component how it addresses this same size, while the size
+        // is still to hand: the per-glyph calls only ever see the canonical's
+        // identifier, and handing a gdr bitmap index to FreeType as a pixel
+        // size renders the glyph at a couple of pixels tall.
+        std::vector<std::uint32_t> &identifiers = metric_identifiers_[canonical_identifier];
+        identifiers.assign(components_.size(), canonical_identifier);
+
+        for (std::size_t i = 0; i < components_.size(); i++) {
+            std::uint32_t component_identifier = canonical_identifier;
+
+            if (components_[i].adapter_->get_nearest_supported_metric(components_[i].face_index_, targeted_font_size,
+                    &component_identifier, is_design_font_size)) {
+                identifiers[i] = component_identifier;
+            }
+        }
+
+        if (metric_identifier) {
+            *metric_identifier = canonical_identifier;
+        }
+
+        return metrics;
+    }
+
+    bool linked_font_file_adapter::get_table_content(const std::size_t face_index, const std::uint32_t tag4,
+        std::uint8_t *dest, std::uint32_t &dest_size) {
+        return canonical().adapter_->get_table_content(canonical().face_index_, tag4, dest, dest_size);
+    }
+
+}

--- a/src/emu/services/src/fbs/fbs.cpp
+++ b/src/emu/services/src/fbs/fbs.cpp
@@ -422,10 +422,20 @@ namespace eka2l1 {
         // Probably also indicates that font aren't loaded yet
         load_fonts(sys->get_io_system());
 
+        // User-imported fonts are stored outside the guest drives, so they need
+        // a separate pass. They are appended after the ROM set, and
+        // seek_the_open_font takes the first exact face-name match, so an
+        // imported font never displaces a ROM one -- it only adds coverage.
+        load_custom_fonts(sys->get_config()->storage);
+
         // A CJK variant presents a Latin font and a CJK font as one typeface
         // through link.ini. Both have to be in the store before the typefaces
         // naming them can be assembled.
         load_linked_fonts(sys->get_io_system());
+
+        // Anything imported is only useful once the device's own faces can
+        // reach it, the ROM having no link.ini that mentions it.
+        persistent_font_store.attach_user_font_fallbacks();
 
         fs_server = kern->get_by_name<service::server>(epoc::fs::get_server_name_through_epocver(
             kern->get_epoc_version()));

--- a/src/emu/services/src/fbs/fbs.cpp
+++ b/src/emu/services/src/fbs/fbs.cpp
@@ -422,6 +422,11 @@ namespace eka2l1 {
         // Probably also indicates that font aren't loaded yet
         load_fonts(sys->get_io_system());
 
+        // A CJK variant presents a Latin font and a CJK font as one typeface
+        // through link.ini. Both have to be in the store before the typefaces
+        // naming them can be assembled.
+        load_linked_fonts(sys->get_io_system());
+
         fs_server = kern->get_by_name<service::server>(epoc::fs::get_server_name_through_epocver(
             kern->get_epoc_version()));
 

--- a/src/emu/services/src/fbs/impls/font.cpp
+++ b/src/emu/services/src/fbs/impls/font.cpp
@@ -22,6 +22,7 @@
  */
 
 #include <services/fbs/fbs.h>
+#include <services/fbs/linked_font_config.h>
 
 #include <common/cvt.h>
 #include <common/log.h>
@@ -1137,19 +1138,65 @@ namespace eka2l1 {
 
         // Add fonts
         const auto extension = common::lowercase_string(eka2l1::path_extension(common::ucs2_to_utf8(path)));
-        epoc::adapter::font_file_adapter_kind adapter_kind = epoc::adapter::font_file_adapter_kind::none;
 
         if (extension == ".ttf") {
-            adapter_kind = epoc::adapter::font_file_adapter_kind::freetype;
-        } else if (extension == ".gdr") {
-            adapter_kind = epoc::adapter::font_file_adapter_kind::gdr;
+            return persistent_font_store.add_fonts(buf, epoc::adapter::font_file_adapter_kind::freetype);
         }
 
-        if (adapter_kind != epoc::adapter::font_file_adapter_kind::none) {
-            persistent_font_store.add_fonts(buf, adapter_kind);
+        if (extension == ".gdr") {
+            return persistent_font_store.add_fonts(buf, epoc::adapter::font_file_adapter_kind::gdr);
         }
 
-        return true;
+        // CFontStore::AddFileL offers the file to every rasterizer and keeps
+        // whichever one recognises it, so the extension is only ever a hint. A
+        // ROM font really can be named something else: the 5320 carries its
+        // Chinese font as s60sc.ccc, a TrueType file all the same, and skipping
+        // it leaves the device with no CJK glyphs at all.
+        for (const auto kind : { epoc::adapter::font_file_adapter_kind::freetype,
+                 epoc::adapter::font_file_adapter_kind::gdr }) {
+            if (persistent_font_store.add_fonts(buf, kind)) {
+                LOG_TRACE(SERVICE_FBS, "Loaded font file {} by content", common::ucs2_to_utf8(path));
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // Linked typefaces are assembled once every font is in the store: their
+    // components can sit on a different drive than the link.ini naming them.
+    void fbs_server::load_linked_fonts(eka2l1::io_system *io) {
+        for (drive_number drv = drive_z; drv >= drive_a; drv = static_cast<drive_number>(static_cast<int>(drv) - 1)) {
+            if (io->get_drive_entry(drv)) {
+                load_linked_fonts_from_directory(io, std::u16string{ drive_to_char16(drv) } + (kern->is_eka1() ? u":\\System\\Fonts\\" : u":\\Resource\\Fonts\\"));
+            }
+        }
+    }
+
+    void fbs_server::load_linked_fonts_from_directory(eka2l1::io_system *io, const std::u16string &fonts_folder_path) {
+        const std::u16string link_path = fonts_folder_path + u"link.ini";
+        symfile f = io->open_file(link_path, READ_MODE | BIN_MODE);
+
+        if (!f) {
+            return;
+        }
+
+        std::vector<std::uint8_t> buf(static_cast<std::size_t>(f->size()));
+        const bool read_ok = !buf.empty()
+            && (f->read_file(buf.data(), 1, static_cast<std::uint32_t>(buf.size())) == buf.size());
+
+        f->close();
+
+        if (!read_ok) {
+            return;
+        }
+
+        for (const auto &spec : epoc::parse_linked_font_config(epoc::decode_linked_font_config(buf.data(), buf.size()))) {
+            if (persistent_font_store.add_linked_font(spec.name, spec.component_names, spec.canonical)) {
+                LOG_TRACE(SERVICE_FBS, "Registered linked typeface {} from {}", common::ucs2_to_utf8(spec.name),
+                    common::ucs2_to_utf8(link_path));
+            }
+        }
     }
 
     void fbs_server::load_fonts(eka2l1::io_system *io) {

--- a/src/emu/services/src/fbs/impls/font.cpp
+++ b/src/emu/services/src/fbs/impls/font.cpp
@@ -24,7 +24,9 @@
 #include <services/fbs/fbs.h>
 #include <services/fbs/linked_font_config.h>
 
+#include <common/buffer.h>
 #include <common/cvt.h>
+#include <common/fileutils.h>
 #include <common/log.h>
 #include <common/path.h>
 #include <common/vecx.h>
@@ -1125,26 +1127,23 @@ namespace eka2l1 {
         }
     }
 
-    bool fbs_server::add_single_font(eka2l1::io_system *io, const std::u16string &path) {
-        symfile f = io->open_file(path, READ_MODE | BIN_MODE);
-        const std::uint64_t fsize = f->size();
+    // The name only picks the adapter, so it can be a guest or a host path.
+    bool fbs_server::add_font(common::ro_stream &stream, const std::string &name, const bool user_font) {
+        std::vector<std::uint8_t> buf(static_cast<std::size_t>(stream.size()));
 
-        std::vector<std::uint8_t> buf;
+        if (buf.empty() || (stream.read(buf.data(), buf.size()) != buf.size())) {
+            LOG_ERROR(SERVICE_FBS, "Unable to read font file {}", name);
+            return false;
+        }
 
-        buf.resize(fsize);
-        f->read_file(&buf[0], 1, static_cast<std::uint32_t>(buf.size()));
-
-        f->close();
-
-        // Add fonts
-        const auto extension = common::lowercase_string(eka2l1::path_extension(common::ucs2_to_utf8(path)));
+        const auto extension = common::lowercase_string(eka2l1::path_extension(name));
 
         if (extension == ".ttf") {
-            return persistent_font_store.add_fonts(buf, epoc::adapter::font_file_adapter_kind::freetype);
+            return persistent_font_store.add_fonts(buf, epoc::adapter::font_file_adapter_kind::freetype, user_font);
         }
 
         if (extension == ".gdr") {
-            return persistent_font_store.add_fonts(buf, epoc::adapter::font_file_adapter_kind::gdr);
+            return persistent_font_store.add_fonts(buf, epoc::adapter::font_file_adapter_kind::gdr, user_font);
         }
 
         // CFontStore::AddFileL offers the file to every rasterizer and keeps
@@ -1154,13 +1153,56 @@ namespace eka2l1 {
         // it leaves the device with no CJK glyphs at all.
         for (const auto kind : { epoc::adapter::font_file_adapter_kind::freetype,
                  epoc::adapter::font_file_adapter_kind::gdr }) {
-            if (persistent_font_store.add_fonts(buf, kind)) {
-                LOG_TRACE(SERVICE_FBS, "Loaded font file {} by content", common::ucs2_to_utf8(path));
+            if (persistent_font_store.add_fonts(buf, kind, user_font)) {
+                LOG_TRACE(SERVICE_FBS, "Loaded font file {} by content", name);
                 return true;
             }
         }
 
         return false;
+    }
+
+    bool fbs_server::add_single_font(eka2l1::io_system *io, const std::u16string &path) {
+        symfile f = io->open_file(path, READ_MODE | BIN_MODE);
+
+        if (!f) {
+            return false;
+        }
+
+        ro_file_stream stream(f.get());
+        add_font(stream, common::ucs2_to_utf8(path));
+
+        // A file we have no adapter for is not a failure: add_font_file_store
+        // reports this back to the guest, and it used to accept anything that
+        // existed.
+        return true;
+    }
+
+    // Fonts the user imported through a frontend. They live in <storage>/fonts,
+    // outside the guest drives, so one import serves every installed device and
+    // survives a device being reinstalled (which rewrites its Z drive).
+    void fbs_server::load_custom_fonts(const std::string &storage) {
+        const std::string fonts_folder_path = eka2l1::add_path(storage, "fonts");
+        auto folder = common::make_directory_iterator(fonts_folder_path, "");
+
+        if (!folder || !folder->is_valid()) {
+            return;
+        }
+
+        common::dir_entry entry;
+
+        while (folder->next_entry(entry) >= 0) {
+            if ((entry.name == ".") || (entry.name == "..")) {
+                continue;
+            }
+
+            const std::string font_path = eka2l1::add_path(fonts_folder_path, entry.name);
+            common::ro_std_file_stream stream(font_path, true);
+
+            if (stream.valid() && add_font(stream, entry.name, true)) {
+                LOG_TRACE(SERVICE_FBS, "Loaded custom font {}", font_path);
+            }
+        }
     }
 
     // Linked typefaces are assembled once every font is in the store: their

--- a/src/emu/services/src/fbs/impls/font_store.cpp
+++ b/src/emu/services/src/fbs/impls/font_store.cpp
@@ -35,7 +35,8 @@ namespace eka2l1::epoc {
         }
     }
 
-    bool font_store::add_fonts(std::vector<std::uint8_t> &buf, const epoc::adapter::font_file_adapter_kind adapter_kind) {
+    bool font_store::add_fonts(std::vector<std::uint8_t> &buf, const epoc::adapter::font_file_adapter_kind adapter_kind,
+        const bool user_font) {
         auto adapter = epoc::adapter::make_font_file_adapter(adapter_kind, buf);
 
         if (!adapter || !adapter->is_valid()) {
@@ -72,6 +73,7 @@ namespace eka2l1::epoc {
                 info.idx = static_cast<std::int32_t>(i);
                 info.face_attrib = attrib;
                 info.adapter = adapter.get();
+                info.user_font = user_font;
 
                 open_font_store.push_back(std::move(info));
             }
@@ -212,6 +214,65 @@ namespace eka2l1::epoc {
         font_adapters.push_back(std::move(adapter));
 
         return true;
+    }
+
+    void font_store::attach_user_font_fallbacks() {
+        struct fallback_font {
+            epoc::adapter::linked_font_file_adapter::component component_;
+            const open_font_face_attrib *attrib_;
+        };
+
+        std::vector<fallback_font> fallbacks;
+
+        for (auto &info : open_font_store) {
+            if (info.user_font) {
+                fallbacks.push_back({ { info.adapter, info.idx }, &info.face_attrib });
+            }
+        }
+
+        if (fallbacks.empty()) {
+            return;
+        }
+
+        for (auto &info : open_font_store) {
+            if (info.user_font) {
+                continue;
+            }
+
+            std::vector<epoc::adapter::linked_font_file_adapter::component> components;
+            components.push_back({ info.adapter, info.idx });
+
+            open_font_face_attrib attrib = info.face_attrib;
+
+            for (const auto &fallback : fallbacks) {
+                // A glyph bitmap reaches the guest in the format the font as a
+                // whole declares, so a component is only of use where the
+                // linked adapter can present its glyphs as that format.
+                if (!epoc::adapter::can_present_glyph_as(fallback.component_.adapter_->get_output_bitmap_type(),
+                        info.adapter->get_output_bitmap_type())) {
+                    continue;
+                }
+
+                components.push_back(fallback.component_);
+
+                for (std::size_t word = 0; word < 4; word++) {
+                    attrib.coverage[word] |= fallback.attrib_->coverage[word];
+                }
+            }
+
+            if (components.size() == 1) {
+                continue;
+            }
+
+            info.face_attrib = attrib;
+
+            auto adapter = std::make_unique<epoc::adapter::linked_font_file_adapter>(std::move(components), 0, attrib);
+
+            info.adapter = adapter.get();
+            info.idx = 0;
+
+            font_adapters.push_back(std::move(adapter));
+        }
     }
 
     open_font_info *font_store::seek_the_font_by_uid(const epoc::uid the_uid, open_font_metrics &target_metric, std::uint32_t *metric_identifier) {

--- a/src/emu/services/src/fbs/impls/font_store.cpp
+++ b/src/emu/services/src/fbs/impls/font_store.cpp
@@ -17,14 +17,29 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <services/fbs/adapter/linked_font_adapter.h>
 #include <services/fbs/font_store.h>
 
 namespace eka2l1::epoc {
-    void font_store::add_fonts(std::vector<std::uint8_t> &buf, const epoc::adapter::font_file_adapter_kind adapter_kind) {
+    static void fill_typeface_flags(const open_font_face_attrib &attrib, epoc::typeface_info &info) {
+        if (attrib.style & epoc::open_font_face_attrib::serif) {
+            info.flags |= epoc::typeface_info::tf_serif;
+        }
+
+        if (!(attrib.style & epoc::open_font_face_attrib::mono_width)) {
+            info.flags |= epoc::typeface_info::tf_propotional;
+        }
+
+        if (attrib.style & epoc::open_font_face_attrib::symbol) {
+            info.flags |= epoc::typeface_info::tf_symbol;
+        }
+    }
+
+    bool font_store::add_fonts(std::vector<std::uint8_t> &buf, const epoc::adapter::font_file_adapter_kind adapter_kind) {
         auto adapter = epoc::adapter::make_font_file_adapter(adapter_kind, buf);
 
-        if (!adapter->is_valid()) {
-            return;
+        if (!adapter || !adapter->is_valid()) {
+            return false;
         }
 
         for (std::size_t i = 0; i < adapter->count(); i++) {
@@ -71,17 +86,7 @@ namespace eka2l1::epoc {
                     typefaces[i].max_height_in_twips_ = common::max<std::int32_t>(typefaces[i].max_height_in_twips_, metrics.max_height); 
                     typefaces[i].min_height_in_twips_ = common::min<std::int32_t>(typefaces[i].min_height_in_twips_, attrib.min_size_in_pixels);
 
-                    if (attrib.style & epoc::open_font_face_attrib::serif) {
-                        typefaces[i].info_.flags |= epoc::typeface_info::tf_serif;
-                    }
-
-                    if (!(attrib.style & epoc::open_font_face_attrib::mono_width)) {
-                        typefaces[i].info_.flags |= epoc::typeface_info::tf_propotional;
-                    }
-
-                    if (attrib.style & epoc::open_font_face_attrib::symbol) {
-                        typefaces[i].info_.flags |= epoc::typeface_info::tf_symbol;
-                    }
+                    fill_typeface_flags(attrib, typefaces[i].info_);
 
                     found_typeface = true;
                     break;
@@ -92,17 +97,7 @@ namespace eka2l1::epoc {
                 epoc::typeface_support support;
                 support.info_.name.assign(nullptr, fam_name);
 
-                if (attrib.style & epoc::open_font_face_attrib::serif) {
-                    support.info_.flags |= epoc::typeface_info::tf_serif;
-                }
-
-                if (!(attrib.style & epoc::open_font_face_attrib::mono_width)) {
-                    support.info_.flags |= epoc::typeface_info::tf_propotional;
-                }
-
-                if (attrib.style & epoc::open_font_face_attrib::symbol) {
-                    support.info_.flags |= epoc::typeface_info::tf_symbol;
-                }
+                fill_typeface_flags(attrib, support.info_);
 
                 support.num_heights_ = 1;
                 support.is_scalable_ = adapter->vectorizable();
@@ -114,6 +109,109 @@ namespace eka2l1::epoc {
         }
 
         font_adapters.push_back(std::move(adapter));
+        return true;
+    }
+
+    bool font_store::add_linked_font(const std::u16string &name, const std::vector<std::u16string> &component_names,
+        const std::size_t canonical) {
+        if (component_names.empty() || (canonical >= component_names.size())) {
+            return false;
+        }
+
+        for (auto &info : open_font_store) {
+            if (common::compare_ignore_case(info.face_attrib.name.to_std_string(nullptr), name) == 0) {
+                return false;
+            }
+        }
+
+        std::vector<epoc::adapter::linked_font_file_adapter::component> components;
+        open_font_info *canonical_info = nullptr;
+        std::uint32_t coverage[4] = { 0, 0, 0, 0 };
+
+        for (std::size_t i = 0; i < component_names.size(); i++) {
+            open_font_info *found = nullptr;
+
+            // link.ini names a component either in full ("Nokia Sans S60
+            // SemiBold") or by family alone ("MHeiM-C-GB18030-S60"), the same
+            // two spellings CFontStore::GetNearestOpenFontInPixelsByFontName
+            // accepts and in the same order of preference.
+            for (auto &info : open_font_store) {
+                if (common::compare_ignore_case(info.face_attrib.name.to_std_string(nullptr), component_names[i]) == 0) {
+                    found = &info;
+                    break;
+                }
+            }
+
+            if (!found) {
+                for (auto &info : open_font_store) {
+                    if (common::compare_ignore_case(info.face_attrib.fam_name.to_std_string(nullptr), component_names[i]) == 0) {
+                        found = &info;
+                        break;
+                    }
+                }
+            }
+
+            // A variant only ships the fonts it needs, while link.ini describes
+            // every variant, so a missing component just means this typeface is
+            // not for this device.
+            if (!found) {
+                return false;
+            }
+
+            if (i == canonical) {
+                canonical_info = found;
+            }
+
+            for (std::size_t word = 0; word < 4; word++) {
+                coverage[word] |= found->face_attrib.coverage[word];
+            }
+
+            components.push_back({ found->adapter, found->idx });
+        }
+
+        open_font_face_attrib attrib = canonical_info->face_attrib;
+        const std::u16string canonical_family = attrib.fam_name.to_std_string(nullptr);
+        attrib.name.assign(nullptr, name);
+        attrib.fam_name.assign(nullptr, name);
+        attrib.local_full_name.assign(nullptr, name);
+        attrib.local_full_fam_name.assign(nullptr, name);
+        std::copy(coverage, coverage + 4, attrib.coverage);
+
+        auto adapter = std::make_unique<epoc::adapter::linked_font_file_adapter>(std::move(components), canonical, attrib);
+
+        open_font_info info;
+        info.family = name;
+        info.idx = 0;
+        info.face_attrib = attrib;
+        info.adapter = adapter.get();
+
+        // CFontStore::LoadFontsAtStartupL loads the linked fonts before the
+        // rest of resource\\fonts, and equally good candidates are settled by
+        // taking the first, so a linked typeface has to sit ahead of the plain
+        // fonts it was assembled from. We can only build it once those are
+        // loaded, hence the insert.
+        open_font_store.insert(open_font_store.begin() + linked_font_count_, std::move(info));
+        linked_font_count_++;
+
+        // Present it to typeface enumeration the same way the canonical
+        // component is, so a client listing typefaces can find it by name.
+        epoc::typeface_support support{};
+
+        for (auto &typeface : typefaces) {
+            if (common::compare_ignore_case(typeface.info_.name.to_std_string(nullptr), canonical_family) == 0) {
+                support = typeface;
+                break;
+            }
+        }
+
+        support.info_.name.assign(nullptr, name);
+        support.info_.flags = 0;
+        fill_typeface_flags(attrib, support.info_);
+
+        typefaces.push_back(std::move(support));
+        font_adapters.push_back(std::move(adapter));
+
+        return true;
     }
 
     open_font_info *font_store::seek_the_font_by_uid(const epoc::uid the_uid, open_font_metrics &target_metric, std::uint32_t *metric_identifier) {
@@ -127,83 +225,130 @@ namespace eka2l1::epoc {
         return nullptr;
     }
 
+    static std::uint32_t coverage_extent(const open_font_face_attrib &attrib) {
+        std::uint32_t bits = 0;
+
+        for (const std::uint32_t word : attrib.coverage) {
+            bits += common::count_bit_set(word);
+        }
+
+        return bits;
+    }
+
+    // Port of CFontStore's MatchFontSpecsInPixels (fontstore/src/FNTSTORE.CPP):
+    // the higher the return value, the better the candidate. The weights are
+    // Symbian's, deliberately small and close together -- a name match is worth
+    // more than every style attribute put together, and being off by a few
+    // pixels costs more than any of them.
+    //
+    // Two of Symbian's terms are missing rather than reweighted: the bitmap
+    // type and the outline/shadow effects, neither of which a face attribute
+    // carries here. They score every candidate identically, so the ranking is
+    // the same without them.
+    int match_font_spec(const open_font_face_attrib &candidate, const std::u16string &candidate_name,
+        const epoc::font_spec_base &spec, const std::int32_t candidate_height) {
+        static constexpr int SCORE_FOR_NAME = 10;
+        static constexpr int MAX_SCORE_FOR_HEIGHT = 10;
+        static constexpr int SCORE_FOR_ITALIC = 2;
+        static constexpr int SCORE_FOR_BOLD = 2;
+        static constexpr int SCORE_FOR_MONO_SPACE = 3;
+        static constexpr int SCORE_FOR_SERIF = 1;
+
+        const std::u16string wanted_name = const_cast<epoc::font_spec_base &>(spec).tf.name.to_std_string(nullptr);
+        const std::uint32_t style = static_cast<const epoc::font_spec_v1 &>(spec).style.flags;
+        const std::uint32_t typeface_flags = const_cast<epoc::font_spec_base &>(spec).tf.flags;
+
+        int score = 0;
+
+        if (!wanted_name.empty() && (common::compare_ignore_case(candidate_name, wanted_name) == 0)) {
+            score += SCORE_FOR_NAME;
+        }
+
+        score += MAX_SCORE_FOR_HEIGHT - common::abs(spec.height - candidate_height);
+
+        const bool candidate_italic = (candidate.style & epoc::open_font_face_attrib::italic);
+        const bool candidate_bold = (candidate.style & epoc::open_font_face_attrib::bold);
+        const bool candidate_mono = (candidate.style & epoc::open_font_face_attrib::mono_width);
+        const bool candidate_serif = (candidate.style & epoc::open_font_face_attrib::serif);
+
+        if (candidate_italic == static_cast<bool>(style & epoc::font_style_base::italic)) {
+            score += SCORE_FOR_ITALIC;
+        }
+
+        if (candidate_bold == static_cast<bool>(style & epoc::font_style_base::bold)) {
+            score += SCORE_FOR_BOLD;
+        }
+
+        if (candidate_mono == !(typeface_flags & epoc::typeface_info::tf_propotional)) {
+            score += SCORE_FOR_MONO_SPACE;
+        }
+
+        if (candidate_serif == static_cast<bool>(typeface_flags & epoc::typeface_info::tf_serif)) {
+            score += SCORE_FOR_SERIF;
+        }
+
+        return score;
+    }
+
+    // CFontStore::GetNearestFontToDesignHeightInPixels tries the requested name
+    // first (GetNearestOpenFontInPixelsByFontName) and only ranks candidates
+    // when that finds nothing (GetNearestOpenFontInPixelsBySimilarity).
     open_font_info *font_store::seek_the_open_font(epoc::font_spec_base &spec) {
-        open_font_info *best = nullptr;
-        int best_score = -99999999;
+        const std::u16string wanted_name = spec.tf.name.to_std_string(nullptr);
+        const std::uint32_t style = static_cast<epoc::font_spec_v1 &>(spec).style.flags;
 
-        const std::u16string my_name = spec.tf.name.to_std_string(nullptr);
-        std::int32_t spec_height = spec.height;
+        if (!wanted_name.empty()) {
+            const bool want_italic = (style & epoc::font_style_base::italic);
+            const bool want_bold = (style & epoc::font_style_base::bold);
 
-        for (auto &info : open_font_store) {
-            bool maybe_same_family = (my_name.find(info.family) != std::string::npos);
-            int score = 0;
+            // Full face name, then family name. Both also require the slant and
+            // the weight to be the ones asked for, so "Nokia Sans S60" in the
+            // regular does not answer a request for the bold.
+            for (const bool by_family : { false, true }) {
+                for (auto &info : open_font_store) {
+                    const std::u16string candidate_name = by_family
+                        ? info.face_attrib.fam_name.to_std_string(nullptr)
+                        : info.face_attrib.name.to_std_string(nullptr);
 
-            // Better returns me!
-            if (info.face_attrib.name.to_std_string(nullptr) == my_name) {
-                return &info;
-            }
-
-            if (maybe_same_family) {
-                score += 10000;
-            }
-
-            std::optional<open_font_metrics> target_metric = info.adapter->get_nearest_supported_metric(info.idx, static_cast<std::uint16_t>(spec_height));
-
-            if (target_metric.has_value()) {
-                // Font that is not vectorizable, according to test, can't resize
-                std::uint32_t subtract_score = (common::abs(spec.height - target_metric->design_height)) * 100;
-                if (info.face_attrib.coverage[1] & 0x8000000) {
-                    // NOTE: Some older games that use special character like Chinese seems to prefer smaller font
-                    // more despite the twips size (since their character is larger in display). Here CJK flag of
-                    // coverage is checked
-                    // But I don't want to make it choose too big fonts like 1000 or too small like 1.
-                    // So here we have the unit divided by 8, reducing penalty. Should help some fonts like
-                    // 11x12 or 15x16 to choose 11x12... 
-                    // I think the twip divider for epocv6 is close enough.
-                    // Take N-Gage for example, with 130ppi, it should be around 11 or 12 if you do the math
-                    subtract_score /= 8;
+                    if ((common::compare_ignore_case(candidate_name, wanted_name) == 0)
+                        && (static_cast<bool>(info.face_attrib.style & epoc::open_font_face_attrib::italic) == want_italic)
+                        && (static_cast<bool>(info.face_attrib.style & epoc::open_font_face_attrib::bold) == want_bold)) {
+                        return &info;
+                    }
                 }
-                score -= subtract_score;
-            }
-
-            // Match the flags. This is also an important factor.
-            if (info.face_attrib.style & epoc::open_font_face_attrib::italic) {
-                // Extra flags are not welcome
-                if ((static_cast<epoc::font_spec_v1 &>(spec).style.flags & epoc::font_style_base::italic)) {
-                    score += 5000;
-                } else {
-                    score -= 3000;
-                }
-            }
-
-            if (info.face_attrib.style & epoc::open_font_face_attrib::bold) {
-                if (static_cast<epoc::font_spec_v1 &>(spec).style.flags & epoc::font_style_base::bold) {
-                    score += 5000;
-                } else {
-                    score -= 3000;
-                }
-            }
-
-            static constexpr std::uint32_t COVERAGE_WORD_COUNT = sizeof(info.face_attrib.coverage) / sizeof(info.face_attrib.coverage[0]);
-
-            // The more coverage, the more varieties of the font.
-            for (std::size_t i = 0; i < COVERAGE_WORD_COUNT; i++) {
-                std::uint32_t coverage_patched = info.face_attrib.coverage[i];
-
-                // Symbols take multiple bits, patch it out, give less scores
-                if ((i == 1) && (coverage_patched & 0xFFFE)) {
-                    score += 40;
-                    coverage_patched &= ~0xFFFE;
-                }
-
-                score += 100 * common::count_bit_set(info.face_attrib.coverage[i]);
-            }
-
-            if (score > best_score) {
-                best = &info;
-                best_score = score;
             }
         }
+
+        open_font_info *best = nullptr;
+        int best_score = 0;
+        std::uint32_t best_extent = 0;
+
+        for (auto &info : open_font_store) {
+            std::optional<open_font_metrics> target_metric = info.adapter->get_nearest_supported_metric(info.idx,
+                static_cast<std::uint16_t>(spec.height));
+
+            const std::int32_t candidate_height = target_metric.has_value() ? target_metric->design_height : spec.height;
+            // Symbian scores the name of the spec a font file reports, which
+            // is the typeface name -- the family, not the full face name.
+            const int score = match_font_spec(info.face_attrib, info.face_attrib.fam_name.to_std_string(nullptr), spec,
+                candidate_height);
+
+            // Symbian settles a tie by taking the candidate it met first, its
+            // font files being in load order (CFontStore::LoadFontsAtStartupL,
+            // which is also why linked typefaces sit at the front of the store
+            // here). That order is the host filesystem's, not the device's, so
+            // ties are broken by coverage instead: a request naming no typeface
+            // should not be answered by a digits-only or symbol face just
+            // because the directory happened to list it first.
+            const std::uint32_t extent = coverage_extent(info.face_attrib);
+
+            if (!best || (score > best_score) || ((score == best_score) && (extent > best_extent))) {
+                best = &info;
+                best_score = score;
+                best_extent = extent;
+            }
+        }
+
 
         return best;
     }

--- a/src/emu/services/src/fbs/impls/linked_font_config.cpp
+++ b/src/emu/services/src/fbs/impls/linked_font_config.cpp
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <services/fbs/linked_font_config.h>
+
+#include <common/cvt.h>
+
+#include <map>
+
+namespace eka2l1::epoc {
+    struct linked_font_element {
+        std::u16string linked_name;
+        std::u16string component_name;
+        bool canonical = false;
+    };
+
+    static std::u16string trim(const std::u16string &str) {
+        std::size_t start = 0;
+        std::size_t end = str.length();
+
+        while ((start < end) && ((str[start] == u' ') || (str[start] == u'\t'))) {
+            start++;
+        }
+
+        while ((end > start) && ((str[end - 1] == u' ') || (str[end - 1] == u'\t'))) {
+            end--;
+        }
+
+        return str.substr(start, end - start);
+    }
+
+    // NOTE: S60's own parser (AknFontProvider's GetGroupCanonicalDetails) takes
+    // every unrecognised token as the component name, so the "SNSemiBold" field
+    // overwrites the typeface name it read moments earlier. Keep the first
+    // unrecognised token instead: that is the field naming a typeface the
+    // device actually ships.
+    static bool parse_line(const std::u16string &line, linked_font_element &element) {
+        std::size_t start = 0;
+        bool has_name = false;
+
+        while (start < line.length()) {
+            std::size_t end = line.find(u':', start);
+
+            if (end == std::u16string::npos) {
+                end = line.length();
+            }
+
+            const std::u16string token = trim(line.substr(start, end - start));
+            start = end + 1;
+
+            if (token.empty()) {
+                continue;
+            }
+
+            if (token.rfind(u"GROUP", 0) == 0) {
+                continue;
+            } else if (token.rfind(u"CANONICAL", 0) == 0) {
+                element.canonical = (token.find(u'1') != std::u16string::npos);
+            } else if (token.rfind(u"FN", 0) == 0) {
+                element.linked_name = token.substr(2);
+            } else if ((token == u"REGULAR") || (token == u"BOLD") || (token.rfind(u"SN", 0) == 0)) {
+                continue;
+            } else if (!has_name) {
+                element.component_name = token;
+                has_name = true;
+            }
+        }
+
+        return has_name && !element.linked_name.empty();
+    }
+
+    std::u16string decode_linked_font_config(const std::uint8_t *data, const std::size_t size) {
+        if ((size >= 2) && (data[0] == 0xFF) && (data[1] == 0xFE)) {
+            return std::u16string(reinterpret_cast<const char16_t *>(data + 2), (size - 2) / sizeof(char16_t));
+        }
+
+        return common::utf8_to_ucs2(std::string(reinterpret_cast<const char *>(data), size));
+    }
+
+    std::vector<linked_font_spec> parse_linked_font_config(const std::u16string &content) {
+        // The map only gathers the lines that belong together -- a section
+        // interleaves the elements of several typefaces -- while `order` keeps
+        // the typefaces in the order the file introduces them.
+        std::vector<std::u16string> order;
+        std::map<std::u16string, std::vector<linked_font_element>> elements;
+
+        std::size_t line_start = 0;
+
+        while (line_start <= content.length()) {
+            std::size_t line_end = content.find_first_of(u"\r\n", line_start);
+
+            if (line_end == std::u16string::npos) {
+                line_end = content.length();
+            }
+
+            const std::u16string line = content.substr(line_start, line_end - line_start);
+            line_start = line_end + 1;
+
+            linked_font_element element;
+
+            if ((line.find(u'[') == std::u16string::npos) && parse_line(line, element)) {
+                if (elements.find(element.linked_name) == elements.end()) {
+                    order.push_back(element.linked_name);
+                }
+
+                elements[element.linked_name].push_back(element);
+            }
+        }
+
+        std::vector<linked_font_spec> specs;
+
+        for (const auto &linked_name : order) {
+            linked_font_spec spec;
+            spec.name = linked_name;
+
+            for (const auto &element : elements[linked_name]) {
+                if (element.canonical) {
+                    spec.canonical = spec.component_names.size();
+                }
+
+                spec.component_names.push_back(element.component_name);
+            }
+
+            specs.push_back(std::move(spec));
+        }
+
+        return specs;
+    }
+}

--- a/src/tests/epoc/CMakeLists.txt
+++ b/src/tests/epoc/CMakeLists.txt
@@ -2,6 +2,7 @@ set(CORE_TEST_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/mem.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/vfs.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/e32img.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/loader/gdr.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/mbm.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/mif.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/nvg.cpp

--- a/src/tests/epoc/CMakeLists.txt
+++ b/src/tests/epoc/CMakeLists.txt
@@ -10,6 +10,8 @@ set(CORE_TEST_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/spi.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/applist/registeration.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/fbs/bitmap.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/services/fbs/fontmatch.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/services/fbs/linkedfont.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/svg_icon.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/centralrepo/crebinloader.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/centralrepo/creiniloader.cpp

--- a/src/tests/epoc/loader/gdr.cpp
+++ b/src/tests/epoc/loader/gdr.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Header identification in the bitmap font store parser. A font file is offered
+// to each rasterizer in turn until one recognises it, so the parser has to be
+// able to say no to a file that is not a font store -- everything after the
+// header is counts and offsets, and reading those out of unrelated bytes walks
+// the parser off the end of the buffer.
+
+#include <catch2/catch.hpp>
+#include <loader/gdr.h>
+
+#include <common/buffer.h>
+
+#include <cstdint>
+#include <vector>
+
+using namespace eka2l1;
+
+namespace {
+    // fnttran writes these as literal constants at the head of every font store:
+    // bitmapfonttools/src/FNTRECRD.CPP, FontStoreFile::ExternalizeHeader, with the
+    // values in bitmapfonttools/inc/UID.H.
+    constexpr std::uint32_t STORE_WRITE_ONCE_LAYOUT_UID = 268435511;
+    constexpr std::uint32_t FONT_STORE_FILE_UID = 268435513;
+    constexpr std::uint32_t NULL_UID = 0;
+    constexpr std::uint32_t FONT_STORE_FILE_CHECKSUM = 0x47393853;
+
+    void append32(std::vector<std::uint8_t> &buf, const std::uint32_t value) {
+        for (int i = 0; i < 4; i++) {
+            buf.push_back(static_cast<std::uint8_t>((value >> (i * 8)) & 0xFF));
+        }
+    }
+
+    // A font store holding no fonts: the identifying header, the five header
+    // words that carry no constants, then an empty copyright list, an empty font
+    // bitmap list and an empty typeface list.
+    std::vector<std::uint8_t> make_empty_store(const std::uint32_t layout_uid = STORE_WRITE_ONCE_LAYOUT_UID,
+        const std::uint32_t file_uid = FONT_STORE_FILE_UID,
+        const std::uint32_t checksum = FONT_STORE_FILE_CHECKSUM) {
+        std::vector<std::uint8_t> buf;
+
+        append32(buf, layout_uid);
+        append32(buf, file_uid);
+        append32(buf, NULL_UID);
+        append32(buf, checksum);
+
+        append32(buf, 0); // id offset
+        append32(buf, 0); // fnttran version
+        append32(buf, 0); // collection uid
+        append32(buf, 0); // pixel aspect ratio
+        append32(buf, 0); // data stream id
+
+        append32(buf, 0); // copyright strings
+        append32(buf, 0); // font bitmaps
+        append32(buf, 0); // typefaces
+
+        return buf;
+    }
+
+    bool parse(std::vector<std::uint8_t> buf) {
+        common::ro_buf_stream stream(buf.data(), buf.size());
+
+        loader::gdr::file_store store;
+        return loader::gdr::parse_store(reinterpret_cast<common::ro_stream *>(&stream), store);
+    }
+}
+
+TEST_CASE("gdr_store_header_is_identified", "gdr_file") {
+    REQUIRE(parse(make_empty_store()));
+}
+
+TEST_CASE("gdr_rejects_a_file_that_is_not_a_font_store", "gdr_file") {
+    // What a .ttf, or anything else offered to this parser, looks like.
+    REQUIRE(!parse(std::vector<std::uint8_t>(256, 0x5A)));
+}
+
+TEST_CASE("gdr_rejects_a_store_with_the_wrong_identifiers", "gdr_file") {
+    // Each of the three constants on its own is enough to disqualify the file,
+    // so a near-miss -- a printer store, which shares the layout uid -- cannot
+    // be read as a font store.
+    REQUIRE(!parse(make_empty_store(STORE_WRITE_ONCE_LAYOUT_UID + 1)));
+    REQUIRE(!parse(make_empty_store(STORE_WRITE_ONCE_LAYOUT_UID, 268435514))); // KPdrStoreFileUid
+    REQUIRE(!parse(make_empty_store(STORE_WRITE_ONCE_LAYOUT_UID, FONT_STORE_FILE_UID, 0x4739A38F))); // KPdrStoreFileChecksum
+}
+
+TEST_CASE("gdr_rejects_a_truncated_header", "gdr_file") {
+    std::vector<std::uint8_t> buf = make_empty_store();
+    buf.resize(10);
+
+    REQUIRE(!parse(buf));
+}

--- a/src/tests/epoc/services/fbs/fontmatch.cpp
+++ b/src/tests/epoc/services/fbs/fontmatch.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch.hpp>
+
+#include <services/fbs/font_store.h>
+
+using namespace eka2l1;
+
+namespace {
+    epoc::font_spec_v1 make_spec(const std::u16string &name, const std::int32_t height, const std::uint32_t style_flags,
+        const std::uint32_t typeface_flags = epoc::typeface_info::tf_propotional) {
+        epoc::font_spec_v1 spec{};
+
+        spec.tf.name.assign(nullptr, name);
+        spec.tf.flags = typeface_flags;
+        spec.height = height;
+        spec.style.flags = style_flags;
+
+        return spec;
+    }
+
+    epoc::open_font_face_attrib make_face(const std::u16string &name, const std::int32_t style) {
+        epoc::open_font_face_attrib attrib{};
+
+        attrib.name.assign(nullptr, name);
+        attrib.fam_name.assign(nullptr, name);
+        attrib.style = style;
+
+        return attrib;
+    }
+}
+
+TEST_CASE("font_match_prefers_name_over_every_style_attribute", "fbs") {
+    // MatchFontSpecsInPixels pays 10 for the name and 2 for the weight, so a
+    // font asked for by name wins even when another one matches the weight.
+    epoc::font_spec_v1 spec = make_spec(u"MHeiM-C-GB18030-S60", 20, epoc::font_style_base::bold);
+
+    const epoc::open_font_face_attrib named = make_face(u"MHeiM-C-GB18030-S60", 0);
+    const epoc::open_font_face_attrib bold = make_face(u"Nokia Sans S60 SemiBold", epoc::open_font_face_attrib::bold);
+
+    REQUIRE(epoc::match_font_spec(named, u"MHeiM-C-GB18030-S60", spec, 20)
+        > epoc::match_font_spec(bold, u"Nokia Sans S60 SemiBold", spec, 20));
+}
+
+TEST_CASE("font_match_costs_more_for_height_than_for_weight", "fbs") {
+    // Height is worth 10 - |diff|, so being two pixels off already outweighs
+    // the 2 points a weight match is worth. The old scoring had bold override
+    // up to fifty pixels of difference.
+    epoc::font_spec_v1 spec = make_spec(u"", 20, epoc::font_style_base::bold);
+
+    const epoc::open_font_face_attrib bold = make_face(u"Bitmap Bold", epoc::open_font_face_attrib::bold);
+    const epoc::open_font_face_attrib regular = make_face(u"Bitmap Regular", 0);
+
+    REQUIRE(epoc::match_font_spec(regular, u"Bitmap Regular", spec, 20)
+        > epoc::match_font_spec(bold, u"Bitmap Bold", spec, 17));
+
+    // At the same height the weight decides after all.
+    REQUIRE(epoc::match_font_spec(bold, u"Bitmap Bold", spec, 20)
+        > epoc::match_font_spec(regular, u"Bitmap Regular", spec, 20));
+}
+
+TEST_CASE("font_match_scores_italic_mono_and_serif", "fbs") {
+    epoc::font_spec_v1 upright = make_spec(u"", 20, 0);
+    epoc::font_spec_v1 italic = make_spec(u"", 20, epoc::font_style_base::italic);
+
+    const epoc::open_font_face_attrib slanted = make_face(u"Face Italic", epoc::open_font_face_attrib::italic);
+    const epoc::open_font_face_attrib plain = make_face(u"Face", 0);
+
+    REQUIRE(epoc::match_font_spec(slanted, u"Face Italic", italic, 20) > epoc::match_font_spec(plain, u"Face", italic, 20));
+    REQUIRE(epoc::match_font_spec(plain, u"Face", upright, 20) > epoc::match_font_spec(slanted, u"Face Italic", upright, 20));
+
+    // Monospace is rated above serif, as it changes the layout rather than
+    // just the look.
+    epoc::font_spec_v1 mono_wanted = make_spec(u"", 20, 0, 0);
+    const epoc::open_font_face_attrib mono = make_face(u"Mono", epoc::open_font_face_attrib::mono_width);
+    const epoc::open_font_face_attrib serif = make_face(u"Serif", epoc::open_font_face_attrib::serif);
+
+    REQUIRE(epoc::match_font_spec(mono, u"Mono", mono_wanted, 20) > epoc::match_font_spec(serif, u"Serif", mono_wanted, 20));
+}
+
+TEST_CASE("font_match_ignores_name_when_none_was_asked_for", "fbs") {
+    // An empty typeface name means "whatever fits", and must not hand the 10
+    // points to a font whose own name happens to be empty too.
+    epoc::font_spec_v1 spec = make_spec(u"", 20, 0);
+
+    const epoc::open_font_face_attrib unnamed = make_face(u"", 0);
+    const epoc::open_font_face_attrib named = make_face(u"Nokia Sans S60", 0);
+
+    REQUIRE(epoc::match_font_spec(unnamed, u"", spec, 20) == epoc::match_font_spec(named, u"Nokia Sans S60", spec, 20));
+}

--- a/src/tests/epoc/services/fbs/linkedfont.cpp
+++ b/src/tests/epoc/services/fbs/linkedfont.cpp
@@ -1,0 +1,441 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch.hpp>
+
+#include <services/fbs/adapter/linked_font_adapter.h>
+#include <services/fbs/linked_font_config.h>
+
+#include <set>
+
+using namespace eka2l1;
+
+// A stanza of the X7 (rm-707) ROM's Z:\Resource\Fonts\link.ini, which pairs
+// each Nokia Sans face with the simplified Chinese font.
+static const std::u16string SCHR_SECTION =
+    u"[SCHR_LINK_START]\r\n"
+    u"Nokia Sans S60 Regular:GROUP2:CANONICAL1:REGULAR:SNRegular:FNNOKSCHRSANSRLF:\r\n"
+    u"MHeiM-C-GB18030-S60:GROUP1:CANONICAL0:REGULAR:SNRegular:FNNOKSCHRSANSRLF:\r\n"
+    u"Nokia Sans S60 SemiBold:GROUP2:CANONICAL1:REGULAR:SNSemiBold:FNNOKSCHRSANSSBLF:\r\n"
+    u"MHeiM-C-GB18030-S60:GROUP1:CANONICAL0:REGULAR:SNSemiBold:FNNOKSCHRSANSSBLF:\r\n"
+    u"[SCHR_LINK_STOP]\r\n";
+
+TEST_CASE("linked_font_config_parses_typefaces", "fbs") {
+    const std::vector<epoc::linked_font_spec> specs = epoc::parse_linked_font_config(SCHR_SECTION);
+
+    REQUIRE(specs.size() == 2);
+
+    // The FN field names the typeface, and the typefaces keep the order the
+    // file introduces them in.
+    REQUIRE(specs[0].name == u"NOKSCHRSANSRLF");
+    REQUIRE(specs[1].name == u"NOKSCHRSANSSBLF");
+
+    // Components stay in file order: the Latin font is consulted first, so
+    // Latin text keeps its own face and only the rest falls to the CJK font.
+    REQUIRE(specs[1].component_names.size() == 2);
+    REQUIRE(specs[1].component_names[0] == u"Nokia Sans S60 SemiBold");
+    REQUIRE(specs[1].component_names[1] == u"MHeiM-C-GB18030-S60");
+
+    // CANONICAL1 is on the Latin component, and the SN field must not be
+    // mistaken for a typeface name (S60's own parser does exactly that).
+    REQUIRE(specs[1].canonical == 0);
+}
+
+TEST_CASE("linked_font_config_ignores_unknown_sections", "fbs") {
+    // Section markers are not honoured: every variant's typefaces are offered,
+    // and the store drops the ones this ROM has no fonts for.
+    const std::vector<epoc::linked_font_spec> specs = epoc::parse_linked_font_config(
+        u"[TCHKHR_LINK_START]\r\n"
+        u"Nokia Sans S60 Regular:GROUP2:CANONICAL1:REGULAR:SNRegular:FNNOKTCHKHRSANSRLF:\r\n"
+        u"MHeiM-C-B5HK-S60:GROUP1:CANONICAL0:REGULAR:SNRegular:FNNOKTCHKHRSANSRLF:\r\n"
+        u"[TCHKHR_LINK_STOP]\r\n");
+
+    REQUIRE(specs.size() == 1);
+    REQUIRE(specs[0].name == u"NOKTCHKHRSANSRLF");
+    REQUIRE(specs[0].component_names.size() == 2);
+}
+
+TEST_CASE("linked_font_config_skips_incomplete_lines", "fbs") {
+    // A line without an FN field names no typeface, and a stray blank or
+    // comment-looking line is not an element either.
+    const std::vector<epoc::linked_font_spec> specs = epoc::parse_linked_font_config(
+        u"\r\n"
+        u"Nokia Sans S60 Regular:GROUP2:CANONICAL1:\r\n"
+        u"   \r\n"
+        u"Nokia Sans S60 Regular:GROUP2:CANONICAL1:REGULAR:SNRegular:FNONLYONE:\r\n");
+
+    REQUIRE(specs.size() == 1);
+    REQUIRE(specs[0].name == u"ONLYONE");
+    REQUIRE(specs[0].component_names.size() == 1);
+}
+
+TEST_CASE("linked_font_config_decodes_utf16_and_utf8", "fbs") {
+    const std::uint8_t utf16[] = { 0xFF, 0xFE, 'F', 0x00, 'N', 0x00, 'X', 0x00 };
+    REQUIRE(epoc::decode_linked_font_config(utf16, sizeof(utf16)) == u"FNX");
+
+    const std::uint8_t utf8[] = { 'F', 'N', 'X' };
+    REQUIRE(epoc::decode_linked_font_config(utf8, sizeof(utf8)) == u"FNX");
+}
+
+namespace {
+    // Stands in for a real font file: knows a fixed set of codepoints and hands
+    // out a bitmap it owns, so bitmap ownership can be checked.
+    struct fake_font_adapter : public epoc::adapter::font_file_adapter_base {
+        std::set<std::int32_t> codepoints_;
+        std::uint32_t advance_;
+        std::size_t live_bitmaps_ = 0;
+
+        explicit fake_font_adapter(std::set<std::int32_t> codepoints, const std::uint32_t advance)
+            : codepoints_(std::move(codepoints))
+            , advance_(advance) {
+        }
+
+        bool is_valid() override {
+            return true;
+        }
+
+        bool vectorizable() const override {
+            return true;
+        }
+
+        std::size_t count() override {
+            return 1;
+        }
+
+        bool get_face_attrib(const std::size_t idx, epoc::open_font_face_attrib &face_attrib) override {
+            face_attrib = {};
+            return true;
+        }
+
+        epoc::glyph_bitmap_type requested_bitmap_type_ = epoc::default_glyph_bitmap;
+
+        std::uint8_t *get_glyph_bitmap(const std::size_t idx, std::uint32_t code, const std::uint32_t metric_identifier,
+            int *rasterized_width, int *rasterized_height, std::uint32_t &total_size, epoc::glyph_bitmap_type *bmp_type,
+            epoc::open_font_character_metric &character_metric) override {
+            live_bitmaps_++;
+            total_size = 1;
+
+            if (bmp_type) {
+                requested_bitmap_type_ = *bmp_type;
+                *bmp_type = epoc::monochrome_glyph_bitmap;
+            }
+
+            if (rasterized_width) {
+                *rasterized_width = 1;
+            }
+
+            if (rasterized_height) {
+                *rasterized_height = 1;
+            }
+
+            return new std::uint8_t(static_cast<std::uint8_t>(advance_));
+        }
+
+        void free_glyph_bitmap(std::uint8_t *data) override {
+            live_bitmaps_--;
+            delete data;
+        }
+
+        epoc::glyph_bitmap_type get_output_bitmap_type() const override {
+            return epoc::monochrome_glyph_bitmap;
+        }
+
+        bool does_glyph_exist(std::size_t idx, std::uint32_t code, const std::uint32_t metric_identifier) override {
+            return codepoints_.count(static_cast<std::int32_t>(code)) != 0;
+        }
+
+        bool has_character(const std::size_t face_index, const std::int32_t codepoint, const std::uint32_t metric_identifier) override {
+            return codepoints_.count(codepoint) != 0;
+        }
+
+        std::uint32_t last_metric_identifier_ = 0xFFFFFFFF;
+
+        std::uint32_t get_glyph_advance(const std::size_t face_index, const std::uint32_t codepoint,
+            const std::uint32_t metric_identifier, const bool vertical) override {
+            last_metric_identifier_ = metric_identifier;
+            return advance_;
+        }
+
+        std::int32_t begin_get_atlas(std::uint8_t *atlas_ptr, const eka2l1::vec2 atlas_size) override {
+            return 0;
+        }
+
+        bool get_glyph_atlas(const std::int32_t handle, const std::size_t idx, const char16_t start_code, int *unicode_point,
+            const char16_t num_code, const std::uint32_t metric_identifier, epoc::adapter::character_info *info) override {
+            return true;
+        }
+
+        void end_get_atlas(const std::int32_t handle) override {
+        }
+
+        std::optional<epoc::open_font_metrics> get_metric_with_uid(const std::size_t face_index, const std::uint32_t uid,
+            std::uint32_t *metric_identifier) override {
+            return std::nullopt;
+        }
+
+        std::optional<epoc::open_font_metrics> get_nearest_supported_metric(const std::size_t face_index,
+            const std::uint16_t targeted_font_size, std::uint32_t *metric_identifier, bool is_design_font_size) override {
+            epoc::open_font_metrics metrics{};
+            metrics.design_height = static_cast<std::int16_t>(targeted_font_size);
+
+            if (metric_identifier) {
+                *metric_identifier = targeted_font_size;
+            }
+
+            return metrics;
+        }
+    };
+
+    // A component whose metric identifier means something else entirely: gdr
+    // numbers a face's bitmaps, while FreeType uses the pixel size.
+    struct indexed_font_adapter : public fake_font_adapter {
+        using fake_font_adapter::fake_font_adapter;
+
+        std::optional<epoc::open_font_metrics> get_nearest_supported_metric(const std::size_t face_index,
+            const std::uint16_t targeted_font_size, std::uint32_t *metric_identifier, bool is_design_font_size) override {
+            epoc::open_font_metrics metrics{};
+            metrics.design_height = static_cast<std::int16_t>(targeted_font_size);
+
+            // Whatever the size, this face only has two bitmaps.
+            if (metric_identifier) {
+                *metric_identifier = (targeted_font_size > 12) ? 1 : 0;
+            }
+
+            return metrics;
+        }
+
+    };
+
+    constexpr std::int32_t LATIN_CODE = u'A';
+    constexpr std::int32_t CJK_CODE = 0x6587; // 文
+    constexpr std::int32_t UNCOVERED_CODE = 0x1F600;
+}
+
+TEST_CASE("linked_font_adapter_dispatches_per_glyph", "fbs") {
+    fake_font_adapter latin({ LATIN_CODE }, 7);
+    fake_font_adapter cjk({ LATIN_CODE, CJK_CODE }, 13);
+
+    epoc::open_font_face_attrib attrib{};
+    attrib.style = epoc::open_font_face_attrib::bold;
+
+    // Latin first, as link.ini lists it, and canonical.
+    epoc::adapter::linked_font_file_adapter linked({ { &latin, 0 }, { &cjk, 0 } }, 0, attrib);
+
+    // A codepoint both cover comes from the first component, so Latin text is
+    // not silently restyled by the CJK font.
+    REQUIRE(linked.get_glyph_advance(0, LATIN_CODE, 12, false) == 7);
+
+    // One only the CJK font has goes there instead of rendering .notdef.
+    REQUIRE(linked.get_glyph_advance(0, CJK_CODE, 12, false) == 13);
+
+    // Nothing covers this one; the canonical component answers, as it would
+    // have without linking.
+    REQUIRE(linked.get_glyph_advance(0, UNCOVERED_CODE, 12, false) == 7);
+
+    // The typeface covers the union of its components.
+    REQUIRE(linked.has_character(0, LATIN_CODE, 12));
+    REQUIRE(linked.has_character(0, CJK_CODE, 12));
+    REQUIRE(!linked.has_character(0, UNCOVERED_CODE, 12));
+
+    // It presents itself as one face, wearing the canonical attributes.
+    REQUIRE(linked.count() == 1);
+
+    epoc::open_font_face_attrib reported{};
+    REQUIRE(linked.get_face_attrib(0, reported));
+    REQUIRE(reported.style == epoc::open_font_face_attrib::bold);
+    REQUIRE(!linked.get_face_attrib(1, reported));
+}
+
+TEST_CASE("linked_font_adapter_sends_a_glyph_index_to_the_canonical_font", "fbs") {
+    // Shaping hands back glyph indices rather than codepoints, flagged with the
+    // high bit, and an index only means anything to the face that produced it --
+    // which is the canonical component, the one that did the shaping. Routing an
+    // index by "codepoint" lands it in whichever component claims that number
+    // and draws an unrelated glyph.
+    fake_font_adapter latin({ LATIN_CODE, static_cast<std::int32_t>(0x80000000 | LATIN_CODE) }, 7);
+    fake_font_adapter cjk({ CJK_CODE }, 13);
+
+    // The CJK font is canonical here, so a misrouted index is visible.
+    epoc::adapter::linked_font_file_adapter linked({ { &latin, 0 }, { &cjk, 0 } }, 1, {});
+
+    REQUIRE(linked.get_glyph_advance(0, 0x80000000 | LATIN_CODE, 12, false) == 13);
+
+    // The same number without the flag is a codepoint, and does go to Latin.
+    REQUIRE(linked.get_glyph_advance(0, LATIN_CODE, 12, false) == 7);
+}
+
+TEST_CASE("linked_font_adapter_keeps_the_canonical_font_in_charge", "fbs") {
+    // link.ini marks one component canonical, and that is the face the linked
+    // typeface presents as -- its attributes and its metrics. The others are
+    // reachable only for glyphs the canonical one does not have, so nothing
+    // about the device font's look changes.
+    fake_font_adapter device({ LATIN_CODE }, 7);
+    fake_font_adapter cjk({ CJK_CODE }, 13);
+
+    epoc::open_font_face_attrib attrib{};
+    attrib.style = epoc::open_font_face_attrib::serif;
+
+    epoc::adapter::linked_font_file_adapter linked({ { &device, 0 }, { &cjk, 0 } }, 0, attrib);
+
+    std::uint32_t metric_identifier = 0;
+    const std::optional<epoc::open_font_metrics> metrics = linked.get_nearest_supported_metric(0, 17, &metric_identifier, true);
+
+    REQUIRE(metrics.has_value());
+    REQUIRE(metrics->design_height == 17);
+    REQUIRE(metric_identifier == 17);
+
+    epoc::open_font_face_attrib reported{};
+    REQUIRE(linked.get_face_attrib(0, reported));
+    REQUIRE(reported.style == epoc::open_font_face_attrib::serif);
+
+    // Only what the device face cannot draw reaches the CJK one.
+    REQUIRE(linked.get_glyph_advance(0, LATIN_CODE, 17, false) == 7);
+    REQUIRE(linked.get_glyph_advance(0, CJK_CODE, 17, false) == 13);
+}
+
+TEST_CASE("monochrome_glyph_compression_repeats_identical_scanlines", "fbs") {
+    // Symbian's monochrome glyph: a mode bit -- 0 for "the one scanline that
+    // follows repeats" -- then a four bit count, then the scanline, all least
+    // significant bit first. Two identical four pixel rows cost one scanline.
+    const std::uint32_t source[] = { 0b1010'1010 };
+
+    std::vector<std::uint32_t> dest(epoc::adapter::monochrome_glyph_word_count(4, 2), 0);
+    const std::uint32_t written = epoc::adapter::compress_monochrome_glyph(source, 4, 2, dest.data());
+
+    REQUIRE(written == 1 + 4 + 4);
+    REQUIRE((dest[0] & 1) == 0); // repeat mode
+    REQUIRE(((dest[0] >> 1) & 0xF) == 2); // twice
+    REQUIRE(((dest[0] >> 5) & 0xF) == 0b1010);
+}
+
+TEST_CASE("monochrome_glyph_compression_writes_differing_scanlines_out", "fbs") {
+    // Two rows that differ have to be written verbatim, so both are in there.
+    const std::uint32_t source[] = { 0b0101'1010 };
+
+    std::vector<std::uint32_t> dest(epoc::adapter::monochrome_glyph_word_count(4, 2), 0);
+    const std::uint32_t written = epoc::adapter::compress_monochrome_glyph(source, 4, 2, dest.data());
+
+    REQUIRE(written == 1 + 4 + 8);
+    REQUIRE((dest[0] & 1) == 1); // verbatim mode
+    REQUIRE(((dest[0] >> 1) & 0xF) == 2); // two scanlines
+    REQUIRE(((dest[0] >> 5) & 0xFF) == 0b0101'1010);
+}
+
+TEST_CASE("linked_font_glyphs_are_presentable_only_where_convertible", "fbs") {
+    // A component backing a face has to be able to hand over glyphs in the
+    // format that face declares. Antialiased output can be thresholded down to
+    // monochrome; the other direction is not implemented.
+    REQUIRE(epoc::adapter::can_present_glyph_as(epoc::antialised_glyph_bitmap, epoc::antialised_glyph_bitmap));
+    REQUIRE(epoc::adapter::can_present_glyph_as(epoc::monochrome_glyph_bitmap, epoc::monochrome_glyph_bitmap));
+    REQUIRE(epoc::adapter::can_present_glyph_as(epoc::antialised_glyph_bitmap, epoc::monochrome_glyph_bitmap));
+    REQUIRE(!epoc::adapter::can_present_glyph_as(epoc::monochrome_glyph_bitmap, epoc::antialised_glyph_bitmap));
+}
+
+TEST_CASE("font_adapters_reject_what_they_cannot_read", "fbs") {
+    // Loading a font by content depends on this: a file is handed to each
+    // rasterizer in turn and the one that recognises it keeps it, which only
+    // works if the others say no. The 5320 keeps its Chinese font in a file
+    // named s60sc.ccc, so the extension cannot be trusted.
+    std::vector<std::uint8_t> garbage(256, 0x5A);
+
+    for (const auto kind : { epoc::adapter::font_file_adapter_kind::freetype,
+             epoc::adapter::font_file_adapter_kind::gdr }) {
+        auto adapter = epoc::adapter::make_font_file_adapter(kind, garbage);
+
+        REQUIRE(adapter);
+        REQUIRE(!adapter->is_valid());
+    }
+}
+
+TEST_CASE("linked_font_adapter_translates_metric_identifiers", "fbs") {
+    // A metric identifier is only meaningful to the adapter that issued it, and
+    // the per-glyph calls only ever carry the canonical's. Handing a gdr bitmap
+    // index to FreeType as a pixel size renders the glyph a couple of pixels
+    // tall, which is what a device pairing a gdr Latin face with a scalable CJK
+    // one would draw.
+    indexed_font_adapter device({ LATIN_CODE }, 7);
+    fake_font_adapter cjk({ CJK_CODE }, 13);
+
+    epoc::adapter::linked_font_file_adapter linked({ { &device, 0 }, { &cjk, 0 } }, 0, {});
+
+    std::uint32_t metric_identifier = 0;
+    REQUIRE(linked.get_nearest_supported_metric(0, 17, &metric_identifier, true).has_value());
+
+    // The canonical's own numbering is what the caller is given back.
+    REQUIRE(metric_identifier == 1);
+
+    // The canonical still sees its own identifier...
+    REQUIRE(linked.get_glyph_advance(0, LATIN_CODE, metric_identifier, false) == 7);
+    REQUIRE(device.last_metric_identifier_ == 1);
+
+    // ...while the other component is addressed the way it expects, by size.
+    REQUIRE(linked.get_glyph_advance(0, CJK_CODE, metric_identifier, false) == 13);
+    REQUIRE(cjk.last_metric_identifier_ == 17);
+}
+
+TEST_CASE("linked_font_adapter_asks_components_for_the_face_format", "fbs") {
+    // Rather than convert after the fact, the component is told which format
+    // the face declares -- FreeType can rasterise monochrome itself, hinted,
+    // which is far kinder to a small CJK glyph than thresholding a grey one.
+    fake_font_adapter device({ LATIN_CODE }, 7);
+    fake_font_adapter cjk({ CJK_CODE }, 13);
+
+    epoc::adapter::linked_font_file_adapter linked({ { &device, 0 }, { &cjk, 0 } }, 0, {});
+
+    int width = 0;
+    int height = 0;
+    std::uint32_t total_size = 0;
+    epoc::glyph_bitmap_type bmp_type = epoc::default_glyph_bitmap;
+    epoc::open_font_character_metric metric{};
+
+    std::uint8_t *bitmap = linked.get_glyph_bitmap(0, CJK_CODE, 12, &width, &height, total_size, &bmp_type, metric);
+
+    REQUIRE(bitmap);
+    REQUIRE(cjk.requested_bitmap_type_ == epoc::monochrome_glyph_bitmap);
+    REQUIRE(bmp_type == epoc::monochrome_glyph_bitmap);
+
+    linked.free_glyph_bitmap(bitmap);
+    REQUIRE(cjk.live_bitmaps_ == 0);
+}
+
+TEST_CASE("linked_font_adapter_frees_bitmap_through_its_owner", "fbs") {
+    fake_font_adapter latin({ LATIN_CODE }, 7);
+    fake_font_adapter cjk({ CJK_CODE }, 13);
+
+    epoc::adapter::linked_font_file_adapter linked({ { &latin, 0 }, { &cjk, 0 } }, 0, {});
+
+    int width = 0;
+    int height = 0;
+    std::uint32_t total_size = 0;
+    epoc::glyph_bitmap_type bmp_type = epoc::default_glyph_bitmap;
+    epoc::open_font_character_metric metric{};
+
+    // free_glyph_bitmap() only gets a pointer back, so the adapter has to
+    // remember which component allocated it -- gdr and stb really do own it.
+    std::uint8_t *cjk_bitmap = linked.get_glyph_bitmap(0, CJK_CODE, 12, &width, &height, total_size, &bmp_type, metric);
+
+    REQUIRE(cjk_bitmap);
+    REQUIRE(cjk.live_bitmaps_ == 1);
+    REQUIRE(latin.live_bitmaps_ == 0);
+
+    linked.free_glyph_bitmap(cjk_bitmap);
+
+    REQUIRE(cjk.live_bitmaps_ == 0);
+    REQUIRE(latin.live_bitmaps_ == 0);
+}


### PR DESCRIPTION
A Chinese or Japanese S60 device does not ship one font covering both Latin and CJK. It ships two, and pairs them in `Z:\Resource\Fonts\link.ini`: a linked typeface names its components in lookup order and marks one canonical, and `CFontStore` assembles them into a single face before anything else in the fonts folder is loaded. The emulator ignored that file, so every one of those devices drew CJK text as `.notdef` boxes while the font holding the glyphs sat unused in the store.

Three commits, each standing on its own.

## 1. The font store parser learns to say no

`fnttran` writes four literal constants at the head of every `.gdr` — `KStoreWriteOnceLayoutUid`, `KFontStoreFileUid`, `KNullUid`, `KFontStoreFileChecksum` (`bitmapfonttools/src/FNTRECRD.CPP`, `FontStoreFile::ExternalizeHeader`, values in `bitmapfonttools/inc/UID.H`). The parser read all four and checked none, so any file at all was accepted and the parse continued into counts and offsets read out of unrelated bytes. A 256-byte run of `0x5A` parses as a valid empty font store on macOS and **segfaults on Linux**.

That was harmless while every file reaching the parser came from a fonts folder and was picked by extension. It stops being harmless in the next commit, where a file is offered to each rasterizer in turn — being asked about a file that is not its own becomes the normal case.

## 2. Linked typefaces

`link.ini` is parsed into linked typeface specs, and each becomes a font file adapter over the components it links:

- **A glyph goes to the first component that has it**, so Latin text keeps the Latin face and only the rest falls through to the CJK one. A codepoint no component covers goes to the canonical, exactly as it would have without linking.
- **A code with the high bit set is a glyph index, not a codepoint.** It only means something to the face that produced it — the canonical component, which did the shaping — so those are never dispatched.
- **The canonical component lends the typeface its attributes and metrics**, and a metric identifier is translated per component on the way in: gdr numbers a face's bitmaps while FreeType uses the pixel size, so handing one's identifier to the other renders the glyph a few pixels tall.
- **A component is only used where its glyphs can be presented in the format the face declares**, and the component is asked for that format rather than converted after the fact — FreeType rasterises monochrome itself, hinted, which is far kinder to a small CJK glyph than thresholding a grey one.

Two supporting changes were needed:

- `font_store`'s face selection is now a port of `CFontStore::MatchFontSpecsInPixels`, so a request naming a face gets that face rather than whichever candidate happened to score on style. Without it the newly assembled typeface loses to its own Latin component.
- **A font file's extension is only a hint.** `CFontStore::AddFileL` offers the file to every rasterizer and keeps whichever one recognises it, and a ROM really does name fonts freely: the 5320 carries its Chinese font as `s60sc.ccc`, a TrueType file all the same. Skipping it left that device with no CJK glyphs at all, `link.ini` or not.

## 3. The fonts a frontend imports

The iOS frontend merged in #587 has an "Install Fonts" entry that copies the picked files into `<storage>/fonts` and tells the user to restart the device for them to take effect. Nothing ever reads that folder: `load_fonts` only walks `<drive>:\Resource\Fonts` (`\System\Fonts` on EKA1), so the import lands in a dead end. The frontend half went up without the server half behind it — my oversight in #587.

`load_custom_fonts` walks `<storage>/fonts` right after the drive scan and feeds every entry to the store. The folder sits outside the guest drives on purpose, so one import serves every installed device and survives a device reinstall rewriting its Z drive. Being appended after the ROM set, and `seek_the_open_font` taking the first exact face-name match, an imported font never displaces a ROM one — it only adds coverage. Nothing here is iOS specific: desktop and Android pick a font up by dropping it in the same folder.

The read-and-pick-an-adapter half of `add_single_font` moves into `add_font`, which takes a `common::ro_stream` so a guest file (`ro_file_stream` over a `symfile`) and a host file (`ro_std_file_stream`) share one copy of it.

**An imported font would otherwise sit in the store unused.** A CJK variant ships a `link.ini` pairing its Latin typeface with a CJK one, but a Latin-only ROM ships neither the font nor the link, and nothing about a font request says which script it is about to draw — so no request ever names the import. `attach_user_font_fallbacks` therefore gives every device face the imported fonts as trailing components of a linked typeface: the arrangement `link.ini` describes, and the mechanism commit 2 adds, with the device's own face canonical so nothing about its appearance or metrics changes.

`add_single_font` also stopped dereferencing a null `symfile` when the open fails, and still reports success for a file it has no adapter for — `add_font_file_store` hands that result straight to the guest, which used to accept anything that existed.

## Verification

Twenty-two new test cases, all against synthetic input — no font file is needed, so nothing copyrighted is involved. `ekatests` goes from 80 cases / 261 assertions to 102 / 339.

Disabling one behaviour at a time, in a tree with the rest intact:

| Behaviour disabled | Cases that fail |
|---|---|
| a glyph goes to the component that has it | 6 |
| a glyph index is not dispatched by codepoint | 1 |
| metric identifiers translated per component | 1 |
| a face name outscores every style attribute | 1 |
| the font store header is identified | 1 |

Three things are **not** covered, and are worth naming rather than glossing over:

- `font_store` passing the canonical index through to the adapter is only reachable with real fonts in the store, which a unit test cannot put there.
- The parser's guard against reading `link.ini`'s `SN` field as a component name is unreachable with the stanza shape every ROM uses, where the component name is the first token on the line. It is kept as defence for a variant that orders the fields differently.
- Nothing in commit 3 carries a test of its own, for the same reason as the first point. The linked-typeface machinery it leans on is covered by commit 2's cases.
