### PR TITLE
ci: Build the iOS app for a device only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -266,11 +266,16 @@ jobs:
     env:
       EKA2L1_IOS_CONFIGURATION: Release
 
+    # Device only. Both slices are arm64 and compile almost the same translation
+    # units, so the simulator build was mostly a second copy of the device one at
+    # twice the wall clock -- and what actually has to keep working is that the app
+    # builds for a phone. The cost is that code behind TARGET_OS_SIMULATOR (the
+    # synthetic camera backend) is no longer compiled by CI; add the label back if
+    # that grows past a stub.
     strategy:
       fail-fast: false
       matrix:
         include:
-          - label: simulator
           - label: device
 
     steps:


### PR DESCRIPTION
The iOS job added in #592 builds both slices. They are both arm64 and compile nearly the same translation units, so the simulator build is largely a second copy of the device one — and it doubles the job's wall clock. On a busy queue the iOS matrix is the last thing every run waits for, including runs that changed nothing near it.

What has to keep working is that the app builds for a phone. That is the slice this keeps.

**The cost, stated in the workflow so it is not a surprise later:** code behind `TARGET_OS_SIMULATOR` — today just the synthetic camera backend — is no longer compiled anywhere in CI. The matrix is left in place rather than flattened, so the label can be added back with one line if that grows past a stub.

Workflow only.
