### PR TITLE
fbs: Restore the icon mask contract this file refers to

### DIFF
--- a/src/emu/services/src/fbs/impls/bitmap.cpp
+++ b/src/emu/services/src/fbs/impls/bitmap.cpp
@@ -1766,6 +1766,25 @@ namespace eka2l1 {
             return convert_to_rgba8888(serv, buf_stream, dest, file.sbm_headers[index], -1, static_cast<bitmap_file_compression>(file.sbm_headers[index].compression), make_standard_mask);
         }
 
+        // Symbian icon masks come in two families with opposite polarities. BITGDI's
+        // CFbsBitGc::BitBltMasked (bitgdi/sbit/BITBLT.CPP) picks between them:
+        //
+        //     if (aMaskBitmap->DisplayMode() == EGray256)
+        //         DoBitBltAlpha(..., EFalse);          // alpha blend, aInvertMask ignored
+        //     ...
+        //     const TDrawMode drawMode = aInvertMask ? EDrawModeAND : EDrawModeANDNOT;
+        //
+        // So only an EGray256 mask is a real alpha/soft mask, where luminance is the
+        // alpha and white is opaque. Every other display mode is a binary stencil
+        // whose polarity comes from the caller, and Avkon passes aInvertMask=ETrue
+        // almost everywhere (EIKCLBD.CPP, EIKMENUB.CPP, Aknscind.cpp, ...), which
+        // ANDs the mask in as-is: white keeps the destination, so white is
+        // transparent.
+        //
+        // We keep classifying by depth rather than by that display mode, because
+        // some S60v2 icons carry gray-valued opacity in a mask the header flags as
+        // colour, and treating those as stencils inverts them. Depth alone gets
+        // every mask in the 6680 ROM right except the handful covered below.
         static bool mask_depth_is_soft(const std::uint32_t bpp) {
             return (bpp > 1) && (bpp <= 8);
         }


### PR DESCRIPTION
Comment only.

The comment above `soft_mask_reads_inside_out` opens with:

> The exception: a few S60v2 AIF icons store a *binary* stencil at 8bpp, in the colour-key polarity **the contract above describes** …

Since #589 there is nothing above it — the passage it points at was dropped on the way in, and `mask_depth_is_soft` now sits there bare with an exception below it that refers back to a contract the file no longer states.

That passage is the reason the depth test is written the way it is. BITGDI's `CFbsBitGc::BitBltMasked` (`bitgdi/sbit/BITBLT.CPP`) treats **only** an `EGray256` mask as a real alpha mask and every other display mode as a binary stencil whose polarity comes from the caller — and Avkon passes `aInvertMask=ETrue` almost everywhere. This code deliberately classifies by *depth* rather than by that display mode, because some S60v2 icons carry gray-valued opacity in a mask the header flags as colour, and reading those as stencils inverts them.

Without it the depth test looks arbitrary and the exception dangles. Restored verbatim; no code change.
