### PR TITLE
Re-run stage two after the first device is installed

### DIFF
--- a/src/emu/qt/include/qt/state.h
+++ b/src/emu/qt/include/qt/state.h
@@ -80,7 +80,13 @@ namespace eka2l1::desktop {
         bool stretch_to_fill_display;
 
         common::event graphics_event;
+
+        // init_event asks the OS thread to (re)attempt the stage two initialisation, init_done_event
+        // reports an attempt back. They must stay separate: outside of Win32 common::event auto-resets
+        // on wait, so one event for both directions lets the requester swallow its own signal.
         common::event init_event;
+        common::event init_done_event;
+
         common::event pause_event;
         common::event kill_event;
 

--- a/src/emu/qt/src/mainwindow.cpp
+++ b/src/emu/qt/src/mainwindow.cpp
@@ -685,9 +685,11 @@ void main_window::on_new_device_added() {
         emulator_state_.symsys->mount(drive_d, drive_media::physical, eka2l1::add_path(emulator_state_.conf.storage, "/drives/d/"), io_attrib_internal);
         emulator_state_.symsys->mount(drive_e, drive_media::physical, eka2l1::add_path(emulator_state_.conf.storage, "/drives/e/"), io_attrib_removeable);
 
-        // Set and wait for reinitialization
+        // Set and wait for reinitialization. The app list built below needs the ROM drive that
+        // only the stage two initialisation mounts, so this really has to wait for the retry.
+        emulator_state_.init_done_event.reset();
         emulator_state_.init_event.set();
-        emulator_state_.init_event.wait();
+        emulator_state_.init_done_event.wait();
 
         refresh_current_device_label();
         reprepare_touch_mappings();

--- a/src/emu/qt/src/thread.cpp
+++ b/src/emu/qt/src/thread.cpp
@@ -279,7 +279,7 @@ namespace eka2l1::desktop {
             }
 
             const bool success = state.stage_two();
-            state.init_event.set();
+            state.init_done_event.set();
 
             if (first_time) {
                 state.graphics_event.wait();
@@ -290,9 +290,10 @@ namespace eka2l1::desktop {
                 break;
             }
 
-            // Try wait for initialization from other parties to make this success.
-            state.init_event.reset();
+            // Try wait for initialization from other parties to make this success. Reset only
+            // after the wait returned, so a request raised while we were busy is not dropped.
             state.init_event.wait();
+            state.init_event.reset();
         }
 
         // Register SEH handler for this thread
@@ -352,7 +353,8 @@ namespace eka2l1::desktop {
 
         // Instantiate UI and High-level interface threads
         std::thread os_thread_obj(os_thread, std::ref(state));
-        state.init_event.wait();
+        state.init_done_event.wait();
+        state.init_done_event.reset();
 
         eka2l1::common::arg_parser parser(argc, argv);
 

--- a/src/emu/services/src/window/window.cpp
+++ b/src/emu/services/src/window/window.cpp
@@ -1304,19 +1304,24 @@ namespace eka2l1 {
 
     void window_server::load_wsini() {
         io_system *io = sys->get_io_system();
-        std::optional<eka2l1::drive> drv;
-        drive_number dn = drive_z;
+        drive_number rom_drive = drive_invalid;
 
-        for (; dn >= drive_a; dn = (drive_number)((int)dn - 1)) {
-            drv = io->get_drive_entry(dn);
+        for (int i = static_cast<int>(drive_z); i >= static_cast<int>(drive_a); i--) {
+            std::optional<eka2l1::drive> drv = io->get_drive_entry(static_cast<drive_number>(i));
 
             if (drv && drv->media_type == drive_media::rom) {
+                rom_drive = static_cast<drive_number>(i);
                 break;
             }
         }
 
+        if (rom_drive == drive_invalid) {
+            LOG_ERROR(SERVICE_WINDOW, "No ROM drive is mounted, app using window server will broken");
+            return;
+        }
+
         std::u16string wsini_path;
-        wsini_path += static_cast<char16_t>((char)dn + 'A');
+        wsini_path += static_cast<char16_t>(static_cast<char>(rom_drive) + 'A');
         wsini_path += u":\\system\\data\\wsini.ini";
 
         auto wsini_path_host = io->get_raw_path(wsini_path);

--- a/src/emu/vfs/src/vfs.cpp
+++ b/src/emu/vfs/src/vfs.cpp
@@ -672,11 +672,19 @@ namespace eka2l1 {
             const std::string root = eka2l1::root_name(path_ucs8);
             std::u16string vert_path_copy = vert_path;
 
-            if (root == "" || !mappings[ascii_to_drive_number(static_cast<char>(std::towlower(root[0])))].second) {
+            if (root == "") {
                 return std::nullopt;
             }
 
-            drive &drv = mappings[ascii_to_drive_number(static_cast<char>(std::towlower(root[0])))].first;
+            const char root_letter = static_cast<char>(std::towlower(root[0]));
+
+            // root_name only looks for a ':', so this is not necessarily a drive letter. Anything
+            // else would index the mappings array out of bounds.
+            if ((root_letter < 'a') || (root_letter > 'z') || !mappings[ascii_to_drive_number(root_letter)].second) {
+                return std::nullopt;
+            }
+
+            drive &drv = mappings[ascii_to_drive_number(root_letter)].first;
             std::u16string map_path = common::utf8_to_ucs2(drv.real_path);
 
             if (!eka2l1::is_separator(static_cast<char>(map_path.back()))) {


### PR DESCRIPTION
### Symptom

On a fresh profile (no device installed yet), installing a device and then launching any app crashes the emulator. On macOS the report is `SIGBUS / KERN_PROTECTION_FAILURE`:

```
main_window::on_app_clicked -> setup_screen_draw -> get_current_active_screen
  -> window_server::get_screens -> window_server::load_wsini
  -> io_system::get_raw_path -> physical_file_system::get_real_physical_path   <- crash
```

Restarting the emulator afterwards works fine, which is what makes it look app-specific.

### Root cause

`common::event` does not have the same semantics on all platforms (`src/emu/common/src/sync.cpp`): on Win32 it is a manual-reset event (`CreateEvent(NULL, TRUE, ...)`), while the POSIX implementation clears the flag inside `wait()`.

`main_window::on_new_device_added()` used a single event for both directions of the handshake with the OS thread:

```cpp
emulator_state_.init_event.set();
emulator_state_.init_event.wait();
```

Off Win32 the `set()` raises the flag once, and the requesting thread's own `wait()` consumes it, so the OS thread parked at the bottom of the retry loop never wakes up and stage two is never re-attempted. Drive Z is mounted only by stage two (`state.cpp`), so the ROM drive stays absent even though the app list is already populated and clickable.

`window_server::load_wsini()` then walks the drives looking for the ROM one, runs past `drive_a` down to `-1`, and builds `"@:\system\data\wsini.ini"`. `common::root_name()` accepts `"@:"` because it only checks that the second character is `':'`, and `ascii_to_drive_number('@')` is `-33`, which indexes the 26-entry `mappings` array out of bounds. The garbage `drive` that comes back holds a wild `std::string`, and dereferencing it faults.

I confirmed the whole chain on the crashing session's log: `Stage two initialisation abort` at startup, and `Device being used: ...` never appears again even after the device was installed. Sampling the process with no device installed shows the OS thread parked in `common::event::wait()` inside `os_thread`, with the graphics thread already running.

### Fix

- Split the handshake into `init_event` (main -> OS thread, "please retry") and `init_done_event` (OS thread -> main, "attempt finished"), and reset only *after* a wait returned so a request raised while the OS thread is busy is not dropped.
- `load_wsini()` bails out with an error when no ROM drive is mounted, instead of forming a path from an invalid drive number.
- `get_real_physical_path()` rejects root letters outside `a-z` rather than indexing `mappings` with them. This is the guard that turns a bad path into a failed lookup instead of a host crash.

### Testing

- Built on macOS (arm64, Qt 6.11, Release). Normal launch path re-verified: stage two succeeds, the app list loads, a guest app boots, and no crash reports are produced.
- The handshake itself was checked with a standalone reproduction of the two patterns against the POSIX `common::event` semantics: the old single-event pattern never delivers the retry (0/20 runs), the split-event one always does (20/20).
- Windows behaviour should be unchanged: with a manual-reset event both waits were already satisfied, which is why this never showed up there. I do not have a Windows machine to confirm that, so a second pair of eyes on that path is welcome.