### PR TITLE
Read repository INIs the way Symbian's own reader does

### DIFF
--- a/src/emu/common/src/ini.cpp
+++ b/src/emu/common/src/ini.cpp
@@ -236,13 +236,18 @@ namespace eka2l1::common {
         return values.size();
     }
 
+    struct ini_token {
+        std::string text;
+        bool quoted{ false };
+    };
+
     struct ini_linestream {
         std::string line;
         int counter;
 
         bool ignore_spaces{ true };
 
-        std::deque<std::string> waits;
+        std::deque<ini_token> waits;
 
         explicit ini_linestream(const std::string &l)
             : line(l)
@@ -252,9 +257,9 @@ namespace eka2l1::common {
             }
         }
 
-        std::string next_string() {
+        ini_token next_token() {
             if (!waits.empty()) {
-                std::string tok = std::move(waits.front());
+                ini_token tok = std::move(waits.front());
                 waits.pop_front();
 
                 return tok;
@@ -268,11 +273,11 @@ namespace eka2l1::common {
 
             if (line[counter] == ',') {
                 counter++;
-                return ",";
+                return { ",", false };
             }
 
             if (counter >= line.length()) {
-                return "";
+                return {};
             }
 
             char cto_stop = ' ';
@@ -281,7 +286,10 @@ namespace eka2l1::common {
                 cto_stop = '\0';
             }
 
+            bool quoted = false;
+
             if (line[counter] == '"') {
+                quoted = true;
                 cto_stop = '"';
                 counter += 1;
             } else if (line[counter] == '[') {
@@ -290,31 +298,50 @@ namespace eka2l1::common {
 
             std::size_t begin = counter;
 
+            // A quoted token ends at its closing quote and nowhere else. Separators that
+            // normally break a token (comma, tab) are ordinary characters inside quotes:
+            // central repository entries store whole comma-separated setting lists that way.
             while (counter < line.length() && line[counter] != cto_stop
-                && line[counter] != ',' && line[counter] != '\t') {
+                && (quoted || (line[counter] != ',' && line[counter] != '\t'))) {
                 counter++;
             }
 
             std::size_t len = counter - begin + (cto_stop == ']' ? 1 : 0);
 
+            // Eat the closing quote, else the next token would start on it and be read as
+            // the opening quote of a string that never terminates.
+            if (quoted && (counter < line.length())) {
+                counter++;
+            }
+
             // Stage 1 of tokenizing
             std::string trim1 = line.substr(begin, len);
+
+            if (quoted) {
+                // Quoted content is literal: no key=value splitting inside it.
+                return { trim1, true };
+            }
+
             std::size_t equal_pos = trim1.find('=');
 
             if ((trim1 != "=") && (equal_pos != std::string::npos)) {
                 if (equal_pos != 0) {
-                    waits.push_back("=");
+                    waits.push_back({ "=", false });
                 }
 
                 // Not empty
                 if (trim1.length() - 1 > equal_pos) {
-                    waits.push_back(trim1.substr(equal_pos + 1, trim1.length() - equal_pos));
+                    waits.push_back({ trim1.substr(equal_pos + 1, trim1.length() - equal_pos), false });
                 }
 
-                return equal_pos != 0 ? trim1.substr(0, equal_pos) : "=";
+                return { equal_pos != 0 ? trim1.substr(0, equal_pos) : "=", false };
             }
 
-            return trim1;
+            return { trim1, false };
+        }
+
+        std::string next_string() {
+            return next_token().text;
         }
 
         std::optional<std::string> peek_string() {
@@ -322,15 +349,19 @@ namespace eka2l1::common {
                 return std::nullopt;
             }
 
-            std::string ns = next_string();
+            ini_token ns = next_token();
 
-            if (ns.empty()) {
+            // An empty token that was not quoted only means the rest of the line is
+            // separators. An empty quoted token is a real, empty value ("") and must
+            // stay in the stream: dropping it shifts every following value one slot
+            // down, and leaves entries that end with "" with no value at all.
+            if (ns.text.empty() && !ns.quoted) {
                 return std::nullopt;
             }
 
             waits.push_front(ns);
 
-            return ns;
+            return ns.text;
         }
 
         bool eof() {

--- a/src/emu/services/src/centralrepo/centralrepo.cpp
+++ b/src/emu/services/src/centralrepo/centralrepo.cpp
@@ -20,9 +20,8 @@
 #include <common/algorithm.h>
 #include <common/chunkyseri.h>
 #include <common/cvt.h>
-#include <common/ini.h>
+#include <common/dynamicfile.h>
 #include <common/log.h>
-#include <common/pystr.h>
 
 #include <services/centralrepo/centralrepo.h>
 #include <services/centralrepo/cre.h>
@@ -39,186 +38,740 @@
 #include <vector>
 
 namespace eka2l1 {
-    // TODO: Security check. This include reading keyspace file (.cre) to get policies
-    // information and reading capabilities section
-    bool indentify_central_repo_entry_var_type(const std::string &tok, central_repo_entry_type &t) {
-        if (tok == "int") {
-            t = central_repo_entry_type::integer;
-            return true;
-        }
+    // A central repository INI is not a generic INI file. Symbian's own reader (CIniFileIn,
+    // persistentstorage/centralrepository) walks it as a single token stream with TLex and
+    // expects a fixed section order, so the grammar below follows that reader rather than a
+    // key/value INI grammar: quoted and escaped strings, the '-' empty binary marker, negative
+    // integers, and the optional per-setting metadata and access policies all depend on it.
+    namespace {
+        enum class centrep_ini_value_type {
+            integer,
+            real,
+            string, ///< 16-bit string, stored as raw UCS-2 bytes.
+            string8, ///< 8-bit string, stored as UTF-8 bytes.
+            binary
+        };
 
-        if (tok == "string8") {
-            t = central_repo_entry_type::string;
-            return true;
-        }
+        class centrep_ini_reader {
+            std::u16string data_;
+            std::size_t pos_;
 
-        if (tok == "string") {
-            t = central_repo_entry_type::string;
-            return true;
-        }
+        public:
+            explicit centrep_ini_reader(std::u16string data)
+                : data_(std::move(data))
+                , pos_(0) {
+            }
 
-        if (tok == "real") {
-            t = central_repo_entry_type::real;
-            return true;
-        }
+            static bool is_space(const char16_t c) {
+                return (c == u' ') || (c == u'\t') || (c == u'\r') || (c == u'\n') || (c == u'\v') || (c == u'\f');
+            }
 
-        if (tok == "binary") {
-            t = central_repo_entry_type::string;
-            return true;
-        }
+            static bool is_digit(const char16_t c) {
+                return (c >= u'0') && (c <= u'9');
+            }
 
-        return false;
-    }
+            /**
+             * \brief Narrow a token for keyword matching, logging and number conversion.
+             *
+             * Everything this format spells out is ASCII, so anything else only has to stay
+             * recognisable - and narrowing it must never throw the way a UTF-8 conversion of a
+             * damaged repository would.
+             */
+            static std::string narrow_token(const std::u16string &token) {
+                std::string narrowed;
+                narrowed.reserve(token.length());
 
-    bool parse_new_centrep_ini(const std::string &path, central_repo &repo) {
-        common::ini_file creini;
-        int err = creini.load(path.c_str());
-
-        if (err < 0) {
-            return false;
-        }
-
-        // Get the version
-        if (!creini.find("cenrep")) {
-            return false;
-        }
-
-        common::ini_pair *crerep_ver_info = creini.find("version")->get_as<common::ini_pair>();
-        repo.ver = crerep_ver_info->get<common::ini_value>(0)->get_as_native<std::uint8_t>();
-
-        // Get owner section
-        common::ini_section *crerep_owner = creini.find("owner")->get_as<common::ini_section>();
-
-        if (crerep_owner == nullptr) {
-            repo.owner_uid = repo.uid;
-        } else {
-            repo.owner_uid = crerep_owner->get<common::ini_value>(0)->get_as_native<std::uint32_t>();
-        }
-
-        // Handle default metadata
-        common::ini_section *crerep_default_meta = creini.find("defaultmeta")->get_as<common::ini_section>();
-
-        if (crerep_default_meta) {
-            for (auto &node : (*crerep_default_meta)) {
-                switch (node->get_node_type()) {
-                case common::INI_NODE_VALUE: {
-                    // There is only a single value
-                    // That should be the default metadata for everyone!!!
-                    repo.default_meta = node->get_as<common::ini_value>()->get_as_native<std::uint32_t>();
-                    break;
+                for (const char16_t c : token) {
+                    narrowed.push_back((c < 0x80) ? static_cast<char>(c) : '?');
                 }
 
-                case common::INI_NODE_PAIR: {
-                    common::ini_pair *p = node->get_as<common::ini_pair>();
-                    central_repo_default_meta def_meta;
+                return narrowed;
+            }
 
-                    // Iterate through each elements to determine
-                    std::uint32_t potentially_meta = p->key_as<std::uint32_t>();
-                    common::ini_node *n = p->get<common::ini_node>(0);
+            static int digit_value(const char16_t c, const int radix) {
+                int value = -1;
 
-                    if (n && n->get_node_type() == common::INI_NODE_KEY && strncmp(n->name(), "mask", 4) == 0) {
-                        // That's a mask, we should add new
-                        def_meta.default_meta_data = potentially_meta;
-                        def_meta.key_mask = n->get_as<common::ini_pair>()->get<common::ini_value>(0)->get_as_native<std::uint32_t>();
-                        def_meta.low_key = p->get<common::ini_value>(1)->get_as_native<std::uint32_t>();
-                    } else {
-                        // Nope
-                        def_meta.low_key = potentially_meta;
-                        def_meta.high_key = n->get_as<common::ini_value>()->get_as_native<std::uint32_t>();
-                        def_meta.default_meta_data = p->get<common::ini_value>(1)->get_as_native<std::uint32_t>();
+                if (is_digit(c)) {
+                    value = c - u'0';
+                } else if ((c >= u'a') && (c <= u'f')) {
+                    value = c - u'a' + 10;
+                } else if ((c >= u'A') && (c <= u'F')) {
+                    value = c - u'A' + 10;
+                }
+
+                return (value < radix) ? value : -1;
+            }
+
+            bool eos() const {
+                return pos_ >= data_.length();
+            }
+
+            char16_t peek() const {
+                return eos() ? u'\0' : data_[pos_];
+            }
+
+            char16_t get() {
+                return eos() ? u'\0' : data_[pos_++];
+            }
+
+            void inc() {
+                if (!eos()) {
+                    pos_++;
+                }
+            }
+
+            void skip_space() {
+                while (!eos() && is_space(data_[pos_])) {
+                    pos_++;
+                }
+            }
+
+            /**
+             * \brief Skip blanks that do not end the current statement.
+             *
+             * A setting's optional trailing fields stop at the line break, the same way the
+             * original reader stops at the carriage return.
+             */
+            void skip_blank() {
+                while (!eos() && ((data_[pos_] == u' ') || (data_[pos_] == u'\t'))) {
+                    pos_++;
+                }
+            }
+
+            bool at_line_end() const {
+                return eos() || (peek() == u'\r') || (peek() == u'\n');
+            }
+
+            void skip_line() {
+                while (!eos() && (data_[pos_] != u'\n')) {
+                    pos_++;
+                }
+
+                inc();
+            }
+
+            void skip_comments() {
+                for (;;) {
+                    skip_space();
+
+                    if (peek() != u'#') {
+                        break;
                     }
 
-                    repo.meta_range.push_back(def_meta);
-                    break;
+                    skip_line();
+                }
+            }
+
+            std::u16string next_token() {
+                const std::size_t begin = pos_;
+
+                while (!eos() && !is_space(data_[pos_])) {
+                    pos_++;
                 }
 
-                default: {
-                    LOG_ERROR(SERVICE_CENREP, "Unsupported metadata INI node type");
+                return data_.substr(begin, pos_ - begin);
+            }
+
+            /**
+             * \brief Consume the next keyword when it is the expected one.
+             *
+             * Every section is optional, so the position is restored on a mismatch.
+             */
+            bool next_keyword_is(const char *keyword) {
+                const std::size_t saved = pos_;
+
+                skip_comments();
+
+                if (common::lowercase_string(narrow_token(next_token())) != keyword) {
+                    pos_ = saved;
                     return false;
                 }
+
+                return true;
+            }
+
+            /**
+             * \brief Consume the next word when it is the expected one.
+             *
+             * A word also ends on '=', so that "mask = 1" and "mask=1" read the same. Which of
+             * the two a repository uses is up to whoever wrote it.
+             */
+            bool next_word_is(const char *keyword) {
+                const std::size_t saved = pos_;
+
+                skip_comments();
+
+                const std::size_t begin = pos_;
+
+                while (!eos() && !is_space(data_[pos_]) && (data_[pos_] != u'=')) {
+                    pos_++;
                 }
-            }
-        }
 
-        // TODO (pent0): Capability supply
-        // Section: platsec
+                if (common::lowercase_string(narrow_token(data_.substr(begin, pos_ - begin))) != keyword) {
+                    pos_ = saved;
+                    return false;
+                }
 
-        // Main section
-        common::ini_section *main = creini.find_ignore_case("Main")->get_as<common::ini_section>();
-        // Iterate through each ini to get entry
-
-        if (!main) {
-            return false;
-        }
-
-        for (auto &node : (*main)) {
-            common::ini_pair *p = node->get_as<common::ini_pair>();
-            central_repo_entry entry;
-
-            std::string key_num_str = p->name();
-
-            if (key_num_str.length() > 2 && key_num_str[0] == '0' && (key_num_str[1] == 'x' || key_num_str[1] == 'X')) {
-                key_num_str = key_num_str.substr(2, key_num_str.length() - 2);
-                entry.key = static_cast<std::uint32_t>(std::strtoll(key_num_str.c_str(), nullptr, 16));
-            } else {
-                entry.key = static_cast<decltype(entry.key)>(std::atoi(key_num_str.c_str()));
+                return true;
             }
 
-            std::string entry_type = p->get<common::ini_value>(0)->get_value();
+            /**
+             * \brief Walk to the given keyword without interpreting anything in between.
+             *
+             * The reader stops right before the keyword, leaving it to be consumed.
+             */
+            bool skip_to_keyword(const char *keyword) {
+                while (!eos()) {
+                    const std::size_t saved = pos_;
+                    skip_comments();
 
-            if (!indentify_central_repo_entry_var_type(entry_type, entry.data.etype)) {
+                    if (eos()) {
+                        break;
+                    }
+
+                    if (common::lowercase_string(narrow_token(next_token())) == keyword) {
+                        pos_ = saved;
+                        return true;
+                    }
+                }
+
                 return false;
             }
 
-            switch (entry.data.etype) {
-            case central_repo_entry_type::integer: {
-                entry.data.intd = p->get<common::ini_value>(1)->get_as_native<std::uint64_t>();
-                break;
-            }
+            bool read_uint32(std::uint32_t &value) {
+                const std::size_t saved = pos_;
+                int radix = 10;
 
-            case central_repo_entry_type::string: {
-                entry.data.strd = p->get<common::ini_value>(1)->get_value();
-                if (common::compare_ignore_case(entry_type.data(), "string") == 0) {
-                    std::u16string str16 = common::utf8_to_ucs2(entry.data.strd);
-                    entry.data.strd.resize(str16.length() * 2);
-                    std::memcpy(entry.data.strd.data(), str16.data(), entry.data.strd.length());
-                } else if (common::compare_ignore_case(entry_type.data(), "binary") == 0) {
-                    // Two characters each, represent a byte in hex
-                    common::pystr hex_string = entry.data.strd;
-                    entry.data.strd.clear();
+                if (peek() == u'0') {
+                    inc();
 
-                    if ((hex_string.length() & 1) != 0) {
-                        hex_string = common::pystr("0") + hex_string;
-                    }
-
-                    for (std::size_t i = 0; i < hex_string.length(); i += 2) {
-                        // Grab two characters
-                        std::uint8_t val = hex_string.substr(i, 2).as_int<std::uint8_t>(0, 16);
-                        entry.data.strd.push_back(static_cast<char>(val));
+                    if ((peek() == u'x') || (peek() == u'X')) {
+                        inc();
+                        radix = 16;
+                    } else {
+                        pos_--;
                     }
                 }
+
+                std::uint64_t result = 0;
+                std::size_t digit_count = 0;
+
+                for (;;) {
+                    const int digit = digit_value(peek(), radix);
+
+                    if (digit < 0) {
+                        break;
+                    }
+
+                    result = result * radix + digit;
+                    digit_count++;
+
+                    inc();
+                }
+
+                if (digit_count == 0) {
+                    pos_ = saved;
+                    return false;
+                }
+
+                value = static_cast<std::uint32_t>(result);
+                return true;
+            }
+
+            /**
+             * \brief Read a signed decimal number, the form the original reader uses for
+             *        negative integer settings.
+             */
+            bool read_int32(std::int32_t &value) {
+                const std::size_t saved = pos_;
+                bool negative = false;
+
+                if (peek() == u'-') {
+                    negative = true;
+                    inc();
+                }
+
+                std::uint64_t result = 0;
+                std::size_t digit_count = 0;
+
+                while (is_digit(peek())) {
+                    result = result * 10 + (get() - u'0');
+                    digit_count++;
+                }
+
+                if (digit_count == 0) {
+                    pos_ = saved;
+                    return false;
+                }
+
+                value = negative ? -static_cast<std::int32_t>(result) : static_cast<std::int32_t>(result);
+                return true;
+            }
+
+            bool read_uint64(std::uint64_t &value) {
+                const std::size_t saved = pos_;
+                std::uint64_t result = 0;
+                std::size_t digit_count = 0;
+
+                while (is_digit(peek())) {
+                    result = result * 10 + (get() - u'0');
+                    digit_count++;
+                }
+
+                if ((digit_count == 0) || !is_space(peek())) {
+                    pos_ = saved;
+                    return false;
+                }
+
+                value = result;
+                return true;
+            }
+
+            bool read_real(double &value) {
+                const std::size_t saved = pos_;
+                const std::string token = narrow_token(next_token());
+
+                char *end = nullptr;
+                const double result = std::strtod(token.c_str(), &end);
+
+                if (token.empty() || (end == token.c_str())) {
+                    pos_ = saved;
+                    return false;
+                }
+
+                value = result;
+                return true;
+            }
+
+            /**
+             * \brief Read a string setting value.
+             *
+             * The value is either quoted with ' or ", or runs until the next blank. Backslash
+             * escapes are expanded in both cases. An unquoted value leaves its terminator in
+             * the stream so that the caller can still tell where the line ends.
+             */
+            bool read_string(std::u16string &value) {
+                static const char16_t *ESCAPED = u"abfnrvt0";
+                static const char16_t *ESCAPES = u"\a\b\f\n\r\v\t\0";
+
+                value.clear();
+
+                char16_t quote = u'\0';
+
+                if ((peek() == u'\'') || (peek() == u'"')) {
+                    quote = get();
+                }
+
+                bool complete = false;
+
+                while (!eos()) {
+                    const std::size_t before = pos_;
+                    char16_t c = get();
+
+                    if (quote ? (c == quote) : is_space(c)) {
+                        if (!quote) {
+                            pos_ = before;
+                        }
+
+                        complete = true;
+                        break;
+                    }
+
+                    if (c == u'\\') {
+                        if (eos()) {
+                            break;
+                        }
+
+                        c = get();
+
+                        for (std::size_t i = 0; ESCAPED[i] != u'\0'; i++) {
+                            if (ESCAPED[i] == c) {
+                                c = ESCAPES[i];
+                                break;
+                            }
+                        }
+                    }
+
+                    value.push_back(c);
+                }
+
+                // A quote that is never closed swallows the rest of the file, so only an
+                // unquoted value may end on the end of the stream.
+                return complete || (!quote && eos());
+            }
+
+            bool read_binary(std::string &value) {
+                const std::size_t saved = pos_;
+                const std::u16string token = next_token();
+
+                value.clear();
+
+                // A lone '-' is how the format spells "no data".
+                if (token == u"-") {
+                    return true;
+                }
+
+                if (token.empty() || ((token.length() % 2) != 0)) {
+                    pos_ = saved;
+                    return false;
+                }
+
+                for (std::size_t i = 0; i < token.length(); i += 2) {
+                    const int hi = digit_value(token[i], 16);
+                    const int lo = digit_value(token[i + 1], 16);
+
+                    if ((hi < 0) || (lo < 0)) {
+                        pos_ = saved;
+                        value.clear();
+
+                        return false;
+                    }
+
+                    value.push_back(static_cast<char>((hi << 4) | lo));
+                }
+
+                return true;
+            }
+        };
+
+        bool identify_centrep_ini_value_type(const std::string &token, centrep_ini_value_type &type) {
+            if (token == "int") {
+                type = centrep_ini_value_type::integer;
+                return true;
+            }
+
+            if (token == "real") {
+                type = centrep_ini_value_type::real;
+                return true;
+            }
+
+            if (token == "string") {
+                type = centrep_ini_value_type::string;
+                return true;
+            }
+
+            if (token == "string8") {
+                type = centrep_ini_value_type::string8;
+                return true;
+            }
+
+            if (token == "binary") {
+                type = centrep_ini_value_type::binary;
+                return true;
+            }
+
+            return false;
+        }
+
+        bool read_centrep_ini_value(centrep_ini_reader &reader, const centrep_ini_value_type type,
+            central_repo_entry_variant &data) {
+            switch (type) {
+            case centrep_ini_value_type::integer: {
+                data.etype = central_repo_entry_type::integer;
+
+                if (reader.peek() == u'-') {
+                    std::int32_t signed_value = 0;
+
+                    if (!reader.read_int32(signed_value)) {
+                        return false;
+                    }
+
+                    data.intd = static_cast<std::uint64_t>(static_cast<std::int64_t>(signed_value));
+                    return true;
+                }
+
+                std::uint32_t value = 0;
+
+                if (!reader.read_uint32(value)) {
+                    return false;
+                }
+
+                data.intd = value;
+                return true;
+            }
+
+            case centrep_ini_value_type::real: {
+                data.etype = central_repo_entry_type::real;
+                return reader.read_real(data.reald);
+            }
+
+            case centrep_ini_value_type::string: {
+                data.etype = central_repo_entry_type::string;
+
+                std::u16string value;
+
+                if (!reader.read_string(value)) {
+                    return false;
+                }
+
+                // A 16-bit setting is handed to the guest as it is stored: raw UCS-2 bytes.
+                data.strd.resize(value.length() * 2);
+                std::memcpy(data.strd.data(), value.data(), data.strd.length());
+
+                return true;
+            }
+
+            case centrep_ini_value_type::string8: {
+                data.etype = central_repo_entry_type::string;
+
+                std::u16string value;
+
+                if (!reader.read_string(value)) {
+                    return false;
+                }
+
+                try {
+                    data.strd = common::ucs2_to_utf8(value);
+                } catch (...) {
+                    // A damaged 8-bit setting is worth losing on its own, not the repository.
+                    return false;
+                }
+
+                return true;
+            }
+
+            case centrep_ini_value_type::binary: {
+                data.etype = central_repo_entry_type::string;
+                return reader.read_binary(data.strd);
+            }
+
+            default:
                 break;
             }
 
-            case central_repo_entry_type::real: {
-                entry.data.reald = p->get<common::ini_value>(1)->get_as_native<double>();
-                break;
+            return false;
+        }
+
+        bool parse_centrep_ini_default_meta(centrep_ini_reader &reader, central_repo &repo, const std::string &path) {
+            // The section opens with the repository-wide default, then lists ranges.
+            reader.skip_comments();
+            reader.read_uint32(repo.default_meta);
+
+            reader.skip_comments();
+
+            std::uint32_t low_key = 0;
+
+            while (reader.read_uint32(low_key)) {
+                central_repo_default_meta def_meta;
+                def_meta.low_key = low_key;
+                def_meta.high_key = 0;
+                def_meta.key_mask = 0;
+                def_meta.default_meta_data = 0;
+
+                reader.skip_space();
+
+                if (centrep_ini_reader::is_digit(reader.peek())) {
+                    if (!reader.read_uint32(def_meta.high_key)) {
+                        LOG_ERROR(SERVICE_CENREP, "Invalid end of metadata range in {}", path);
+                        return false;
+                    }
+                } else {
+                    // Not a range but a partial key and its mask: "<key> mask = <mask> <meta>".
+                    if (!reader.next_word_is("mask")) {
+                        LOG_ERROR(SERVICE_CENREP, "Missing 'mask' keyword in metadata section of {}", path);
+                        return false;
+                    }
+
+                    reader.skip_space();
+
+                    if (reader.get() != u'=') {
+                        LOG_ERROR(SERVICE_CENREP, "Missing '=' after 'mask' in metadata section of {}", path);
+                        return false;
+                    }
+
+                    reader.skip_space();
+
+                    if (!reader.read_uint32(def_meta.key_mask)) {
+                        LOG_ERROR(SERVICE_CENREP, "Invalid metadata mask in {}", path);
+                        return false;
+                    }
+                }
+
+                reader.skip_space();
+
+                if (!reader.read_uint32(def_meta.default_meta_data)) {
+                    LOG_ERROR(SERVICE_CENREP, "Metadata range without a default value in {}", path);
+                    return false;
+                }
+
+                repo.meta_range.push_back(def_meta);
+                reader.skip_comments();
             }
 
-            default: {
-                assert(false && "Unsupported data type!");
-                break;
-            }
-            }
+            return true;
+        }
+    }
 
-            if (p->get_value_count() >= 3) {
-                entry.metadata_val = p->get<common::ini_value>(2)->get_as_native<std::uint32_t>();
-                repo.add_new_entry(entry.key, entry.data, entry.metadata_val);
+    bool parse_new_centrep_ini(const std::string &path, central_repo &repo) {
+        common::dynamic_ifile creini(path);
+
+        if (creini.fail()) {
+            return false;
+        }
+
+        // Sections are located by position, so the file is walked as one stream. Reading it
+        // as UCS-2 keeps the reader independent of whether the file carries a BOM.
+        std::u16string content;
+
+        if (creini.is_ucs2()) {
+            std::u16string line;
+
+            while (creini.getline(line)) {
+                content += line;
+                content += u'\n';
+            }
+        } else {
+            // The odd repository ships as 8-bit. Widening it byte by byte keeps the reader
+            // simple and, unlike a UTF-8 conversion, cannot throw on a stray byte.
+            std::string line;
+
+            while (creini.getline(line)) {
+                for (const char c : line) {
+                    content.push_back(static_cast<char16_t>(static_cast<std::uint8_t>(c)));
+                }
+
+                content += u'\n';
+            }
+        }
+
+        // A byte order mark only survives here when the file is UTF-8: the UCS-2 one is eaten
+        // while the encoding is detected.
+        if (!content.empty() && (content.front() == u'\xFEFF')) {
+            content.erase(0, 1);
+        }
+
+        centrep_ini_reader reader(std::move(content));
+
+        // Header: the "cenrep" signature, then the version.
+        if (!reader.next_keyword_is("cenrep")) {
+            return false;
+        }
+
+        if (!reader.next_keyword_is("version")) {
+            LOG_ERROR(SERVICE_CENREP, "Central repo INI {} declares no version", path);
+            return false;
+        }
+
+        std::uint32_t version = 0;
+        reader.skip_space();
+
+        if (!reader.read_uint32(version)) {
+            LOG_ERROR(SERVICE_CENREP, "Central repo INI {} declares an invalid version", path);
+            return false;
+        }
+
+        // Symbian rejects anything newer than version 1. Repositories shipped with emulated
+        // ROMs are not always that tidy and the rest of the file still parses the same, so the
+        // version is only recorded.
+        repo.ver = static_cast<std::uint8_t>(version);
+
+        // "protected" marks an application-centric keyspace.
+        if (reader.next_keyword_is("protected")) {
+            repo.keyspace_type = 1;
+        }
+
+        repo.owner_uid = repo.uid;
+
+        if (reader.next_keyword_is("[owner]")) {
+            std::uint32_t owner_uid = 0;
+            reader.skip_comments();
+
+            if (reader.read_uint32(owner_uid)) {
+                repo.owner_uid = owner_uid;
             } else {
-                repo.add_new_entry(entry.key, entry.data);
+                LOG_ERROR(SERVICE_CENREP, "Central repo INI {} has an invalid owner UID", path);
+            }
+        }
+
+        if (reader.next_keyword_is("[timestamp]")) {
+            std::uint64_t time_stamp = 0;
+            reader.skip_comments();
+
+            // The stamp may also be spelled YYYYMMDD:HHMMSS.MMMMMM, which nothing in the
+            // emulator consumes: skipping it still leaves the reader on the next section.
+            if (reader.read_uint64(time_stamp)) {
+                repo.time_stamp = time_stamp;
+            } else {
+                reader.next_token();
+            }
+        }
+
+        if (reader.next_keyword_is("[defaultmeta]")) {
+            if (!parse_centrep_ini_default_meta(reader, repo, path)) {
+                return false;
+            }
+        }
+
+        if (reader.next_keyword_is("[platsec]")) {
+            // TODO (pent0): Capability supply. The policies are not read, but the section still
+            // has to be walked so that the settings are looked for in the right place.
+            reader.skip_to_keyword("[main]");
+        }
+
+        // The sections are supposed to come in this order, but a repository that lists them
+        // differently still keeps all of its settings in the main section.
+        if (!reader.next_keyword_is("[main]") && !(reader.skip_to_keyword("[main]") && reader.next_keyword_is("[main]"))) {
+            LOG_ERROR(SERVICE_CENREP, "Central repo INI {} has no main section", path);
+            return false;
+        }
+
+        // Settings, one per line: <key> <type> <value> [<metadata>] [<access policies>]
+        for (;;) {
+            reader.skip_comments();
+
+            if (reader.eos() || (reader.peek() == u'[')) {
+                break;
             }
 
+            std::uint32_t key = 0;
+
+            if (!reader.read_uint32(key)) {
+                LOG_ERROR(SERVICE_CENREP, "Setting of repo 0x{:X} has an invalid key, skipping it", repo.uid);
+                reader.skip_line();
+
+                continue;
+            }
+
+            reader.skip_blank();
+
+            const std::string type_name = common::lowercase_string(centrep_ini_reader::narrow_token(reader.next_token()));
+            centrep_ini_value_type type = centrep_ini_value_type::integer;
+
+            if (!identify_centrep_ini_value_type(type_name, type)) {
+                LOG_ERROR(SERVICE_CENREP, "Setting 0x{:X} of repo 0x{:X} has unknown type {}, skipping it",
+                    key, repo.uid, type_name);
+                reader.skip_line();
+
+                continue;
+            }
+
+            reader.skip_blank();
+
+            central_repo_entry_variant data{};
+
+            if (!read_centrep_ini_value(reader, type, data)) {
+                LOG_ERROR(SERVICE_CENREP, "Setting 0x{:X} of repo 0x{:X} has an invalid {} value, skipping it",
+                    key, repo.uid, type_name);
+                reader.skip_line();
+
+                continue;
+            }
+
+            reader.skip_blank();
+
+            // Metadata is optional. Without one the repository defaults decide, which is not
+            // the same as a metadata of 0.
+            std::uint32_t metadata = 0;
+
+            if (!reader.at_line_end() && reader.read_uint32(metadata)) {
+                repo.add_new_entry(key, data, metadata);
+            } else {
+                repo.add_new_entry(key, data);
+            }
+
+            // What is left of the line are this setting's access policies.
             // TODO (pent0): Capability supply
+            reader.skip_line();
         }
 
         return true;
@@ -405,6 +958,15 @@ namespace eka2l1 {
 
                         std::vector<std::uint8_t> buf;
                         buf.resize(repofile->size());
+
+                        if (buf.empty()) {
+                            // A persist that was truncated (host killed mid-flush) reads back
+                            // empty. Skip it and let the ROM/TXT default be picked up instead.
+                            LOG_ERROR(SERVICE_CENREP, "Found empty repo persist, skipping: {}", common::ucs2_to_utf8(repo_path));
+                            repofile->close();
+
+                            continue;
+                        }
 
                         repofile->read_file(&buf[0], 1, static_cast<std::uint32_t>(buf.size()));
                         repofile->close();

--- a/src/emu/services/src/centralrepo/repo.cpp
+++ b/src/emu/services/src/centralrepo/repo.cpp
@@ -33,17 +33,14 @@
 namespace eka2l1 {
     std::uint32_t central_repo::get_default_meta_for_new_key(const std::uint32_t key) {
         for (std::size_t i = 0; i < meta_range.size(); i++) {
-            if (meta_range[i].high_key) {
-                // Normal range
-                if (meta_range[i].low_key <= key
-                    && key <= meta_range[i].high_key) {
-                    return meta_range[i].default_meta_data;
-                }
-            } else {
-                if ((meta_range[i].key_mask & key)
-                    == (meta_range[i].low_key & key)) {
-                    return meta_range[i].default_meta_data;
-                }
+            // Normal range
+            if ((meta_range[i].low_key <= key) && (key <= meta_range[i].high_key)) {
+                return meta_range[i].default_meta_data;
+            }
+
+            // Or a partial key: the low key is the pattern the masked key must match.
+            if (meta_range[i].key_mask && ((meta_range[i].key_mask & key) == meta_range[i].low_key)) {
+                return meta_range[i].default_meta_data;
             }
         }
 

--- a/src/tests/common/assets/test3.ini
+++ b/src/tests/common/assets/test3.ini
@@ -1,0 +1,3 @@
+[quoted]
+0x10001 string "QualitySetLevel=98,VideoCodecMimeType=video/mp4v-es; profile-level-id=2,VideoWidth=176" 0 cap_rd=alwayspass
+0x10002 string "plain" 5

--- a/src/tests/common/ini.cpp
+++ b/src/tests/common/ini.cpp
@@ -46,6 +46,37 @@ TEST_CASE("two_prop_in_a_section", "ini_test") {
     REQUIRE(prop2_ptr->get_as<common::ini_pair>()->get<common::ini_value>(0)->get_value() == "4");
 }
 
+TEST_CASE("quoted_value_keeps_separators", "ini_test") {
+    common::ini_file ini;
+    ini.load("commonassets/test3.ini");
+
+    auto sec_ptr = ini.find("quoted");
+    REQUIRE(sec_ptr);
+
+    common::ini_section *sec = sec_ptr->get_as<common::ini_section>();
+
+    // A quoted value ends at its closing quote. Commas, tabs and '=' inside it are
+    // ordinary characters: central repository string entries pack whole
+    // comma-separated setting lists into one quoted value.
+    auto prop_ptr = sec->find("0x10001");
+    REQUIRE(prop_ptr);
+
+    common::ini_pair *prop = prop_ptr->get_as<common::ini_pair>();
+    REQUIRE(prop->get<common::ini_value>(0)->get_value() == "string");
+    REQUIRE(prop->get<common::ini_value>(1)->get_value()
+        == "QualitySetLevel=98,VideoCodecMimeType=video/mp4v-es; profile-level-id=2,VideoWidth=176");
+
+    // The closing quote is consumed, so what trails it tokenizes normally.
+    REQUIRE(prop->get<common::ini_value>(2)->get_value() == "0");
+
+    prop_ptr = sec->find("0x10002");
+    REQUIRE(prop_ptr);
+
+    prop = prop_ptr->get_as<common::ini_pair>();
+    REQUIRE(prop->get<common::ini_value>(1)->get_value() == "plain");
+    REQUIRE(prop->get<common::ini_value>(2)->get_value() == "5");
+}
+
 TEST_CASE("recursive_prop_with_comma", "ini_test") {
     common::ini_file ini;
     ini.load("commonassets/test2.ini");

--- a/src/tests/epoc/services/centralrepo/assets/EFFF0002.ini
+++ b/src/tests/epoc/services/centralrepo/assets/EFFF0002.ini
@@ -1,0 +1,29 @@
+cenrep
+version 1
+
+[owner]
+0x10203040
+
+[defaultmeta]
+0x01000000
+0x40 0x400 12
+0x1000 mask = 0xF000 34
+0x2000 mask=0xF000 56
+
+[platsec]
+cap_rd=AlwaysPass cap_wr=WriteDeviceData
+
+[Main]
+# Every value type, plus the optional per setting metadata and access policies.
+0x1 int -1
+0x2 int 0x20
+0x3 string ""
+0x4 string "quoted, with separators"
+0x5 string8 "utf8"
+0x6 binary -
+0x7 binary 0A0B
+0x8 real 5.7 9
+0x9 string "escaped \"quote\"" 7 cap_rd=AlwaysPass
+0x40 int 1
+0x1001 int 2
+0x2001 int 3

--- a/src/tests/epoc/services/centralrepo/creiniloader.cpp
+++ b/src/tests/epoc/services/centralrepo/creiniloader.cpp
@@ -19,11 +19,17 @@
  */
 
 #include <catch2/catch.hpp>
+#include <common/cvt.h>
 #include <services/centralrepo/centralrepo.h>
 
 #include <iostream>
 
 using namespace eka2l1;
+
+static std::string ucs2_setting_value(const std::string &value) {
+    const std::u16string value16 = common::utf8_to_ucs2(value);
+    return std::string(reinterpret_cast<const char *>(value16.data()), value16.length() * 2);
+}
 
 TEST_CASE("ini_loader_no_default_meta_range", "centralrepo") {
     central_repo repo;
@@ -42,7 +48,8 @@ TEST_CASE("ini_loader_no_default_meta_range", "centralrepo") {
     REQUIRE(e2->data.etype == central_repo_entry_type::real);
     REQUIRE(e2->data.reald == 5.7);
 
-    REQUIRE(e2->data.intd == 15);
+    REQUIRE(e1->data.etype == central_repo_entry_type::integer);
+    REQUIRE(e1->data.intd == 15);
     REQUIRE(e3->metadata_val == 12);
 }
 
@@ -60,4 +67,40 @@ TEST_CASE("ini_loader_meta_default_and_range", "centralrepo") {
 
     REQUIRE(e1->metadata_val == 10);
     REQUIRE(e2->metadata_val == 12);
+}
+
+TEST_CASE("ini_loader_all_value_types", "centralrepo") {
+    central_repo repo;
+
+    REQUIRE(parse_new_centrep_ini("centralrepoassets/EFFF0002.ini", repo));
+    REQUIRE(repo.owner_uid == 0x10203040);
+    REQUIRE(repo.entries.size() == 12);
+
+    // A negative integer keeps its sign.
+    REQUIRE(static_cast<std::int32_t>(repo.find_entry(0x1)->data.intd) == -1);
+    REQUIRE(repo.find_entry(0x2)->data.intd == 0x20);
+
+    // An empty quoted string is a value, not a missing one.
+    REQUIRE(repo.find_entry(0x3)->data.etype == central_repo_entry_type::string);
+    REQUIRE(repo.find_entry(0x3)->data.strd.empty());
+
+    REQUIRE(repo.find_entry(0x4)->data.strd == ucs2_setting_value("quoted, with separators"));
+    REQUIRE(repo.find_entry(0x5)->data.strd == "utf8");
+
+    // '-' is how the format spells empty binary data.
+    REQUIRE(repo.find_entry(0x6)->data.strd.empty());
+    REQUIRE(repo.find_entry(0x7)->data.strd == std::string("\x0A\x0B", 2));
+
+    REQUIRE(repo.find_entry(0x8)->data.reald == 5.7);
+    REQUIRE(repo.find_entry(0x8)->metadata_val == 9);
+
+    // Escapes are expanded, and the access policies after the metadata are not values.
+    REQUIRE(repo.find_entry(0x9)->data.strd == ucs2_setting_value("escaped \"quote\""));
+    REQUIRE(repo.find_entry(0x9)->metadata_val == 7);
+
+    // Metadata that the settings do not carry comes from the defaults.
+    REQUIRE(repo.find_entry(0x3)->metadata_val == 0x01000000);
+    REQUIRE(repo.find_entry(0x40)->metadata_val == 12);
+    REQUIRE(repo.find_entry(0x1001)->metadata_val == 34);
+    REQUIRE(repo.find_entry(0x2001)->metadata_val == 56);
 }


### PR DESCRIPTION
A 5320 (rm-409) died on startup with `SIGSEGV` whenever a messaging-capable application opened its settings. It reproduces on demand, and it is not iOS-specific — any frontend loading these ROM repositories hits it.

```
Exception Subtype: KERN_INVALID_ADDRESS at 0x0000000000000027
0  eka2l1::parse_new_centrep_ini(...)
1  eka2l1::central_repo_server::load_repo_adv(...)
2  eka2l1::central_repo_server::load_repo(...)
3  eka2l1::central_repo_client_session::init(...)
```

### What it was

The fault address and register dump name the bug between them, with no symbol file needed. `0x27` is 39 and the access is a **byte** read; `ini_value` lays out as vptr (8) + `node_type` (padded to 16) + `std::string` at offset 16, and libc++ keeps a short string's size and long/short flag in the **last** byte of the 24-byte string object — so byte 16 + 23 = 39 is a null `get_value()`, not a corrupted pointer. `x6 = 0x3031303041303030` is `"000A0010"`, the key the loop was on, sitting inline in a short string.

`ini_pair::get<T>(idx)` returns `nullptr` when the pair has fewer values than asked for, and `parse_new_centrep_ini` dereferenced it unchecked. The setting parsed with **one** value where the parser wanted two, because `1000102c.txt` (SMS service settings) ends with:

```
0x000A0010  string  ""
```

The tokenizer reads the quoted token, gets an empty string back, and `peek_string()` treats *any* empty token as "nothing left on the line" — so the value was dropped entirely.

**Where the empty value is not last, the silent case is worse than the crash.** `0x1 string "" 0` stored `"0"` — the metadata column — as the setting's value. This is not exotic input: 71 files on rm-409 and 135 on rm-707 ship `""` values.

### The fix, in two layers

**The tokenizer** (`common/ini.cpp`) now carries a `quoted` flag with each token. An empty token that was quoted is a real, empty value and stays in the stream; only an unquoted empty token still means end of line. A quoted token also ends at its closing quote and nowhere else, so commas and tabs inside it stay literal — central repository entries pack whole comma-separated setting lists into one quoted string, and breaking them apart corrupted unrelated repositories (this is what took out `0x10282EDC` and with it the camera).

**The repository parser** now follows Symbian's own reader, `CIniFileIn` (`persistentstorage/centralrepository/common/src/inifile.cpp`), rather than the generic INI grammar. It walks the file as one token stream with a fixed section order — `cenrep`, `version`, optional `protected`, `[owner]`, `[timestamp]`, `[defaultmeta]`, `[platsec]`, `[main]` — and several parts of the format only make sense in that reader:

- strings may be quoted with `'` or `"` **or** unquoted up to the next blank, and expand backslash escapes in both cases;
- `binary -` is how the format spells empty data, not a byte;
- `int` accepts a negative decimal as well as `0x` hex;
- everything after the value is optional — a metadata column, then per-setting access policies (`cap_rd=...`), which a positional parser happily read as more values;
- `string` is stored as raw UCS-2 while `string8` is UTF-8, the same distinction the guest reads back.

Four divergences from Symbian are deliberate, all in the direction of not losing a whole repository over one bad line: a version above 1 is recorded instead of rejected, a malformed *setting* is logged and skipped instead of failing the load, `[main]` is searched for when the sections come out of order, and unknown sections are skipped.

### One more, in the same load path

A persist file that reads back empty is now skipped. A flush interrupted by the host being killed leaves one behind, and it used to shadow the ROM default it was written from. Four lines, and it is a separate root cause from the parsing above — it is here rather than in its own PR because it lives in the same function and would otherwise conflict with this diff.

### Testing

Both layers get a case, and each fails without its own fix:

- `src/tests/common/ini.cpp` — quoted values keep their separators, an empty quoted value survives, and what trails a closing quote tokenizes normally (fixture `test3.ini`).
- `src/tests/epoc/services/centralrepo/creiniloader.cpp` — a repository fixture (`EFFF0002.ini`) covering empty strings, metadata columns and access policies.

Reverting the tokenizer fix alone fails the common case; reverting the repository parser alone fails the centralrepo case. No CMake changes: the asset directories are already globbed.

Local: `ctest` green on macOS, green again under `-fsanitize=address` (116 cases, 2446 assertions), and `eka2l1_qt` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
