### PR TITLE
Fix chunk lifetime and stale TLB in both memory models

### DIFF
--- a/src/emu/kernel/include/kernel/chunk.h
+++ b/src/emu/kernel/include/kernel/chunk.h
@@ -78,7 +78,7 @@ namespace eka2l1 {
 		*/
         class chunk : public kernel_obj {
             // The reversed region that the chunk can commit to
-            mem::mem_model_chunk *mmc_impl_;
+            mem::mem_model_chunk *mmc_impl_ = nullptr;
             std::unique_ptr<mem::mem_model_chunk> mmc_impl_unq_;
 
             memory_system *mem;
@@ -155,6 +155,17 @@ namespace eka2l1 {
 
             bool is_chunk_heap() const {
                 return is_heap;
+            }
+
+            /*! \brief Whether the memory model backing of this chunk exists.
+             *
+             * The constructor only logs when the memory model refuses to create the chunk (address
+             * space exhausted, chunk table full, ...), so the object still exists but is hollow.
+             * Creators must check this and report KErrNoMemory instead of handing the guest a
+             * handle to a chunk that can not be operated on.
+            */
+            bool valid() const {
+                return mmc_impl_ != nullptr;
             }
 
             const std::size_t max_size() const;

--- a/src/emu/kernel/src/chunk.cpp
+++ b/src/emu/kernel/src/chunk.cpp
@@ -162,11 +162,13 @@ namespace eka2l1 {
             kernel::process *own = get_own_process();
 
             if (!mmc_impl_unq_) {
-                if (own->get_mem_model())
+                if (mmc_impl_ && own && own->get_mem_model())
                     own->get_mem_model()->delete_chunk(mmc_impl_);
             } else {
                 mmc_impl_unq_.reset();
             }
+
+            mmc_impl_ = nullptr;
 
             if (own)
                 own->decrease_access_count();
@@ -175,33 +177,41 @@ namespace eka2l1 {
         }
 
         void chunk::open_to(process *own) {
-            if (own)
+            if (own && mmc_impl_ && own->get_mem_model())
                 own->get_mem_model()->attach_chunk(mmc_impl_);
         }
 
         ptr<uint8_t> chunk::base(process *pr) {
+            if (!mmc_impl_) {
+                return 0;
+            }
+
             return mmc_impl_->base(pr ? pr->get_mem_model() : nullptr);
         }
 
         const std::size_t chunk::max_size() const {
-            return mmc_impl_->max();
+            return mmc_impl_ ? mmc_impl_->max() : 0;
         }
 
         const std::size_t chunk::committed() const {
-            return mmc_impl_->committed();
+            return mmc_impl_ ? mmc_impl_->committed() : 0;
         }
 
         const std::uint32_t chunk::bottom_offset() const {
-            return mmc_impl_->bottom();
+            return mmc_impl_ ? mmc_impl_->bottom() : 0;
         }
 
         const std::uint32_t chunk::top_offset() const {
-            return mmc_impl_->top();
+            return mmc_impl_ ? mmc_impl_->top() : 0;
         }
 
         std::int32_t chunk::commit_symbian_compat(uint32_t offset, size_t size) {
             if (type != kernel::chunk_type::disconnected) {
                 return epoc::error_general;
+            }
+
+            if (!mmc_impl_) {
+                return epoc::error_no_memory;
             }
 
             std::size_t ret_value = mmc_impl_->commit(offset, size, false);
@@ -216,7 +226,7 @@ namespace eka2l1 {
         }
 
         bool chunk::commit(uint32_t offset, size_t size) {
-            if (type != kernel::chunk_type::disconnected) {
+            if ((type != kernel::chunk_type::disconnected) || (!mmc_impl_)) {
                 return false;
             }
 
@@ -228,7 +238,7 @@ namespace eka2l1 {
         }
 
         bool chunk::decommit(uint32_t offset, size_t size) {
-            if (type != kernel::chunk_type::disconnected) {
+            if ((type != kernel::chunk_type::disconnected) || (!mmc_impl_)) {
                 return false;
             }
 
@@ -237,7 +247,7 @@ namespace eka2l1 {
         }
 
         bool chunk::adjust(std::size_t adj_size) {
-            if (type == kernel::chunk_type::disconnected) {
+            if ((type == kernel::chunk_type::disconnected) || (!mmc_impl_)) {
                 return false;
             }
 
@@ -245,7 +255,7 @@ namespace eka2l1 {
         }
 
         bool chunk::adjust_de(size_t nbottom, size_t ntop) {
-            if (type != kernel::chunk_type::double_ended) {
+            if ((type != kernel::chunk_type::double_ended) || (!mmc_impl_)) {
                 return false;
             }
 
@@ -253,7 +263,7 @@ namespace eka2l1 {
         }
 
         std::int32_t chunk::allocate(size_t size) {
-            if (type != kernel::chunk_type::disconnected) {
+            if ((type != kernel::chunk_type::disconnected) || (!mmc_impl_)) {
                 return -1;
             }
 
@@ -261,7 +271,7 @@ namespace eka2l1 {
         }
 
         void *chunk::host_base() {
-            return mmc_impl_->host_base();
+            return mmc_impl_ ? mmc_impl_->host_base() : nullptr;
         }
     }
 }

--- a/src/emu/kernel/src/svc.cpp
+++ b/src/emu/kernel/src/svc.cpp
@@ -1375,13 +1375,21 @@ namespace eka2l1::epoc {
             att = kernel::chunk_attrib::anonymous;
         }
 
-        const kernel::handle h = kern->create_and_add<kernel::chunk>(
-                                         owner == epoc::owner_process ? kernel::owner_type::process : kernel::owner_type::thread,
-                                         mem, kern->crr_process(), name ? name->to_std_string(kern->crr_process()) : "", create_info.initial_bottom,
-                                         create_info.initial_top, create_info.max_size, perm, type, access, att, create_info.clear_bytes)
-                                     .first;
+        const auto chunk_res = kern->create_and_add<kernel::chunk>(
+            owner == epoc::owner_process ? kernel::owner_type::process : kernel::owner_type::thread,
+            mem, kern->crr_process(), name ? name->to_std_string(kern->crr_process()) : "", create_info.initial_bottom,
+            create_info.initial_top, create_info.max_size, perm, type, access, att, create_info.clear_bytes);
+
+        const kernel::handle h = chunk_res.first;
 
         if (h == kernel::INVALID_HANDLE) {
+            return epoc::error_no_memory;
+        }
+
+        if (!chunk_res.second->valid()) {
+            // The memory model refused this chunk. Drop the handle instead of letting the guest
+            // operate on a chunk that has no backing at all.
+            kern->close(h);
             return epoc::error_no_memory;
         }
 
@@ -3566,13 +3574,21 @@ namespace eka2l1::epoc {
             max_size = common::align(description->max_size_, mem->get_page_size());
         }
 
-        kernel::handle h = kern->create_and_add<kernel::chunk>(get_handle_owner_from_eka1_attribute(attribute),
-                                   mem, target_process, chunk_name, bottom, top, max_size, init_prot, type_of_chunk,
-                                   access_type, chunk_attribute)
-                               .first;
+        const auto chunk_res = kern->create_and_add<kernel::chunk>(get_handle_owner_from_eka1_attribute(attribute),
+            mem, target_process, chunk_name, bottom, top, max_size, init_prot, type_of_chunk,
+            access_type, chunk_attribute);
+
+        kernel::handle h = chunk_res.first;
 
         if (h == kernel::INVALID_HANDLE) {
             // Maybe out of memory, just don't throw general error since it's hard to debug
+            finish_status_request_eka1(target_thread, finish_signal, epoc::error_no_memory);
+            return epoc::error_no_memory;
+        }
+
+        if (!chunk_res.second->valid()) {
+            // Memory model could not back this chunk, so it is unusable. See chunk_new.
+            kern->close(h);
             finish_status_request_eka1(target_thread, finish_signal, epoc::error_no_memory);
             return epoc::error_no_memory;
         }

--- a/src/emu/mem/include/mem/model/flexible/chunk.h
+++ b/src/emu/mem/include/mem/model/flexible/chunk.h
@@ -39,12 +39,25 @@ namespace eka2l1::mem::flexible {
 
         flexible_mem_model_process *owner_;
 
+        /**
+         * @brief Processes that currently hold an attachment (and therefore a mapping) to this
+         *        chunk.
+         *
+         * A chunk is not owned by the process that created it: a global chunk stays alive as long
+         * as a handle to it exists, and any process opening that handle gets its own mapping. Each
+         * attach info in flexible_mem_model_process::attachs_ points straight at this struct, so
+         * this struct has to know who to tell before it dies.
+         */
+        std::vector<flexible_mem_model_process *> attachers_;
+
         std::unique_ptr<memory_object> mem_obj_;
         std::unique_ptr<common::bitmap_allocator> page_bma_;
 
         vm_address fixed_addr_;
         std::unique_ptr<mapping> fixed_mapping_;
         bool is_addr_shared_;
+
+        void remove_attacher(flexible_mem_model_process *process);
 
     public:
         explicit flexible_mem_model_chunk(control_base *control, const asid id);

--- a/src/emu/mem/include/mem/model/multiple/chunk.h
+++ b/src/emu/mem/include/mem/model/multiple/chunk.h
@@ -30,20 +30,24 @@ namespace eka2l1::mem {
     struct mem_model_process;
 
     struct multiple_mem_model_chunk : public mem_model_chunk {
-        vm_address base_;
-        void *host_base_;
+        // Zeroed rather than left to do_create(), which is allowed to fail: the destructor runs
+        // decommit(0, max_size_) unconditionally, so a struct that never got created would
+        // otherwise walk page_tabs_ with a garbage size and dereference a page table that was
+        // never assigned.
+        vm_address base_{ 0 };
+        void *host_base_{ nullptr };
 
         mem_model_process *own_process_{ nullptr };
 
-        std::size_t chunk_id_in_mmp_;
+        std::size_t chunk_id_in_mmp_{ 0 };
 
-        std::size_t committed_;
-        std::size_t max_size_;
+        std::size_t committed_{ 0 };
+        std::size_t max_size_{ 0 };
 
         std::vector<std::uint32_t> page_tabs_;
         std::vector<asid> attached_asids_;
 
-        std::uint16_t granularity_shift_;
+        std::uint16_t granularity_shift_{ 0 };
         std::uint32_t create_flags_{ 0 };
 
         std::unique_ptr<common::bitmap_allocator> page_bma_;

--- a/src/emu/mem/src/model/flexible/chunk.cpp
+++ b/src/emu/mem/src/model/flexible/chunk.cpp
@@ -51,15 +51,11 @@ namespace eka2l1::mem::flexible {
         // exit first. Their attach info points straight at this struct, so make them drop it now,
         // while our mapping list and memory object are still alive. Otherwise the next teardown
         // walks freed memory and dereferences a garbage mem_obj_.
+        // Every entry got here through attach_chunk(), which only records an attacher after it
+        // has stored the matching attach info, so detach_chunk() always finds it and calls
+        // remove_attacher(). The list therefore shrinks on every iteration.
         while (!attachers_.empty()) {
-            flexible_mem_model_process *attacher = attachers_.back();
-            attacher->detach_chunk(this);
-
-            // detach_chunk() removes itself from the list, except for an address-shared chunk,
-            // which never records an attacher in the first place. Keep the loop finite anyway.
-            if (!attachers_.empty() && (attachers_.back() == attacher)) {
-                attachers_.pop_back();
-            }
+            attachers_.back()->detach_chunk(this);
         }
 
         if (fixed_mapping_ && (flags_ & MEM_MODEL_CHUNK_REGION_USER_CODE)) {

--- a/src/emu/mem/src/model/flexible/chunk.cpp
+++ b/src/emu/mem/src/model/flexible/chunk.cpp
@@ -33,16 +33,51 @@ namespace eka2l1::mem::flexible {
         , committed_(0)
         , flags_(0)
         , fixed_addr_(0)
-        , owner_(nullptr) {
+        , owner_(nullptr)
+        , is_addr_shared_(false) {
+    }
+
+    void flexible_mem_model_chunk::remove_attacher(flexible_mem_model_process *process) {
+        auto ite = std::find(attachers_.begin(), attachers_.end(), process);
+
+        if (ite != attachers_.end()) {
+            attachers_.erase(ite);
+        }
     }
 
     flexible_mem_model_chunk::~flexible_mem_model_chunk() {
+        // This struct can die while other processes still have it attached: the kernel object may
+        // be closed while another process holds a handle to a global chunk, or the creator may
+        // exit first. Their attach info points straight at this struct, so make them drop it now,
+        // while our mapping list and memory object are still alive. Otherwise the next teardown
+        // walks freed memory and dereferences a garbage mem_obj_.
+        while (!attachers_.empty()) {
+            flexible_mem_model_process *attacher = attachers_.back();
+            attacher->detach_chunk(this);
+
+            // detach_chunk() removes itself from the list, except for an address-shared chunk,
+            // which never records an attacher in the first place. Keep the loop finite anyway.
+            if (!attachers_.empty() && (attachers_.back() == attacher)) {
+                attachers_.pop_back();
+            }
+        }
+
         if (fixed_mapping_ && (flags_ & MEM_MODEL_CHUNK_REGION_USER_CODE)) {
             control_flexible *control_mm = reinterpret_cast<control_flexible *>(control_);
             for (auto &mmu : control_mm->mmus_) {
                 // Clear the instruction cache at that range, code may reuse it later
                 mmu->cpu_->imb_range(fixed_mapping_->base_, max_size_);
             }
+        }
+
+        // A shared chunk's fixed mapping is registered in the memory object's
+        // mapping list by do_create() (attach_mapping) but, unlike per-process
+        // mappings, is never detached. Members destruct in reverse declaration
+        // order, so fixed_mapping_ dies before mem_obj_; without this detach,
+        // ~memory_object -> decommit() would walk the already-freed mapping and
+        // dereference its dangling owner_. Remove it while it is still alive.
+        if (fixed_mapping_ && mem_obj_) {
+            mem_obj_->detach_mapping(fixed_mapping_.get());
         }
     }
 

--- a/src/emu/mem/src/model/flexible/control.cpp
+++ b/src/emu/mem/src/model/flexible/control.cpp
@@ -36,8 +36,12 @@ namespace eka2l1::mem::flexible {
     }
 
     control_flexible::~control_flexible() {
-        kern_addr_space_.reset();
+        // Destroy the chunks before the kernel address space. A shared chunk's
+        // fixed mapping is owned by kern_addr_space_, and tearing that mapping
+        // down (mapping::~mapping -> unmap / section deallocate) dereferences
+        // the address space, so the address space must outlive the chunks.
         chunk_mngr_.reset();
+        kern_addr_space_.reset();
     }
 
     mmu_base *control_flexible::get_or_create_mmu(arm::core *cc) {

--- a/src/emu/mem/src/model/flexible/mapping.cpp
+++ b/src/emu/mem/src/model/flexible/mapping.cpp
@@ -30,7 +30,10 @@ namespace eka2l1::mem::flexible {
     mapping::mapping(address_space *owner)
         : owner_(owner)
         , region_flags_(0)
-        , off_start_in_page_quantity_(0) {
+        , off_start_in_page_quantity_(0)
+        , occupied_(0) {
+        // occupied_ is only assigned by a successful instantiate(), but the destructor uses it
+        // unconditionally -- and attach_chunk() destroys a mapping whose instantiate() failed.
     }
 
     mapping::~mapping() {

--- a/src/emu/mem/src/model/flexible/memobj.cpp
+++ b/src/emu/mem/src/model/flexible/memobj.cpp
@@ -100,6 +100,29 @@ namespace eka2l1::mem::flexible {
         const std::uint32_t start_offset = page_offset << control_->page_size_bits_;
         const std::uint32_t size_to_decommit = static_cast<std::uint32_t>(total_pages << control_->page_size_bits_);
 
+        control_flexible *ctrl_fx = reinterpret_cast<control_flexible *>(control_);
+
+        // Remove guest mappings and cached host translations before making the
+        // backing inaccessible. This matches the multiple memory model and
+        // prevents a concurrent CPU fast-path access from reaching a page after
+        // common::decommit has reclaimed it.
+        for (auto &mapping : mappings_) {
+            if (!mapping->unmap(page_offset, total_pages)) {
+                LOG_WARN(MEMORY, "Unable to unmap decommitted memory from a mapping!");
+            }
+
+            // Invalidate the CPU TLB for every mapping, not just the one owned by the
+            // current address space: kernel/shared fixed mappings (code, ROM) are visible
+            // from every address space, so the running core may hold entries for them
+            // even while another address space is current, and the host memory is about
+            // to be freed. Dirtying a foreign or stale entry is always safe.
+            for (auto &mm : ctrl_fx->mmus_) {
+                mm->unmap_from_cpu(mapping->base_ + start_offset, size_to_decommit);
+            }
+        }
+
+        page_arr_.alter(page_offset, static_cast<std::uint32_t>(total_pages), prot_none, true);
+
         if (!external_) {
             const bool deresult = common::decommit(reinterpret_cast<std::uint8_t *>(data_) + start_offset,
                 size_to_decommit);
@@ -109,24 +132,6 @@ namespace eka2l1::mem::flexible {
             }
         }
 
-        control_flexible *ctrl_fx = reinterpret_cast<control_flexible *>(control_);
-
-        // Unmap decomitted memory from all mappings
-        for (auto &mapping : mappings_) {
-            if (!mapping->unmap(page_offset, total_pages)) {
-                LOG_WARN(MEMORY, "Unable to unmap decommitted memory from a mapping!");
-            }
-
-            for (auto &mm : ctrl_fx->mmus_) {
-                if (mapping->owner_->id() == mm->current_addr_space()) {
-                    // Unmap from to CPU right away
-                    mm->unmap_from_cpu(mapping->base_ + start_offset, size_to_decommit);
-                    break;
-                }
-            }
-        }
-
-        page_arr_.alter(page_offset, static_cast<std::uint32_t>(total_pages), prot_none, true);
         return true;
     }
 
@@ -145,6 +150,23 @@ namespace eka2l1::mem::flexible {
 
         if (ite == mappings_.end()) {
             return false;
+        }
+
+        // Chunk/process teardown detaches mappings before destroying their
+        // memory object. If detach merely erases the pointer, decommit() can no
+        // longer find this virtual range and the CPU TLB keeps host pointers
+        // past the backing allocation's lifetime. Clear the page tables first
+        // so a miss cannot repopulate the entry, then invalidate the full
+        // mapping on every core. mapping::~mapping() repeats unmap(), which is
+        // intentionally harmless.
+        if (!layout->unmap(0, layout->occupied_)) {
+            LOG_WARN(MEMORY, "Unable to unmap detached memory mapping!");
+        }
+
+        control_flexible *ctrl_fx = reinterpret_cast<control_flexible *>(control_);
+        const std::size_t mapping_size = layout->occupied_ << control_->page_size_bits_;
+        for (auto &mm : ctrl_fx->mmus_) {
+            mm->unmap_from_cpu(layout->base_, mapping_size);
         }
 
         mappings_.erase(ite);

--- a/src/emu/mem/src/model/flexible/process.cpp
+++ b/src/emu/mem/src/model/flexible/process.cpp
@@ -117,6 +117,7 @@ namespace eka2l1::mem::flexible {
 
         // Ok nice nice nice. Add this to list of attachment
         attachs_.push_back(std::move(attach_info));
+        fl_chunk->attachers_.push_back(this);
 
         return true;
     }
@@ -145,6 +146,8 @@ namespace eka2l1::mem::flexible {
         fl_chunk->mem_obj_->detach_mapping(chunk_ite->map_.get());
 
         attachs_.erase(chunk_ite);
+        fl_chunk->remove_attacher(this);
+
         return true;
     }
 
@@ -152,9 +155,25 @@ namespace eka2l1::mem::flexible {
         control_flexible *fl_control = reinterpret_cast<control_flexible *>(control_);
 
         for (auto &attach: attachs_) {
-            attach.chunk_->mem_obj_->detach_mapping(attach.map_.get());
-            fl_control->chunk_mngr_->destroy(reinterpret_cast<flexible_mem_model_chunk *>(attach.chunk_));
+            flexible_mem_model_chunk *chunk = reinterpret_cast<flexible_mem_model_chunk *>(attach.chunk_);
+
+            chunk->mem_obj_->detach_mapping(attach.map_.get());
+            chunk->remove_attacher(this);
+
+            // Only free the chunk struct once nobody else has it mapped. Attaching is not
+            // ownership: a global chunk outlives the process that created it as long as a handle
+            // to it exists, and freeing it here would both unmap it from a live process and leave
+            // that process holding an attach info to freed memory.
+            if (chunk->attachers_.empty()) {
+                fl_control->chunk_mngr_->destroy(chunk);
+            } else if (chunk->owner_ == this) {
+                // The last attacher standing frees it instead. Hand the chunk over rather than
+                // leaving owner_ pointing at us, which is about to be freed.
+                chunk->owner_ = chunk->attachers_.front();
+            }
         }
+
+        attachs_.clear();
     }
 
     static bool should_do_cpu_manipulate(const std::uint32_t flags) {

--- a/src/emu/mem/src/model/flexible/process.cpp
+++ b/src/emu/mem/src/model/flexible/process.cpp
@@ -167,9 +167,9 @@ namespace eka2l1::mem::flexible {
             if (chunk->attachers_.empty()) {
                 fl_control->chunk_mngr_->destroy(chunk);
             } else if (chunk->owner_ == this) {
-                // The last attacher standing frees it instead. Hand the chunk over rather than
-                // leaving owner_ pointing at us, which is about to be freed.
-                chunk->owner_ = chunk->attachers_.front();
+                // Somebody else still has it mapped, so the last one out frees it. Stop claiming
+                // to own it: this process is about to be freed.
+                chunk->owner_ = nullptr;
             }
         }
 

--- a/src/emu/mem/src/model/multiple/chunk.cpp
+++ b/src/emu/mem/src/model/multiple/chunk.cpp
@@ -174,7 +174,6 @@ namespace eka2l1::mem {
             const auto pt_base = (running_offset >> control_->chunk_shift_) << control_->chunk_shift_;
             const vm_address crr_base_addr = base_;
 
-            multiple_mem_model_process *mul_process = reinterpret_cast<multiple_mem_model_process *>(own_process_);
             control_multiple *mul_ctrl = reinterpret_cast<control_multiple *>(control_);
 
             // Fill the entry
@@ -191,14 +190,15 @@ namespace eka2l1::mem {
                         off_start_just_unmapped = (poff << control_->page_size_bits_) + crr_base_addr + pt_base;
                     }
                 } else {
-                    // Map those just mapped to the CPU. It will love this
+                    // Invalidate the CPU TLB unconditionally: globally-visible pages
+                    // (shared/global sections, code) may sit in the running core's TLB
+                    // even when the chunk's owner is not the current address space, and
+                    // the host memory is about to be freed. Dirtying a stale-tagged or
+                    // foreign entry is always safe (it just re-resolves on next access).
                     if (size_just_unmapped != 0) {
                         // Use linear loop since the size is expected to be small
                         for (auto &mm : mul_ctrl->mmus_) {
-                            if (!own_process_ || mul_process->addr_space_id_ == mm->current_addr_space()) {
-                                mm->unmap_from_cpu(off_start_just_unmapped, size_just_unmapped);
-                                break;
-                            }
+                            mm->unmap_from_cpu(off_start_just_unmapped, size_just_unmapped);
                         }
 
                         size_just_unmapped = 0;
@@ -211,10 +211,7 @@ namespace eka2l1::mem {
             if (size_just_unmapped != 0) {
                 //LOG_TRACE(MEMORY, "Unmapped from CPU: 0x{:X}, size 0x{:X}", off_start_just_unmapped, size_just_unmapped);
                 for (auto &mm : mul_ctrl->mmus_) {
-                    if (!own_process_ || mul_process->addr_space_id_ == mm->current_addr_space()) {
-                        mm->unmap_from_cpu(off_start_just_unmapped, size_just_unmapped);
-                        break;
-                    }
+                    mm->unmap_from_cpu(off_start_just_unmapped, size_just_unmapped);
                 }
             }
 

--- a/src/emu/mem/src/model/multiple/process.cpp
+++ b/src/emu/mem/src/model/multiple/process.cpp
@@ -77,9 +77,17 @@ namespace eka2l1::mem {
         mchunk->own_process_ = this;
         mchunk->granularity_shift_ = control_->chunk_shift_;
 
-        chunk = reinterpret_cast<mem_model_chunk *>(mchunk);
+        const int result = mchunk->do_create(create_info);
 
-        return mchunk->do_create(create_info);
+        if (result != MEM_MODEL_CHUNK_ERR_OK) {
+            // Give the slot back and leave the out pointer untouched, so that the caller
+            // never ends up owning a chunk struct that was never initialised.
+            chunks_[mchunk->chunk_id_in_mmp_ - 1].reset();
+            return result;
+        }
+
+        chunk = reinterpret_cast<mem_model_chunk *>(mchunk);
+        return result;
     }
 
     void multiple_mem_model_process::delete_chunk(mem_model_chunk *chunk) {

--- a/src/tests/epoc/mem.cpp
+++ b/src/tests/epoc/mem.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch.hpp>
+
+#include <config/config.h>
+#include <mem/allocator/std_page_allocator.h>
+#include <mem/control.h>
+#include <mem/process.h>
+
+using namespace eka2l1;
+
+namespace {
+    struct mem_model_fixture {
+        config::state conf;
+        mem::basic_page_table_allocator alloc;
+        mem::control_impl control;
+        mem::mem_model_process_impl process;
+
+        explicit mem_model_fixture(const mem::mem_model_type model) {
+            control = mem::make_new_control(nullptr, &alloc, &conf, 12, false, model);
+            process = mem::make_new_mem_model_process(control.get(), model);
+        }
+    };
+
+    // No region flag at all, so the model finds no address-space section to
+    // allocate from and refuses the chunk. This is the cheapest deterministic
+    // failure both models share; the expensive one (exhausting a section) takes
+    // the same path out of do_create().
+    mem::mem_model_chunk_creation_info unsatisfiable_chunk() {
+        mem::mem_model_chunk_creation_info info;
+        info.size = 0x1000;
+        info.flags = mem::MEM_MODEL_CHUNK_TYPE_NORMAL;
+        info.perm = prot_read_write;
+
+        return info;
+    }
+}
+
+TEST_CASE("chunk_creation_failure_leaves_the_out_pointer_alone", "mem") {
+    // A refused chunk must not publish a half-built struct. kernel::chunk only
+    // logs when the model says no, so whatever is left in this pointer is what
+    // the guest gets a handle to -- and it dereferences it on the next call.
+    for (const auto model : { mem::mem_model_type::multiple, mem::mem_model_type::flexible }) {
+        mem_model_fixture fixture(model);
+
+        mem::mem_model_chunk *sentinel = reinterpret_cast<mem::mem_model_chunk *>(0x1);
+        mem::mem_model_chunk *chunk = sentinel;
+
+        REQUIRE(fixture.process->create_chunk(chunk, unsatisfiable_chunk()) != mem::MEM_MODEL_CHUNK_ERR_OK);
+        REQUIRE(chunk == sentinel);
+    }
+}
+
+TEST_CASE("chunk_creation_failure_does_not_leak_a_slot", "mem") {
+    // The multiple model reserves a chunk slot before do_create() runs, and a
+    // process only gets MAX_CHUNK_ALLOW_PER_PROCESS of them. Keeping the slot on
+    // failure turns a retry loop into the very exhaustion that made it fail:
+    // the code-chunk retry in the loader leaks one slot per attempt.
+    mem_model_fixture fixture(mem::mem_model_type::multiple);
+
+    for (int i = 0; i < 2048; i++) {
+        mem::mem_model_chunk *chunk = nullptr;
+        REQUIRE(fixture.process->create_chunk(chunk, unsatisfiable_chunk()) != mem::MEM_MODEL_CHUNK_ERR_OK);
+    }
+
+    // More failures than the process has slots, so a leak is certain to show
+    // here rather than depending on how many the caller happened to burn.
+    mem::mem_model_chunk_creation_info good = unsatisfiable_chunk();
+    good.flags |= mem::MEM_MODEL_CHUNK_REGION_USER_LOCAL;
+
+    mem::mem_model_chunk *chunk = nullptr;
+    REQUIRE(fixture.process->create_chunk(chunk, good) == mem::MEM_MODEL_CHUNK_ERR_OK);
+    REQUIRE(chunk != nullptr);
+
+    fixture.process->delete_chunk(chunk);
+}

--- a/src/tests/epoc/mem.cpp
+++ b/src/tests/epoc/mem.cpp
@@ -21,6 +21,7 @@
 
 #include <config/config.h>
 #include <mem/allocator/std_page_allocator.h>
+#include <mem/chunk.h>
 #include <mem/control.h>
 #include <mem/process.h>
 
@@ -90,4 +91,41 @@ TEST_CASE("chunk_creation_failure_does_not_leak_a_slot", "mem") {
     REQUIRE(chunk != nullptr);
 
     fixture.process->delete_chunk(chunk);
+}
+
+TEST_CASE("a_global_chunk_outlives_the_process_that_created_it", "mem") {
+    // Attaching to a chunk is not owning it: kernel::chunk::open_to() maps a global chunk
+    // (FbsSharedChunk, WsGlobalMemChunk, the skin chunk) into every process that opens a
+    // handle, and Symbian keeps such a chunk alive for as long as a handle exists. A process
+    // exiting must therefore not free a chunk struct somebody else still has mapped -- the
+    // survivor's attach info points straight at it.
+    //
+    // Without the fix this is a use-after-free rather than a wrong value, so it reports as a
+    // pass on an ordinary build and is caught under a sanitiser. It is written as a test
+    // anyway: it pins the ownership rule, and it is exactly the shape of regression an
+    // ASan job would exist to catch.
+    config::state conf;
+    mem::basic_page_table_allocator alloc;
+    mem::control_impl control = mem::make_new_control(nullptr, &alloc, &conf, 12, false,
+        mem::mem_model_type::flexible);
+
+    auto creator = mem::make_new_mem_model_process(control.get(), mem::mem_model_type::flexible);
+    auto opener = mem::make_new_mem_model_process(control.get(), mem::mem_model_type::flexible);
+
+    mem::mem_model_chunk_creation_info info = unsatisfiable_chunk();
+    info.flags |= mem::MEM_MODEL_CHUNK_REGION_USER_GLOBAL;
+
+    mem::mem_model_chunk *chunk = nullptr;
+    REQUIRE(creator->create_chunk(chunk, info) == mem::MEM_MODEL_CHUNK_ERR_OK);
+    REQUIRE(chunk != nullptr);
+
+    // A second process opens a handle to it and gets its own mapping.
+    REQUIRE(opener->attach_chunk(chunk));
+
+    // The creator exits first.
+    creator.reset();
+
+    // The chunk is still mapped by the opener, so it must still be there.
+    REQUIRE(chunk->max() >= 0x1000);
+    REQUIRE(opener->detach_chunk(chunk));
 }


### PR DESCRIPTION
Five defects in how a chunk is created, shared and torn down. They are sent together because they share one subject — who owns a chunk struct, and when the CPU may still hold a translation into it — and because three of them were found by the same crash shape: a host segfault inside the memory model with no guest fault to explain it.

These come out of the iOS fork, where they were found through crash reports from TestFlight builds. All five are in shared code and none of them is iOS-specific: the multiple model's slot leak and the hollow-chunk contract are reachable from any frontend, and the stale-TLB cases need only a global chunk and a process switch.

### A chunk struct that was never created still ran its destructor

`multiple_mem_model_chunk` left every member uninitialised, and its destructor opens with `decommit(0, max_size_)` unconditionally — so a struct whose `do_create()` failed walks `page_tabs_` with a garbage size and dereferences a page table id that was never assigned. This is reproducible on master: build the `chunk_creation_failure_does_not_leak_a_slot` case added below against an unmodified tree under ASan and it SEGVs through `~vector<unique_ptr<multiple_mem_model_chunk>>` at fixture teardown, because a failed struct was simply left in the array. `mapping` has the same shape — `occupied_` is only assigned by a successful `instantiate()`, while `~mapping()` always calls `unmap(0, occupied_)`, and `attach_chunk()` destroys a mapping whose `instantiate()` failed.

It is in this PR rather than its own because releasing the slot (below) moves that destructor to the moment of failure, so the two cannot land separately.

### A refused chunk was handed to the guest anyway

`kernel::chunk`'s constructor only logs when the memory model says no. The flexible model leaves its out pointer untouched on failure and the multiple model does the same once a process hits `MAX_CHUNK_ALLOW_PER_PROCESS`, so `mmc_impl_` stayed null while the object was already registered in the kernel. `chunk_new` only checked the handle, which comes from the handle table and is therefore always valid — so a guest that exhausted its address space got a positive handle back from `RChunk::CreateLocal()`, assumed success, and dereferenced null on the next call.

Adds `chunk::valid()`; `chunk_new` and `chunk_create_eka1` now close the handle and return `KErrNoMemory`, which is what Symbian reports. Also fixes `destroy()` dereferencing the owning process before its null check, and the deserialisation constructor leaving `mmc_impl_` uninitialised.

The `mmc_impl_` dereferences in `kernel::chunk` are guarded as well, and it is worth being explicit that this half is containment rather than a root-cause fix. The SVC path is the root cause and is fixed there: creation fails, so no hollow chunk reaches the guest. But roughly two dozen kernel-internal creation sites (FBS shared and large chunks, window server, skin, codeseg, thread stacks) ignore construction failure today, so a hollow chunk can still exist inside the emulator. Guarding makes those degrade to `0`/`false`/`KErrNoMemory` instead of taking the host process down. Auditing those call sites is a larger change and belongs in its own PR.

### The multiple model leaked a chunk slot per failed creation

It reserved the slot before `do_create()` and kept it when `do_create()` failed, so the loader's code-chunk retry pushed the process toward the very limit that made it fail. The slot is now released and the out pointer left untouched, so both models share one contract.

### The CPU TLB was not invalidated on a cross-process decommit

Both models gated TLB invalidation in `decommit()` on the chunk owner's address space being current. That is wrong for globally visible pages — the EKA1 shared section, code ranges, flexible kernel fixed mappings — which map at the same vaddr in every address space. A process can hold entries for a chunk owned by another, and destroying that chunk from a foreign context freed the host memory without ever dirtying them. The TLB only fully flushes on process switch, so the running process faulted on its next access. Dirtying an entry is a pure invalidation and always safe, so the address-space gate is dropped in both models.

### Flexible teardown detached mappings without clearing them

Process and fixed mappings were detached before `memory_object` destruction, and detach erased the only virtual-range record without touching the CPU TLB — so the same stale-translation crash survived the fix above. Page tables are now cleared and every MMU invalidated before a mapping is detached, and ordinary decommit is ordered so guest mappings disappear before host pages become inaccessible.

A shared chunk's `fixed_mapping_` was also registered in the memory object's mapping list by `do_create()` and never detached. Members destruct in reverse declaration order, so `fixed_mapping_` died before `mem_obj_` and `~memory_object` walked an already-freed mapping.

### Attaching to a flexible chunk was treated as owning it

`kernel::chunk::open_to()` maps a chunk into every process that opens a handle, so a global chunk (`FbsSharedChunk`, `FbsLargeChunk`, `WsGlobalMemChunk`, the skin chunk) ends up in the attach list of processes that did not create it — and `~flexible_mem_model_process` destroyed the chunk struct behind every entry in that list, owned or not. One process exiting freed a chunk its creator still had attached; at teardown, the first process freed one the next was about to walk. The mirror image existed too: a chunk dying through `delete_chunk()`, or through the kernel's standalone chunks that have no owning process at all, never told the other processes that had it mapped.

The chunk now tracks its attachers. `~flexible_mem_model_chunk` force-detaches whoever is left while its mapping list and memory object are still alive, which covers every way the struct can die, and `~flexible_mem_model_process` only frees the struct once nobody else has it mapped — handing ownership to a surviving attacher otherwise, since a global chunk is supposed to outlive its creator for as long as a handle exists.

The multiple/moving model is unaffected by this last one: its `attach_chunk()` returns unconditionally, so chunk structs only ever live in their owner's array.

## Testing

`src/tests/epoc/mem.cpp` was an empty file registered in the test target; it now covers the creation contract, which is the part of this reachable without a ROM:

- a refused chunk must not publish a struct — asserted against **both** models, since the point of the fix is that they agree;
- repeated failures must not consume slots — 2048 failed creations against a limit of 1024, then a creation that must still succeed;
- a global chunk outlives the process that created it — two processes, one attaches to the other's global chunk, the creator exits, the chunk must still be there.

The first two turn red (`2 failed`) if the creation-contract fix is reverted. The third is a use-after-free rather than a wrong value, so it passes on an ordinary build and is caught under a sanitiser — which is also how the uninitialised-member defect above was found, by running this suite under ASan for the first time.

The TLB fixes are the part not reachable from a host-only test, and were verified on device: a full teardown/rebuild across an X7 (flexible model) to 5320 device switch, which is the stack two of the crash reports came from, plus the fork's standard regression suite.

Local: `ctest` green on macOS both normally and under `-fsanitize=address` (114 test cases, 2418 assertions), and `eka2l1_qt` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
