### PR TITLE
cpu/dyncom: speed up the interpreter, and add a differential test for it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -309,9 +309,35 @@ jobs:
   # job names carry their runner labels, so they change whenever an image is
   # swapped -- a required check pinned to those silently stops applying. This
   # one does not move.
+  dyncom-difftest:
+    name: dyncom differential test
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    # Same package set as the Linux desktop job. The harness itself only needs
+    # cpu + common + dynarmic, but src/emu/qt is added unconditionally on
+    # desktop, so CMake still has to find Qt at configure time.
+    - name: Set up build environment
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install build-essential libc6-dev libgtk-3-dev \
+          libpulse-dev libasound2-dev libsdl2-dev qt6-base-dev \
+          qt6-base-private-dev qt6-tools-dev qt6-tools-dev-tools \
+          qt6-l10n-tools libqt6svg6-dev
+
+    # Its own build directory on purpose: the harness needs
+    # EKA2L1_DYNCOM_DIFFTEST, which instruments the cpu library, so it must not
+    # share a tree with the jobs that publish artifacts.
+    - name: Run the dyncom differential test
+      run: ./scripts/cpu_difftest.sh 1 20000
+
   ci:
     name: CI
-    needs: [build-android, build-desktop, build-ios]
+    needs: [build-android, build-desktop, build-ios, dyncom-difftest]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -320,9 +346,11 @@ jobs:
         echo "android:  ${{ needs.build-android.result }}"
         echo "desktop:  ${{ needs.build-desktop.result }}"
         echo "ios:      ${{ needs.build-ios.result }}"
+        echo "difftest: ${{ needs.dyncom-difftest.result }}"
         if [ "${{ needs.build-android.result }}" != "success" ] || \
            [ "${{ needs.build-desktop.result }}" != "success" ] || \
-           [ "${{ needs.build-ios.result }}" != "success" ]; then
+           [ "${{ needs.build-ios.result }}" != "success" ] || \
+           [ "${{ needs.dyncom-difftest.result }}" != "success" ]; then
           echo "::error::A build or test job did not pass"
           exit 1
         fi

--- a/scripts/cpu_difftest.sh
+++ b/scripts/cpu_difftest.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Build and run the dyncom interpreter differential test harness on the host.
+#
+# Configures a lean host build (no tools/tests/scripting/Qt frontend), builds the
+# dyncom_difftest target, and runs it. dynarmic is built too: the harness uses it
+# as an independent oracle for whole-program cases.
+# Exits non-zero on the first divergence. This is the verification gate for the
+# harness-gated dyncom optimizations.
+#
+# Usage:
+#   scripts/cpu_difftest.sh                 # default seed/count
+#   scripts/cpu_difftest.sh <seed> <count>  # forwarded to the harness
+#
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+BUILD_DIR="build/host-difftest"
+
+cmake -S . -B "${BUILD_DIR}" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DEKA2L1_BUILD_TOOLS=OFF \
+    -DEKA2L1_BUILD_TESTS=OFF \
+    -DEKA2L1_ENABLE_SCRIPTING_ABILITY=OFF \
+    -DEKA2L1_ENABLE_DISCORD_RICH_PRESENCE=OFF \
+    -DEKA2L1_BUILD_DYNCOM_DIFFTEST=ON \
+    -DEKA2L1_CPU_DYNCOM_ONLY=OFF \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+    >/dev/null
+
+JOBS="$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)"
+cmake --build "${BUILD_DIR}" --target dyncom_difftest -j"${JOBS}"
+
+BIN="$(find "${BUILD_DIR}" -name dyncom_difftest -type f -perm -111 | head -1)"
+if [ -z "${BIN}" ]; then
+    echo "dyncom_difftest binary not found" >&2
+    exit 1
+fi
+
+echo "==> running ${BIN} $*"
+"${BIN}" "$@"

--- a/src/emu/cpu/CMakeLists.txt
+++ b/src/emu/cpu/CMakeLists.txt
@@ -90,7 +90,16 @@ add_library(cpu
         ${SOURCE_12L1R_PUBLIC}
         ${SOURCE_DYNCOM})
 
+# Build the CPU module with the dyncom interpreter only (no dynarmic). Used by
+# the dyncom differential test harness, which only needs the interpreter and
+# otherwise would drag in dynarmic (which fails to build host-side against newer
+# libc++ via boost's removed std::unary_function). Default OFF.
+option(EKA2L1_CPU_DYNCOM_ONLY "Build the CPU module with the dyncom interpreter only (no dynarmic)" OFF)
 
+# Instrument the dyncom interpreter to log guest opcode / instruction-pair /
+# block-length frequencies (used to target super-instruction fusion). Opt-in,
+# default OFF -> zero overhead in normal builds.
+option(EKA2L1_DYNCOM_PROFILE "Profile guest instruction/pair frequencies in the dyncom interpreter" OFF)
 
 # VFP's instruction-level trace sites sit directly on dyncom's hottest path: one
 # log line per float loaded or stored, each synchronously flushed (spdlog
@@ -105,11 +114,16 @@ endif()
 if (ARCHITECTURE_ARM32)
     target_sources(cpu PRIVATE ${SOURCE_12L1R})
     target_link_libraries(cpu PRIVATE Catch2)
-elseif (EKA2L1_IOS AND NOT EKA2L1_IOS_DYNARMIC)
+elseif ((EKA2L1_IOS AND NOT EKA2L1_IOS_DYNARMIC) OR EKA2L1_CPU_DYNCOM_ONLY)
     # iOS builds without EKA2L1_IOS_DYNARMIC run the dyncom interpreter only.
     # This is the App Store / TestFlight configuration: no JIT code is
     # compiled in.
     message(STATUS "cpu: linking without dynarmic (dyncom only)")
+    if (EKA2L1_CPU_DYNCOM_ONLY)
+        # On a non-iOS host the dynarmic-detection macro would otherwise pull in
+        # the dynarmic headers; force it off for the dyncom-only build.
+        target_compile_definitions(cpu PRIVATE EKA2L1_CPU_DYNCOM_ONLY_BUILD=1)
+    endif()
 else()
     target_sources(cpu PRIVATE
             include/cpu/arm_dynarmic.h
@@ -119,6 +133,11 @@ else()
             dynarmic)
 endif()
 
+if (EKA2L1_DYNCOM_PROFILE)
+    # PUBLIC so the ARMul_State layout (which gains two profiling fields) is
+    # consistent in every TU that includes armstate.h, avoiding an ODR mismatch.
+    target_compile_definitions(cpu PUBLIC EKA2L1_DYNCOM_PROFILE=1)
+endif()
 
 target_include_directories(cpu PUBLIC include)
 target_include_directories(cpu PRIVATE ${capstone_INCLUDE_DIRS})
@@ -127,3 +146,16 @@ target_link_libraries(cpu PUBLIC common)
 target_link_libraries(cpu
         PRIVATE
         capstone)
+
+# Differential test harness for the dyncom interpreter (self-A/B + golden ALU
+# oracle over randomized instruction streams). Standalone host tool, default OFF;
+# see scripts/cpu_difftest.sh.
+option(EKA2L1_BUILD_DYNCOM_DIFFTEST "Build the dyncom interpreter differential test harness" OFF)
+if (EKA2L1_BUILD_DYNCOM_DIFFTEST)
+    # The test-only VFP selector lets one process compare host-fast and
+    # reference-softfloat execution without changing production state.
+    target_compile_definitions(cpu PUBLIC EKA2L1_DYNCOM_DIFFTEST=1)
+    add_executable(dyncom_difftest src/dyncom/tests/dyncom_difftest.cpp)
+    target_link_libraries(dyncom_difftest PRIVATE cpu common dynarmic)
+
+endif()

--- a/src/emu/cpu/include/cpu/arm_dynarmic.h
+++ b/src/emu/cpu/include/cpu/arm_dynarmic.h
@@ -35,6 +35,15 @@ namespace eka2l1 {
     namespace arm {
         class dynarmic_core_callback;
 
+#if defined(EKA2L1_DYNCOM_DIFFTEST)
+        // Test-only instrumentation: dynarmic silently hands some instructions to
+        // its embedded dyncom interpreter. A differential harness that uses
+        // dynarmic as dyncom's oracle must be able to see that happen.
+        void dynarmic_note_interpreter_fallback_for_test(const std::size_t num_insts);
+        void dynarmic_reset_interpreter_fallback_for_test();
+        std::uint64_t dynarmic_interpreter_fallback_for_test();
+#endif
+
         class dynarmic_exclusive_monitor : public exclusive_monitor {
         private:
             friend class dynarmic_core;

--- a/src/emu/cpu/include/cpu/arm_interface.h
+++ b/src/emu/cpu/include/cpu/arm_interface.h
@@ -196,6 +196,13 @@ namespace eka2l1::arm {
         virtual void clear_instruction_cache() = 0;
         virtual void imb_range(address addr, std::size_t size) = 0;
 
+        // Informs the core which address space (process) is about to run, so a
+        // backend can tag its translation cache per-process instead of throwing
+        // it away on every context switch. No-op for backends that don't care.
+        virtual void set_asid(const std::uint32_t asid) {
+            (void)asid;
+        }
+
         virtual bool should_clear_old_memory_map() const {
             return true;
         }

--- a/src/emu/cpu/include/cpu/dyncom/arm_dyncom.h
+++ b/src/emu/cpu/include/cpu/dyncom/arm_dyncom.h
@@ -12,6 +12,15 @@
 #include <cpu/dyncom/armstate.h>
 
 namespace eka2l1::arm {
+#if defined(EKA2L1_DYNCOM_DIFFTEST)
+    // Test-only instrumentation for the translation-time loop accelerator. It
+    // only ever attaches during block translation, so a harness must be able to
+    // assert it was actually exercised rather than silently skipped.
+    void dyncom_reset_loop_accel_counters_for_test();
+    std::uint64_t dyncom_loop_accel_attaches_for_test();
+    std::uint64_t dyncom_loop_accel_bulk_iterations_for_test();
+#endif
+
     class dyncom_core final : public core {
     private:
         arm::exclusive_monitor *monitor_;
@@ -19,6 +28,12 @@ namespace eka2l1::arm {
         r12l1::tlb mem_cache_;
 
         std::uint32_t ticks_executed_;
+
+        // True once the scheduler starts feeding us asids (primary core). While
+        // false (e.g. the dyncom interpreter embedded in another backend as a
+        // fallback) we keep the old behaviour of wiping the translation cache on
+        // every load_context, since nobody tells us when the address space flips.
+        bool asid_instruction_cache_ = false;
 
     public:
         explicit dyncom_core(arm::exclusive_monitor *monitor, const std::size_t page_bits);
@@ -66,6 +81,8 @@ namespace eka2l1::arm {
         void clear_instruction_cache() override;
 
         void imb_range(address addr, std::size_t size) override;
+
+        void set_asid(const std::uint32_t asid) override;
 
         std::uint32_t get_num_instruction_executed() override;
 

--- a/src/emu/cpu/include/cpu/dyncom/armstate.h
+++ b/src/emu/cpu/include/cpu/dyncom/armstate.h
@@ -18,9 +18,11 @@
 #pragma once
 
 #include <array>
+#include <common/bytes.h>
 #include <common/types.h>
 #include <unordered_map>
 
+#include <cpu/12l1r/tlb.h>
 #include <cpu/dyncom/arm_regformat.h>
 
 namespace eka2l1::arm {
@@ -157,15 +159,123 @@ public:
 
     // Reads/writes data in big/little endian format based on the
     // state of the E (endian) bit in the APSR.
-    std::uint8_t ReadMemory8(std::uint32_t address) const;
-    std::uint16_t ReadMemory16(std::uint32_t address) const;
-    std::uint32_t ReadMemory32(std::uint32_t address) const;
-    std::uint64_t ReadMemory64(std::uint32_t address) const;
+    // The common case (the address is in the dyncom TLB) is inlined here so the
+    // load/store handlers pay no call overhead; a miss falls through to the
+    // out-of-line slow path (page-table walk, fault handling, big-endian,
+    // logging). mem_cache_ is the same TLB as core->mem_cache(), cached so this
+    // header needn't see the full dyncom_core. Read fast paths return the raw
+    // little-endian value (matching the previous TLB-hit behaviour); writes swap
+    // first so the stored bytes match.
+    std::uint8_t ReadMemory8(std::uint32_t address) const {
+        if (std::uint8_t *ptr = mem_cache_->lookup(address))
+            return *ptr;
+        return ReadMemory8Slow(address);
+    }
+    std::uint16_t ReadMemory16(std::uint32_t address) const {
+        if (std::uint16_t *ptr = reinterpret_cast<std::uint16_t *>(mem_cache_->lookup(address)))
+            return *ptr;
+        return ReadMemory16Slow(address);
+    }
+    std::uint32_t ReadMemory32(std::uint32_t address) const {
+        if (std::uint32_t *ptr = reinterpret_cast<std::uint32_t *>(mem_cache_->lookup(address)))
+            return *ptr;
+        return ReadMemory32Slow(address);
+    }
+    std::uint64_t ReadMemory64(std::uint32_t address) const {
+        if (std::uint64_t *ptr = reinterpret_cast<std::uint64_t *>(mem_cache_->lookup(address)))
+            return *ptr;
+        return ReadMemory64Slow(address);
+    }
     std::uint32_t ReadCode(std::uint32_t address) const;
-    void WriteMemory8(std::uint32_t address, std::uint8_t data);
-    void WriteMemory16(std::uint32_t address, std::uint16_t data);
-    void WriteMemory32(std::uint32_t address, std::uint32_t data);
-    void WriteMemory64(std::uint32_t address, std::uint64_t data);
+    void WriteMemory8(std::uint32_t address, std::uint8_t data) {
+        if (std::uint8_t *ptr = mem_cache_->lookup(address)) {
+            *ptr = data;
+            return;
+        }
+        WriteMemory8Slow(address, data);
+    }
+    void WriteMemory16(std::uint32_t address, std::uint16_t data) {
+        if (InBigEndianMode())
+            data = eka2l1::common::byte_swap(data);
+        if (std::uint16_t *ptr = reinterpret_cast<std::uint16_t *>(mem_cache_->lookup(address))) {
+            *ptr = data;
+            return;
+        }
+        WriteMemory16Slow(address, data);
+    }
+    void WriteMemory32(std::uint32_t address, std::uint32_t data) {
+        if (InBigEndianMode())
+            data = eka2l1::common::byte_swap(data);
+        if (std::uint32_t *ptr = reinterpret_cast<std::uint32_t *>(mem_cache_->lookup(address))) {
+            *ptr = data;
+            return;
+        }
+        WriteMemory32Slow(address, data);
+    }
+    void WriteMemory64(std::uint32_t address, std::uint64_t data) {
+        if (InBigEndianMode())
+            data = eka2l1::common::byte_swap(data);
+        if (std::uint64_t *ptr = reinterpret_cast<std::uint64_t *>(mem_cache_->lookup(address))) {
+            *ptr = data;
+            return;
+        }
+        WriteMemory64Slow(address, data);
+    }
+
+    // Cursor for bulk word transfers (LDM/STM). A register-list transfer touches a
+    // run of contiguous addresses that, in practice, all fall in one guest page, yet
+    // the naive loop pays a full TLB lookup per word. The cursor caches the resolved
+    // host page so a same-page run costs one lookup instead of one per word, and it
+    // re-resolves automatically when the run crosses a page boundary. Semantics are
+    // identical to ReadMemory32/WriteMemory32 (raw little-endian on a TLB hit, the
+    // out-of-line slow path on a miss, and the same big-endian write swap), so it is
+    // a drop-in replacement inside a single instruction's transfer loop.
+    struct block_cursor {
+        std::uint8_t *page_host = nullptr;
+        std::uint32_t page_base = 1; // sentinel: never equals a page-aligned address
+    };
+
+    std::uint32_t ReadMemory32Block(std::uint32_t address, block_cursor &c) const {
+        const std::uint32_t page_off = address & static_cast<std::uint32_t>(mem_cache_->page_mask);
+        if (c.page_host && (address - page_off) == c.page_base)
+            return *reinterpret_cast<std::uint32_t *>(c.page_host + page_off);
+        if (std::uint8_t *ptr = mem_cache_->lookup(address)) {
+            c.page_host = ptr - page_off;
+            c.page_base = address - page_off;
+            return *reinterpret_cast<std::uint32_t *>(ptr);
+        }
+        c.page_host = nullptr;
+        return ReadMemory32Slow(address);
+    }
+
+    void WriteMemory32Block(std::uint32_t address, std::uint32_t data, block_cursor &c) {
+        if (InBigEndianMode())
+            data = eka2l1::common::byte_swap(data);
+        const std::uint32_t page_off = address & static_cast<std::uint32_t>(mem_cache_->page_mask);
+        if (c.page_host && (address - page_off) == c.page_base) {
+            *reinterpret_cast<std::uint32_t *>(c.page_host + page_off) = data;
+            return;
+        }
+        if (std::uint8_t *ptr = mem_cache_->lookup(address)) {
+            c.page_host = ptr - page_off;
+            c.page_base = address - page_off;
+            *reinterpret_cast<std::uint32_t *>(ptr) = data;
+            return;
+        }
+        c.page_host = nullptr;
+        WriteMemory32Slow(address, data);
+    }
+
+    // Slow paths (TLB miss): out-of-line in armstate.cpp. Reads apply the
+    // big-endian swap themselves; writes receive data already swapped.
+    std::uint8_t ReadMemory8Slow(std::uint32_t address) const;
+    std::uint16_t ReadMemory16Slow(std::uint32_t address) const;
+    std::uint32_t ReadMemory32Slow(std::uint32_t address) const;
+    std::uint64_t ReadMemory64Slow(std::uint32_t address) const;
+    void WriteMemory8Slow(std::uint32_t address, std::uint8_t data);
+    void WriteMemory16Slow(std::uint32_t address, std::uint16_t data);
+    void WriteMemory32Slow(std::uint32_t address, std::uint32_t data);
+    void WriteMemory64Slow(std::uint32_t address, std::uint64_t data);
 
     void RaiseException(const int type, const std::uint32_t data);
     void RaiseSystemCall(std::uint32_t val);
@@ -238,12 +348,62 @@ public:
     unsigned bigendSig;
     unsigned syscallSig;
 
+    // Data TLB shared with the owning dyncom_core (== core->mem_cache()), cached
+    // here so the inline memory accessors above don't need the full dyncom_core
+    // definition. Set by dyncom_core right after construction.
+    eka2l1::arm::r12l1::tlb *mem_cache_ = nullptr;
+
     char trans_cache_buf[TRANS_CACHE_SIZE];
     size_t trans_cache_buf_top = 0;
 
-    // TODO(bunnei): Move this cache to a better place - it should be per codeset (likely per
-    // process for our purposes), not per ARMul_State (which tracks CPU core state).
-    std::unordered_map<std::uint32_t, std::size_t> instruction_cache;
+    // Translated basic blocks are tagged with the address space (asid) they were
+    // decoded in, so blocks from different processes coexist and survive the
+    // frequent guest thread/process switches instead of being thrown away on
+    // every context switch. Key = (asid << 32) | virtual_pc. The asid is pushed
+    // in by the scheduler through dyncom_core::set_asid on every process switch.
+    // In the multiple memory model (used by all current frontends) asids are
+    // never recycled within a session, so cached blocks stay valid until the
+    // code itself changes (handled separately via imb_range / clear).
+    std::unordered_map<std::uint64_t, std::size_t> instruction_cache;
+    std::uint32_t instruction_cache_asid = 0;
+
+#ifdef EKA2L1_DYNCOM_PROFILE
+    // Guest-execution profiler scratch (see arm_dyncom_interpreter.cpp): the
+    // previous executed opcode index within the current block and the running
+    // block length. -1 prev means "block start".
+    int prof_prev = -1;
+    std::uint32_t prof_block_len = 0;
+#endif
+
+    std::uint64_t make_instruction_cache_key(std::uint32_t vaddr) const {
+        return (static_cast<std::uint64_t>(instruction_cache_asid) << 32) | vaddr;
+    }
+
+    // Direct-mapped L1 in front of instruction_cache. DISPATCH runs on every
+    // taken branch; an index+compare here turns the common case into a hit that
+    // skips the unordered_map hash/bucket-walk/modulo. Entries are tagged with
+    // the full (asid|vpc) key so they coexist across processes; they only need
+    // clearing when the block map / translation buffer is flushed. Keys are
+    // seeded to a value no real key can take (real high word = asid <= 255).
+    static constexpr std::size_t BLOCK_L1_BITS = 11; // 2048 entries (~32 KB)
+    static constexpr std::size_t BLOCK_L1_COUNT = 1 << BLOCK_L1_BITS;
+    static constexpr std::uint64_t BLOCK_L1_EMPTY = ~static_cast<std::uint64_t>(0);
+
+    struct block_l1_entry {
+        std::uint64_t key;
+        std::size_t ptr;
+    };
+    block_l1_entry block_l1_cache[BLOCK_L1_COUNT];
+
+    void flush_block_l1_cache() {
+        for (std::size_t i = 0; i < BLOCK_L1_COUNT; i++) {
+            block_l1_cache[i].key = BLOCK_L1_EMPTY;
+        }
+    }
+
+    static std::size_t block_l1_index(std::uint64_t key) {
+        return (key ^ (key >> 32)) & (BLOCK_L1_COUNT - 1);
+    }
 
 private:
     void ResetMPCoreCP15Registers();

--- a/src/emu/cpu/include/cpu/dyncom/armsupp.h
+++ b/src/emu/cpu/include/cpu/dyncom/armsupp.h
@@ -15,7 +15,29 @@
 bool AddOverflow(std::uint32_t, std::uint32_t, std::uint32_t);
 bool SubOverflow(std::uint32_t, std::uint32_t, std::uint32_t);
 
-std::uint32_t AddWithCarry(std::uint32_t, std::uint32_t, std::uint32_t, bool *, bool *);
+// Hot path: called by every ADD/ADC/SUB/SBC/RSB/RSC/CMP/CMN. Inlined so the
+// add/sub instruction handlers pay no call overhead; the 64-bit sum carries
+// the carry-out in bit 32 and folds to a single host add on 64-bit targets. Overflow keeps the canonical
+// "32-bit signed result differs from the exact sum" definition (provably
+// correct) and is only computed when the caller wants the flag.
+inline std::uint32_t AddWithCarry(std::uint32_t left, std::uint32_t right, std::uint32_t carry_in,
+    bool *carry_out_occurred, bool *overflow_occurred) {
+    const std::uint64_t unsigned_sum = static_cast<std::uint64_t>(left)
+        + static_cast<std::uint64_t>(right) + static_cast<std::uint64_t>(carry_in);
+    const std::uint32_t result = static_cast<std::uint32_t>(unsigned_sum);
+
+    if (carry_out_occurred)
+        *carry_out_occurred = (unsigned_sum >> 32) != 0;
+
+    if (overflow_occurred) {
+        const std::int64_t signed_sum = static_cast<std::int64_t>(static_cast<std::int32_t>(left))
+            + static_cast<std::int32_t>(right) + static_cast<std::int64_t>(carry_in);
+        *overflow_occurred = (static_cast<std::int64_t>(static_cast<std::int32_t>(result)) != signed_sum);
+    }
+
+    return result;
+}
+
 bool ARMul_AddOverflowQ(std::uint32_t, std::uint32_t);
 
 std::uint8_t ARMul_SignedSaturatedAdd8(std::uint8_t, std::uint8_t);

--- a/src/emu/cpu/include/cpu/dyncom/vfp/vfp.h
+++ b/src/emu/cpu/include/cpu/dyncom/vfp/vfp.h
@@ -22,7 +22,13 @@
 
 #include <cpu/dyncom/vfp/vfp_helper.h> /* for references to cdp SoftFloat functions */
 
-#define VFP_DEBUG_UNTESTED(x) LOG_TRACE(eka2l1::CPU_DYNCOM, "in func {}, " #x " untested", __FUNCTION__);
+#if defined(EKA2L1_DYNCOM_DISABLE_VFP_TRACE)
+#define VFP_LOG_TRACE(...) ((void)0)
+#else
+#define VFP_LOG_TRACE(...) LOG_TRACE(__VA_ARGS__)
+#endif
+
+#define VFP_DEBUG_UNTESTED(x) VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "in func {}, " #x " untested", __FUNCTION__);
 #define CHECK_VFP_ENABLED
 #define CHECK_VFP_CDP_RET vfp_raise_exceptions(cpu, ret, inst_cream->instr, cpu->VFP[VFP_FPSCR]);
 
@@ -35,6 +41,12 @@ void vfp_put_double(ARMul_State *state, std::uint64_t val, std::uint32_t reg);
 void vfp_raise_exceptions(ARMul_State *state, std::uint32_t exceptions, std::uint32_t inst, std::uint32_t fpscr);
 std::uint32_t vfp_single_cpdo(ARMul_State *state, std::uint32_t inst, std::uint32_t fpscr);
 std::uint32_t vfp_double_cpdo(ARMul_State *state, std::uint32_t inst, std::uint32_t fpscr);
+
+#if defined(EKA2L1_DYNCOM_DIFFTEST)
+void vfp_set_single_host_fast_for_test(bool enabled);
+void vfp_reset_single_host_fast_hits_for_test();
+std::uint64_t vfp_single_host_fast_hits_for_test();
+#endif
 
 void VMOVBRS(ARMul_State *state, std::uint32_t to_arm, std::uint32_t t, std::uint32_t n, std::uint32_t *value);
 void VMOVBRRD(ARMul_State *state, std::uint32_t to_arm, std::uint32_t t, std::uint32_t t2, std::uint32_t n, std::uint32_t *value1, std::uint32_t *value2);

--- a/src/emu/cpu/src/arm_dynarmic.cpp
+++ b/src/emu/cpu/src/arm_dynarmic.cpp
@@ -27,6 +27,22 @@
 #include <dynarmic/interface/A32/coprocessor.h>
 
 namespace eka2l1::arm {
+#if defined(EKA2L1_DYNCOM_DIFFTEST)
+    static std::uint64_t g_interpreter_fallback_insts = 0;
+
+    void dynarmic_note_interpreter_fallback_for_test(const std::size_t num_insts) {
+        g_interpreter_fallback_insts += num_insts;
+    }
+
+    void dynarmic_reset_interpreter_fallback_for_test() {
+        g_interpreter_fallback_insts = 0;
+    }
+
+    std::uint64_t dynarmic_interpreter_fallback_for_test() {
+        return g_interpreter_fallback_insts;
+    }
+#endif
+
     class dynarmic_core_cp15 : public Dynarmic::A32::Coprocessor {
         std::uint32_t uprw;
         std::uint32_t data_sync_barrier;
@@ -236,6 +252,14 @@ namespace eka2l1::arm {
         }
 
         void InterpreterFallback(Dynarmic::A32::VAddr addr, size_t num_insts) override {
+#if defined(EKA2L1_DYNCOM_DIFFTEST)
+            // The differential harness uses dynarmic as an independent oracle for
+            // dyncom. Any instruction that lands here is executed by dynarmic's
+            // *embedded dyncom*, so the case degenerates into dyncom-vs-dyncom and
+            // proves nothing. Count it so the harness can reject those cases
+            // instead of scoring them as agreement.
+            dynarmic_note_interpreter_fallback_for_test(num_insts);
+#endif
             if (!parent.interpreter_callback_inited) {
                 parent.interpreter.read_code = parent.read_code;
                 parent.interpreter.read_8bit = parent.read_8bit;

--- a/src/emu/cpu/src/dyncom/arm_dyncom.cpp
+++ b/src/emu/cpu/src/dyncom/arm_dyncom.cpp
@@ -30,6 +30,9 @@ namespace eka2l1::arm {
         , ticks_executed_(0)
         , mem_cache_(page_bits) {
         state_ = std::make_unique<ARMul_State>(this, USER32MODE);
+        // Cache the data TLB on the state so the inline memory accessors can hit
+        // it without needing the full dyncom_core definition in armstate.h.
+        state_->mem_cache_ = &mem_cache_;
     }
 
     dyncom_core::~dyncom_core() {
@@ -129,7 +132,13 @@ namespace eka2l1::arm {
     }
 
     void dyncom_core::load_context(const thread_context &ctx) {
-        clear_instruction_cache();
+        // When the scheduler drives asids (primary core), translated blocks are
+        // tagged per address space and stay valid across thread/process switches,
+        // so there is no need to wipe the cache here. Only the fallback-embedded
+        // interpreter, which never receives an asid, still clears eagerly.
+        if (!asid_instruction_cache_) {
+            clear_instruction_cache();
+        }
 
         for (uint8_t i = 0; i < 16; i++) {
             state_->Reg[i] = ctx.cpu_registers[i];
@@ -160,10 +169,16 @@ namespace eka2l1::arm {
     void dyncom_core::clear_instruction_cache() {
         state_->instruction_cache.clear();
         state_->trans_cache_buf_top = 0;
+        state_->flush_block_l1_cache();
     }
 
     void dyncom_core::imb_range(address addr, std::size_t size) {
         clear_instruction_cache();
+    }
+
+    void dyncom_core::set_asid(const std::uint32_t asid) {
+        state_->instruction_cache_asid = asid;
+        asid_instruction_cache_ = true;
     }
 
     std::uint32_t dyncom_core::get_num_instruction_executed() {

--- a/src/emu/cpu/src/dyncom/arm_dyncom_interpreter.cpp
+++ b/src/emu/cpu/src/dyncom/arm_dyncom_interpreter.cpp
@@ -5,6 +5,7 @@
 #define CITRA_IGNORE_EXIT(x)
 
 #include <algorithm>
+#include <bit>
 #include <cinttypes>
 #include <common/log.h>
 #include <common/types.h>
@@ -17,6 +18,8 @@
 #include <cpu/dyncom/armsupp.h>
 #include <cpu/dyncom/vfp/vfp.h>
 #include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #include <cpu/arm_interface.h>
 
@@ -30,12 +33,10 @@
 #define ROTATE_RIGHT_32(n, i) ROTATE_RIGHT(n, i, 32)
 #define ROTATE_LEFT_32(n, i) ROTATE_LEFT(n, i, 32)
 
-static bool CondPassed(const ARMul_State *cpu, unsigned int cond) {
-    const bool n_flag = cpu->NFlag != 0;
-    const bool z_flag = cpu->ZFlag != 0;
-    const bool c_flag = cpu->CFlag != 0;
-    const bool v_flag = cpu->VFlag != 0;
-
+// Reference predicate for one (cond, NZCV) combination; only used at compile
+// time to build the branchless lookup table below.
+static constexpr bool CondPassedRef(unsigned int cond, bool n_flag, bool z_flag, bool c_flag,
+    bool v_flag) {
     switch (cond) {
     case ConditionCode::EQ:
         return z_flag;
@@ -71,6 +72,945 @@ static bool CondPassed(const ARMul_State *cpu, unsigned int cond) {
     }
 
     return false;
+}
+
+// Bit f of kCondPassedTable[cond] answers CondPassedRef for the flag nibble
+// f = N<<3 | Z<<2 | C<<1 | V, turning the per-instruction predicate into one
+// load + shift that the compiler can inline at every handler site.
+static constexpr std::uint16_t BuildCondMask(unsigned int cond) {
+    std::uint16_t mask = 0;
+    for (unsigned int f = 0; f < 16; ++f) {
+        if (CondPassedRef(cond, (f >> 3) & 1, (f >> 2) & 1, (f >> 1) & 1, f & 1))
+            mask = static_cast<std::uint16_t>(mask | (1u << f));
+    }
+    return mask;
+}
+
+static constexpr std::uint16_t kCondPassedTable[16] = {
+    BuildCondMask(0), BuildCondMask(1), BuildCondMask(2), BuildCondMask(3),
+    BuildCondMask(4), BuildCondMask(5), BuildCondMask(6), BuildCondMask(7),
+    BuildCondMask(8), BuildCondMask(9), BuildCondMask(10), BuildCondMask(11),
+    BuildCondMask(12), BuildCondMask(13), BuildCondMask(14), BuildCondMask(15)
+};
+
+#if defined(_MSC_VER)
+#define DYNCOM_FORCE_INLINE __forceinline
+#else
+#define DYNCOM_FORCE_INLINE inline __attribute__((always_inline))
+#endif
+
+static DYNCOM_FORCE_INLINE bool CondPassed(const ARMul_State *cpu, unsigned int cond) {
+    const unsigned int flags = ((cpu->NFlag != 0) << 3) | ((cpu->ZFlag != 0) << 2)
+        | ((cpu->CFlag != 0) << 1) | (cpu->VFlag != 0);
+    return (kCondPassedTable[cond & 15] >> flags) & 1;
+}
+
+// ---------------------------------------------------------------------------
+// Optional guest-execution profiler (-DEKA2L1_DYNCOM_PROFILE). Counts, per
+// executed instruction, the opcode and the (previous,current) consecutive pair
+// within a basic block, plus the per-block instruction-count distribution, and
+// periodically logs the hottest opcodes / pairs. Used to pick which instruction
+// patterns are worth fusing into super-ops. Zero overhead when not defined.
+// ---------------------------------------------------------------------------
+#ifdef EKA2L1_DYNCOM_PROFILE
+#include <algorithm>
+#include <vector>
+namespace {
+    constexpr int PROF_NUM_OPS = 202; // == arm_instruction_trans_len
+    const char *kProfOpNames[PROF_NUM_OPS] = {
+        "VMLA","VMLS","VNMLA","VNMLS","VNMUL","VMUL","VADD","VSUB","VDIV","VMOVI","VMOVR","VABS","VNEG","VSQRT","VCMP",
+        "VCMP2","VCVTBDS","VCVTBFF","VCVTBFI","VMOVBRS","VMSR","VMOVBRC","VMRS","VMOVBCR","VMOVBRRSS","VMOVBRRD","VSTR",
+        "VPUSH","VSTM","VPOP","VLDR","VLDM","SRS","RFE","BKPT","BLX","CPS","PLD","SETEND","CLREX","REV16","USAD8","SXTB",
+        "UXTB","SXTH","SXTB16","UXTH","UXTB16","CPY","UXTAB","SSUB8","SHSUB8","SSUBADDX","STREX","STREXB","SWP","SWPB",
+        "SSUB16","SSAT16","SHSUBADDX","QSUBADDX","SHADDSUBX","SHADD8","SHADD16","SEL","SADDSUBX","SADD8","SADD16","SHSUB16",
+        "UMAAL","UXTAB16","USUBADDX","USUB8","USUB16","USAT16","USADA8","UQSUBADDX","UQSUB8","UQSUB16","UQADDSUBX","UQADD8",
+        "UQADD16","SXTAB","UHSUBADDX","UHSUB8","UHSUB16","UHADDSUBX","UHADD8","UHADD16","UADDSUBX","UADD8","UADD16","SXTAH",
+        "SXTAB16","QADD8","BXJ","CLZ","UXTAH","BX","REV","BLX2","REVSH","QADD","QADD16","QADDSUBX","LDREX","QDADD","QDSUB",
+        "QSUB","LDREXB","QSUB8","QSUB16","SMUAD","SMMUL","SMUSD","SMLSD","SMLSLD","SMMLA","SMMLS","SMLALD","SMLAD","SMLAW",
+        "SMULW","PKHTB","PKHBT","SMUL","SMLALXY","SMLA","MCRR","MRRC","CMP","TST","TEQ","CMN","SMULL","UMULL","UMLAL",
+        "SMLAL","MUL","MLA","SSAT","USAT","MRS","MSR","AND","BIC","LDM","EOR","ADD","RSB","RSC","SBC","ADC","SUB","ORR",
+        "MVN","MOV","STM","LDM2","LDRSH","STM2","LDM3","LDRSB","STRD","LDRH","STRH","LDRD","STRT","STRBT","LDRBT","LDRT",
+        "MRC","MCR","MSR2","MSR3","MSR4","MSR5","MSR6","LDRB","STRB","LDR","LDRCOND","STR","CDP","STC","LDC","LDREXD",
+        "STREXD","LDREXH","STREXH","NOP","YIELD","WFE","WFI","SEV","SWI","BBL","B_2_THUMB","B_COND_THUMB","BL_1_THUMB",
+        "BL_2_THUMB","BLX_1_THUMB"
+    };
+    inline const char *prof_op_name(int idx) {
+        return (idx >= 0 && idx < PROF_NUM_OPS) ? kProfOpNames[idx] : "?";
+    }
+    struct dyncom_profiler {
+        std::uint64_t op_count[PROF_NUM_OPS] = {};
+        std::vector<std::uint64_t> pair_count;
+        std::uint64_t block_len[64] = {};
+        std::uint64_t total_insts = 0;
+        std::uint64_t total_blocks = 0;
+        std::uint64_t next_dump = 50000000ull;
+        // Sparse guest-PC histogram (64-byte buckets, sampled every 64th
+        // instruction) to attribute hot loops to guest code regions. The code
+        // bytes are snapshotted on first touch, while the bucket's page is
+        // guaranteed mapped in the current process (reading them at dump time
+        // from an unrelated process faults the guest).
+        struct pc_bucket {
+            std::uint64_t count = 0;
+            std::uint32_t code[16] = {};
+        };
+        std::unordered_map<std::uint32_t, pc_bucket> pc_hist;
+        std::uint64_t pc_samples = 0;
+        dyncom_profiler()
+            : pair_count(static_cast<std::size_t>(PROF_NUM_OPS) * PROF_NUM_OPS, 0) {}
+    };
+    dyncom_profiler g_dyncom_profiler;
+
+    void dyncom_profile_dump(ARMul_State *cpu) {
+        dyncom_profiler &p = g_dyncom_profiler;
+        if (p.total_insts == 0)
+            return;
+        // Write to a plain file in the cwd (Documents/data on iOS) so the output
+        // bypasses the per-category log filter (CPU.DynCom is silenced there).
+        std::FILE *f = std::fopen("dyncom_profile.txt", "w");
+        if (!f)
+            return;
+        std::fprintf(f, "=== dyncom profile: %llu insts, %llu blocks, %.2f insts/block ===\n",
+            (unsigned long long)p.total_insts, (unsigned long long)p.total_blocks,
+            p.total_blocks ? (double)p.total_insts / p.total_blocks : 0.0);
+        std::vector<int> ops(PROF_NUM_OPS);
+        for (int i = 0; i < PROF_NUM_OPS; i++) ops[i] = i;
+        std::sort(ops.begin(), ops.end(), [&](int a, int b) { return p.op_count[a] > p.op_count[b]; });
+        for (int i = 0; i < 25 && p.op_count[ops[i]]; i++)
+            std::fprintf(f, "  op   %-12s %13llu (%.1f%%)\n", prof_op_name(ops[i]), (unsigned long long)p.op_count[ops[i]],
+                100.0 * (double)p.op_count[ops[i]] / p.total_insts);
+        std::vector<std::size_t> pairs;
+        for (std::size_t i = 0; i < p.pair_count.size(); i++)
+            if (p.pair_count[i]) pairs.push_back(i);
+        std::sort(pairs.begin(), pairs.end(), [&](std::size_t a, std::size_t b) { return p.pair_count[a] > p.pair_count[b]; });
+        for (std::size_t i = 0; i < 40 && i < pairs.size(); i++) {
+            const int a = static_cast<int>(pairs[i] / PROF_NUM_OPS);
+            const int b = static_cast<int>(pairs[i] % PROF_NUM_OPS);
+            std::fprintf(f, "  pair %-10s -> %-10s %13llu (%.1f%%)\n", prof_op_name(a), prof_op_name(b),
+                (unsigned long long)p.pair_count[pairs[i]], 100.0 * (double)p.pair_count[pairs[i]] / p.total_insts);
+        }
+        for (int i = 0; i < 16; i++)
+            if (p.block_len[i])
+                std::fprintf(f, "  blocklen %2d : %13llu\n", i, (unsigned long long)p.block_len[i]);
+        if (p.pc_samples) {
+            std::vector<std::pair<std::uint32_t, const dyncom_profiler::pc_bucket *>> hot;
+            hot.reserve(p.pc_hist.size());
+            for (const auto &kv : p.pc_hist)
+                hot.emplace_back(kv.first, &kv.second);
+            std::sort(hot.begin(), hot.end(),
+                [](const auto &a, const auto &b) { return a.second->count > b.second->count; });
+            std::fprintf(f, "  pc-hist: %llu samples, %zu buckets (64B)\n",
+                (unsigned long long)p.pc_samples, p.pc_hist.size());
+            for (std::size_t i = 0; i < 48 && i < hot.size(); i++)
+                std::fprintf(f, "  pc %08X %13llu (%.2f%%)\n", hot[i].first,
+                    (unsigned long long)hot[i].second->count,
+                    100.0 * (double)hot[i].second->count / p.pc_samples);
+            for (std::size_t i = 0; i < 10 && i < hot.size(); i++) {
+                std::fprintf(f, "  code %08X:", hot[i].first);
+                for (int w = 0; w < 16; w++)
+                    std::fprintf(f, " %08X", hot[i].second->code[w]);
+                std::fprintf(f, "\n");
+            }
+        }
+        std::fclose(f);
+    }
+}
+#define PROF_STEP(cpu, the_idx)                                                              \
+    do {                                                                                     \
+        dyncom_profiler &pp_ = g_dyncom_profiler;                                            \
+        const int idx_ = (the_idx);                                                          \
+        if (idx_ >= PROF_NUM_OPS)                                                             \
+            break; /* synthetic ops (loop accel) have no table slot */                        \
+        pp_.op_count[idx_]++;                                                                 \
+        pp_.total_insts++;                                                                    \
+        if ((pp_.total_insts & 63) == 0) {                                                    \
+            const std::uint32_t pcb_ = (cpu)->Reg[15] & ~63u;                                 \
+            auto &bkt_ = pp_.pc_hist[pcb_];                                                   \
+            if (bkt_.count++ == 0)                                                            \
+                for (int w_ = 0; w_ < 16; w_++)                                               \
+                    bkt_.code[w_] = (cpu)->ReadMemory32(pcb_ + w_ * 4);                       \
+            pp_.pc_samples++;                                                                 \
+        }                                                                                     \
+        if ((cpu)->prof_prev >= 0)                                                            \
+            pp_.pair_count[static_cast<std::size_t>((cpu)->prof_prev) * PROF_NUM_OPS + idx_]++; \
+        (cpu)->prof_prev = idx_;                                                              \
+        if ((cpu)->prof_block_len < 63)                                                       \
+            (cpu)->prof_block_len++;                                                          \
+        if (pp_.total_insts >= pp_.next_dump) {                                               \
+            dyncom_profile_dump(cpu);                                                         \
+            pp_.next_dump += 50000000ull;                                                    \
+        }                                                                                     \
+    } while (0)
+#define PROF_BLOCK_ENTER(cpu)                                                                \
+    do {                                                                                     \
+        dyncom_profiler &pp_ = g_dyncom_profiler;                                            \
+        pp_.total_blocks++;                                                                   \
+        pp_.block_len[(cpu)->prof_block_len & 63]++;                                          \
+        (cpu)->prof_block_len = 0;                                                            \
+        (cpu)->prof_prev = -1;                                                                \
+    } while (0)
+#else
+#define PROF_STEP(cpu, the_idx) ((void)0)
+#define PROF_BLOCK_ENTER(cpu) ((void)0)
+#endif
+
+// ---------------------------------------------------------------------------
+// Translation-time bulk-loop acceleration.
+//
+// Guest-side pixel-conversion / copy / fill loops (e.g. an RGB565->32bpp
+// convert measured at 14% of Brothers in Arms gameplay) interpret a handful
+// of instructions per element. When a translated Thumb block is a
+// single-block do-while loop of the canonical shape
+//
+//     do { v = load(src); store(dst, f(v)); src += s; dst += d; }
+//     while (--counter != 0);
+//
+// a symbolic one-iteration simulation proves the shape and a synthetic
+// instruction prepended to the block then executes up to counter-1
+// iterations natively through the dyncom TLB. The LAST iteration is always
+// left to the interpreter, so flags, scratch registers and the loop exit
+// come out of real interpretation; the bulk step only advances the
+// induction registers (base pointers + counter), whose per-iteration deltas
+// the matcher proved constant. Any TLB miss simply stops the bulk step and
+// hands the remainder back to the interpreter, so faults and IPC unmapping
+// keep their interpreted behaviour.
+// ---------------------------------------------------------------------------
+
+// Dispatch index of the synthetic bulk-loop instruction. The label table ends
+// with DISPATCH/INIT_INST_LENGTH/END at 202..204 (kept for the switch
+// fallback); 205 is the first free slot and is only ever produced by the
+// emitter below, never by the decoder.
+static constexpr unsigned int LOOP_ACCEL_IDX = 205;
+
+enum accel_chain_op : std::uint8_t {
+    ACC_SHL,
+    ACC_SHR,
+    ACC_SAR,
+    ACC_AND,
+    ACC_ORR,
+    ACC_EOR,
+    ACC_ADD,
+    ACC_SUB,
+    ACC_SXTB,
+    ACC_SXTH,
+};
+
+enum accel_val_kind : std::uint8_t {
+    ACC_VAL_CONST, // constant
+    ACC_VAL_CHAIN, // ops applied to the iteration's loaded value
+    ACC_VAL_REG, // invariant register + offset
+};
+
+struct accel_store {
+    std::int32_t off; // relative to the dst base register's iteration value
+    std::uint8_t width; // 1/2/4 bytes
+    std::uint8_t kind; // accel_val_kind
+    std::uint8_t reg; // ACC_VAL_REG: the invariant register
+    std::uint8_t nops; // ACC_VAL_CHAIN: number of chain ops
+    std::uint32_t cval; // ACC_VAL_CONST value / ACC_VAL_REG offset
+    struct {
+        std::uint8_t op;
+        std::uint32_t imm;
+    } ops[8];
+};
+
+struct loop_accel_inst {
+    std::uint8_t has_load;
+    std::uint8_t load_width; // 1/2/4
+    std::uint8_t load_signed;
+    std::uint8_t src_reg;
+    std::int32_t src_off;
+    std::int32_t src_step; // > 0
+
+    std::uint8_t dst_reg;
+    std::int32_t dst_min_off;
+    std::int32_t dst_step; // >= span, > 0
+    std::uint8_t span; // dense bytes written per iteration
+    std::uint8_t store_count;
+    accel_store stores[4];
+
+    std::uint8_t ind_count;
+    struct {
+        std::uint8_t reg;
+        std::int32_t delta;
+    } ind[8];
+
+    std::uint8_t counter_reg;
+    std::uint16_t body_len; // guest instructions per iteration (incl. branch)
+};
+
+namespace {
+    // Symbolic value for the one-iteration abstract interpretation.
+    struct accel_sym {
+        enum kind_t : std::uint8_t { S_CONST,
+            S_AFFINE, // INIT(reg) + c
+            S_CHAIN, // chain ops over the loaded value
+            S_TOP } kind;
+        std::uint8_t reg; // S_AFFINE base
+        std::uint8_t nops;
+        std::uint32_t c; // S_CONST value / S_AFFINE offset
+        struct {
+            std::uint8_t op;
+            std::uint32_t imm;
+        } ops[8];
+
+        static accel_sym make_const(std::uint32_t v) {
+            accel_sym s{};
+            s.kind = S_CONST;
+            s.c = v;
+            return s;
+        }
+        static accel_sym make_affine(std::uint8_t r, std::uint32_t off) {
+            accel_sym s{};
+            s.kind = S_AFFINE;
+            s.reg = r;
+            s.c = off;
+            return s;
+        }
+        static accel_sym make_top() {
+            accel_sym s{};
+            s.kind = S_TOP;
+            return s;
+        }
+        bool push_op(std::uint8_t op, std::uint32_t imm) {
+            if (nops >= 8)
+                return false;
+            ops[nops].op = op;
+            ops[nops].imm = imm;
+            nops++;
+            return true;
+        }
+    };
+
+    inline std::uint32_t accel_apply_op(std::uint32_t v, std::uint8_t op, std::uint32_t imm) {
+        switch (op) {
+        case ACC_SHL:
+            return (imm >= 32) ? 0 : (v << imm);
+        case ACC_SHR:
+            return (imm >= 32) ? 0 : (v >> imm);
+        case ACC_SAR:
+            return static_cast<std::uint32_t>(static_cast<std::int32_t>(v) >> ((imm >= 32) ? 31 : imm));
+        case ACC_AND:
+            return v & imm;
+        case ACC_ORR:
+            return v | imm;
+        case ACC_EOR:
+            return v ^ imm;
+        case ACC_ADD:
+            return v + imm;
+        case ACC_SUB:
+            return v - imm;
+        case ACC_SXTB:
+            return static_cast<std::uint32_t>(static_cast<std::int32_t>(static_cast<std::int8_t>(v)));
+        case ACC_SXTH:
+            return static_cast<std::uint32_t>(static_cast<std::int32_t>(static_cast<std::int16_t>(v)));
+        }
+        return v;
+    }
+}
+
+#if defined(EKA2L1_DYNCOM_DIFFTEST)
+// Test-only instrumentation. The accelerator only ever attaches to block
+// translation, so a harness that never reaches it would score "no divergence"
+// while proving nothing about it; these let the harness assert it was exercised.
+static std::uint64_t g_loop_accel_attaches = 0;
+static std::uint64_t g_loop_accel_bulk_iterations = 0;
+
+namespace eka2l1::arm {
+    void dyncom_reset_loop_accel_counters_for_test() {
+        g_loop_accel_attaches = 0;
+        g_loop_accel_bulk_iterations = 0;
+    }
+
+    std::uint64_t dyncom_loop_accel_attaches_for_test() {
+        return g_loop_accel_attaches;
+    }
+
+    std::uint64_t dyncom_loop_accel_bulk_iterations_for_test() {
+        return g_loop_accel_bulk_iterations;
+    }
+}
+#endif
+
+// Symbolically simulate one iteration of the candidate Thumb loop at
+// [pc_start .. terminal Bcc]. Returns true and fills `out` when the body is a
+// provably uniform single-load copy/convert/fill loop.
+static bool analyze_thumb_bulk_loop(ARMul_State *cpu, std::uint32_t pc_start, loop_accel_inst &out) {
+    constexpr int MAX_BODY = 24;
+
+    accel_sym sym[8];
+    for (int i = 0; i < 8; i++)
+        sym[i] = accel_sym::make_affine(static_cast<std::uint8_t>(i), 0);
+
+    enum { ACC_NONE,
+        ACC_READ,
+        ACC_WRITE };
+    std::uint8_t first_access[8] = {};
+
+    enum { FLAG_OTHER,
+        FLAG_CMP0,
+        FLAG_SUB1 };
+    int last_flag = FLAG_OTHER;
+    int flag_reg = -1;
+
+    bool have_load = false;
+    bool store_seen = false; // bulk exec is load-then-stores: reject other orders
+    std::uint8_t load_width = 0, load_signed = 0, src_reg = 0;
+    std::int32_t src_off = 0;
+
+    int store_count = 0;
+    struct {
+        std::uint8_t base;
+        std::int32_t off;
+        std::uint8_t width;
+        accel_sym val;
+    } raw_stores[4];
+
+    // Reading a register: record read-before-write and return its symbol.
+    auto rd_sym = [&](int r) -> accel_sym & {
+        if (first_access[r] == ACC_NONE)
+            first_access[r] = ACC_READ;
+        return sym[r];
+    };
+    auto wr_sym = [&](int r, const accel_sym &v) {
+        if (first_access[r] == ACC_NONE)
+            first_access[r] = ACC_WRITE;
+        sym[r] = v;
+    };
+
+    // rd = rn OP imm-const.
+    auto apply_const = [&](const accel_sym &a, std::uint8_t op, std::uint32_t imm) -> accel_sym {
+        accel_sym r = a;
+        switch (a.kind) {
+        case accel_sym::S_CONST:
+            r.c = accel_apply_op(a.c, op, imm);
+            return r;
+        case accel_sym::S_AFFINE:
+            if (op == ACC_ADD) {
+                r.c = a.c + imm;
+                return r;
+            }
+            if (op == ACC_SUB) {
+                r.c = a.c - imm;
+                return r;
+            }
+            return accel_sym::make_top();
+        case accel_sym::S_CHAIN:
+            if (!r.push_op(op, imm))
+                return accel_sym::make_top();
+            return r;
+        default:
+            return accel_sym::make_top();
+        }
+    };
+
+    std::uint32_t pc = pc_start;
+    int count = 0;
+    bool matched_branch = false;
+
+    while (count < MAX_BODY) {
+        const std::uint32_t word = cpu->ReadCode(pc & 0xFFFFFFFC);
+        const std::uint16_t hw = (pc & 2) ? static_cast<std::uint16_t>(word >> 16)
+                                          : static_cast<std::uint16_t>(word & 0xFFFF);
+        count++;
+
+        if ((hw & 0xF000) == 0xD000) {
+            // Bcc / SWI. Terminal only, must be BNE back to pc_start.
+            const std::uint32_t cond = (hw >> 8) & 0xF;
+            if (cond >= 0xE)
+                return false; // undefined / SWI
+            const std::int32_t soff = static_cast<std::int32_t>(static_cast<std::int8_t>(hw & 0xFF)) * 2;
+            const std::uint32_t target = pc + 4 + soff;
+            if (cond != 0x1 /*NE*/ || target != pc_start)
+                return false;
+            matched_branch = true;
+            break;
+        }
+
+        switch (hw >> 13) {
+        case 0: { // 000: shift imm / add-sub reg-imm3
+            if (((hw >> 11) & 3) != 3) {
+                const int opk = (hw >> 11) & 3; // LSL/LSR/ASR
+                const int rm = (hw >> 3) & 7, rd = hw & 7;
+                std::uint32_t imm = (hw >> 6) & 31;
+                std::uint8_t op = (opk == 0) ? ACC_SHL : (opk == 1) ? ACC_SHR
+                                                                    : ACC_SAR;
+                if (opk != 0 && imm == 0)
+                    imm = 32; // LSR/ASR #32 encodings
+                wr_sym(rd, apply_const(rd_sym(rm), op, imm));
+                last_flag = FLAG_OTHER;
+            } else {
+                const int rd = hw & 7, rn = (hw >> 3) & 7;
+                const bool sub = (hw >> 9) & 1;
+                const bool immf = (hw >> 10) & 1;
+                const int rm_or_imm = (hw >> 6) & 7;
+                accel_sym res;
+                const accel_sym a = rd_sym(rn);
+                if (immf) {
+                    res = apply_const(a, sub ? ACC_SUB : ACC_ADD, static_cast<std::uint32_t>(rm_or_imm));
+                    if (sub && rm_or_imm == 1 && rd == rn) {
+                        last_flag = FLAG_SUB1;
+                        flag_reg = rd;
+                    } else {
+                        last_flag = FLAG_OTHER;
+                    }
+                } else {
+                    const accel_sym b = rd_sym(rm_or_imm);
+                    if (b.kind == accel_sym::S_CONST)
+                        res = apply_const(a, sub ? ACC_SUB : ACC_ADD, b.c);
+                    else if (!sub && a.kind == accel_sym::S_CONST)
+                        res = apply_const(b, ACC_ADD, a.c);
+                    else
+                        res = accel_sym::make_top();
+                    last_flag = FLAG_OTHER;
+                }
+                wr_sym(rd, res);
+            }
+            break;
+        }
+        case 1: { // 001: MOV/CMP/ADD/SUB imm8
+            const int opk = (hw >> 11) & 3;
+            const int rd = (hw >> 8) & 7;
+            const std::uint32_t imm = hw & 0xFF;
+            switch (opk) {
+            case 0: // MOV
+                wr_sym(rd, accel_sym::make_const(imm));
+                last_flag = FLAG_OTHER;
+                break;
+            case 1: { // CMP
+                const accel_sym &a = rd_sym(rd);
+                if (imm == 0 && a.kind == accel_sym::S_AFFINE && a.reg == rd) {
+                    last_flag = FLAG_CMP0;
+                    flag_reg = rd;
+                } else {
+                    last_flag = FLAG_OTHER;
+                }
+                break;
+            }
+            case 2: // ADD
+                wr_sym(rd, apply_const(rd_sym(rd), ACC_ADD, imm));
+                last_flag = FLAG_OTHER;
+                break;
+            case 3: // SUB
+                wr_sym(rd, apply_const(rd_sym(rd), ACC_SUB, imm));
+                if (imm == 1) {
+                    last_flag = FLAG_SUB1;
+                    flag_reg = rd;
+                } else {
+                    last_flag = FLAG_OTHER;
+                }
+                break;
+            }
+            break;
+        }
+        case 2: { // 010: ALU reg / hi-reg / PC-literal / reg-offset mem
+            if ((hw & 0xFC00) == 0x4000) { // format 4 ALU
+                const int aop = (hw >> 6) & 0xF;
+                const int rm = (hw >> 3) & 7, rd = hw & 7;
+                switch (aop) {
+                case 0x0: // AND
+                case 0x1: // EOR
+                case 0xC: { // ORR
+                    const accel_sym b = rd_sym(rm);
+                    const accel_sym a = rd_sym(rd);
+                    const std::uint8_t op = (aop == 0x0) ? ACC_AND : (aop == 0x1) ? ACC_EOR
+                                                                                  : ACC_ORR;
+                    if (b.kind == accel_sym::S_CONST)
+                        wr_sym(rd, apply_const(a, op, b.c));
+                    else if (a.kind == accel_sym::S_CONST)
+                        wr_sym(rd, apply_const(b, op, a.c));
+                    else
+                        wr_sym(rd, accel_sym::make_top());
+                    last_flag = FLAG_OTHER;
+                    break;
+                }
+                case 0x2: // LSL reg
+                case 0x3: // LSR reg
+                case 0x4: { // ASR reg
+                    const accel_sym b = rd_sym(rm);
+                    const accel_sym a = rd_sym(rd);
+                    const std::uint8_t op = (aop == 0x2) ? ACC_SHL : (aop == 0x3) ? ACC_SHR
+                                                                                  : ACC_SAR;
+                    if (b.kind == accel_sym::S_CONST && (b.c & 0xFF) < 32)
+                        wr_sym(rd, apply_const(a, op, b.c & 0xFF));
+                    else
+                        wr_sym(rd, accel_sym::make_top());
+                    last_flag = FLAG_OTHER;
+                    break;
+                }
+                case 0x8: // TST
+                case 0xA: // CMP reg
+                case 0xB: // CMN
+                    rd_sym(rm);
+                    rd_sym(rd);
+                    last_flag = FLAG_OTHER;
+                    break;
+                case 0x9: { // NEG (RSB #0)
+                    const accel_sym b = rd_sym(rm);
+                    if (b.kind == accel_sym::S_CONST)
+                        wr_sym(rd, accel_sym::make_const(0u - b.c));
+                    else
+                        wr_sym(rd, accel_sym::make_top());
+                    last_flag = FLAG_OTHER;
+                    break;
+                }
+                case 0xD: { // MUL
+                    const accel_sym b = rd_sym(rm);
+                    const accel_sym a = rd_sym(rd);
+                    if (a.kind == accel_sym::S_CONST && b.kind == accel_sym::S_CONST)
+                        wr_sym(rd, accel_sym::make_const(a.c * b.c));
+                    else
+                        wr_sym(rd, accel_sym::make_top());
+                    last_flag = FLAG_OTHER;
+                    break;
+                }
+                case 0xE: { // BIC
+                    const accel_sym b = rd_sym(rm);
+                    const accel_sym a = rd_sym(rd);
+                    if (b.kind == accel_sym::S_CONST)
+                        wr_sym(rd, apply_const(a, ACC_AND, ~b.c));
+                    else
+                        wr_sym(rd, accel_sym::make_top());
+                    last_flag = FLAG_OTHER;
+                    break;
+                }
+                case 0xF: { // MVN
+                    const accel_sym b = rd_sym(rm);
+                    if (b.kind == accel_sym::S_CONST)
+                        wr_sym(rd, accel_sym::make_const(~b.c));
+                    else
+                        wr_sym(rd, apply_const(b, ACC_EOR, 0xFFFFFFFFu));
+                    last_flag = FLAG_OTHER;
+                    break;
+                }
+                default:
+                    return false; // ADC/SBC/ROR read or thread flags
+                }
+            } else if ((hw & 0xF800) == 0x4800) {
+                return false; // LDR literal: loop-invariant unknown, v1 rejects
+            } else if ((hw & 0xFC00) == 0x4400) {
+                return false; // hi-reg ops / BX
+            } else { // 0101: reg-offset load/store
+                const int opk = (hw >> 9) & 7;
+                const int rm = (hw >> 6) & 7, rn = (hw >> 3) & 7, rd = hw & 7;
+                const accel_sym bsym = rd_sym(rn);
+                const accel_sym osym = rd_sym(rm);
+                accel_sym addr;
+                if (bsym.kind == accel_sym::S_AFFINE && osym.kind == accel_sym::S_CONST)
+                    addr = apply_const(bsym, ACC_ADD, osym.c);
+                else if (osym.kind == accel_sym::S_AFFINE && bsym.kind == accel_sym::S_CONST)
+                    addr = apply_const(osym, ACC_ADD, bsym.c);
+                else
+                    return false;
+                // opk: 0 STR,1 STRH,2 STRB,3 LDRSB,4 LDR,5 LDRH,6 LDRB,7 LDRSH
+                static const std::uint8_t widths[8] = { 4, 2, 1, 1, 4, 2, 1, 2 };
+                const bool is_load = opk >= 3;
+                const std::uint8_t w = widths[opk];
+                if (is_load) {
+                    if (have_load || store_seen)
+                        return false;
+                    have_load = true;
+                    load_width = w;
+                    load_signed = (opk == 3 || opk == 7);
+                    src_reg = addr.reg;
+                    src_off = static_cast<std::int32_t>(addr.c);
+                    accel_sym lv{};
+                    lv.kind = accel_sym::S_CHAIN;
+                    if (load_signed && !lv.push_op(w == 1 ? ACC_SXTB : ACC_SXTH, 0))
+                        return false;
+                    wr_sym(rd, lv);
+                } else {
+                    if (store_count >= 4)
+                        return false;
+                    const accel_sym v = rd_sym(rd);
+                    if (v.kind == accel_sym::S_TOP)
+                        return false;
+                    raw_stores[store_count].base = addr.reg;
+                    raw_stores[store_count].off = static_cast<std::int32_t>(addr.c);
+                    raw_stores[store_count].width = w;
+                    raw_stores[store_count].val = v;
+                    store_count++;
+                    store_seen = true;
+                }
+                // Memory ops leave the flags untouched: keep last_flag as-is.
+            }
+            break;
+        }
+        case 3: // 011: LDR/STR/LDRB/STRB imm5
+        case 4: { // 100: LDRH/STRH imm5 / SP-relative
+            std::uint8_t w;
+            bool is_load;
+            std::uint32_t imm_off;
+            const int rn = (hw >> 3) & 7, rd = hw & 7;
+            if ((hw >> 13) == 3) {
+                const bool byte = (hw >> 12) & 1;
+                is_load = (hw >> 11) & 1;
+                w = byte ? 1 : 4;
+                imm_off = ((hw >> 6) & 31) * (byte ? 1u : 4u);
+            } else {
+                if ((hw >> 12) & 1)
+                    return false; // 1001x: SP-relative
+                is_load = (hw >> 11) & 1;
+                w = 2;
+                imm_off = ((hw >> 6) & 31) * 2u;
+            }
+            const accel_sym bsym = rd_sym(rn);
+            if (bsym.kind != accel_sym::S_AFFINE)
+                return false;
+            const std::int32_t off = static_cast<std::int32_t>(bsym.c + imm_off);
+            if (is_load) {
+                if (have_load || store_seen)
+                    return false;
+                have_load = true;
+                load_width = w;
+                load_signed = 0;
+                src_reg = bsym.reg;
+                src_off = off;
+                accel_sym lv{};
+                lv.kind = accel_sym::S_CHAIN;
+                wr_sym(rd, lv);
+            } else {
+                if (store_count >= 4)
+                    return false;
+                const accel_sym v = rd_sym(rd);
+                if (v.kind == accel_sym::S_TOP)
+                    return false;
+                raw_stores[store_count].base = bsym.reg;
+                raw_stores[store_count].off = off;
+                raw_stores[store_count].width = w;
+                raw_stores[store_count].val = v;
+                store_count++;
+                store_seen = true;
+            }
+            break;
+        }
+        default:
+            return false; // SP-ops, misc, LDM/STM, unconditional B, BL, ...
+        }
+
+        pc += 2;
+    }
+
+    if (!matched_branch || store_count == 0)
+        return false;
+
+    // Loop condition: flags at the branch must come from CMP rc,#0 or
+    // SUBS rc,#1 with rc ending the body at INIT(rc)-1.
+    if ((last_flag != FLAG_CMP0 && last_flag != FLAG_SUB1) || flag_reg < 0)
+        return false;
+    const int rc = flag_reg;
+    if (sym[rc].kind != accel_sym::S_AFFINE || sym[rc].reg != rc || sym[rc].c != 0xFFFFFFFFu)
+        return false;
+
+    // Uniformity: every register read before written must end the body as
+    // INIT(self) + constant delta.
+    std::int32_t deltas[8];
+    for (int r = 0; r < 8; r++) {
+        deltas[r] = 0;
+        if (first_access[r] == ACC_READ) {
+            if (sym[r].kind != accel_sym::S_AFFINE || sym[r].reg != r)
+                return false;
+            deltas[r] = static_cast<std::int32_t>(sym[r].c);
+        }
+    }
+
+    // Stores: single dst base with positive step, dense byte tiling.
+    const std::uint8_t q = raw_stores[0].base;
+    std::int32_t min_off = raw_stores[0].off;
+    for (int i = 0; i < store_count; i++) {
+        if (raw_stores[i].base != q)
+            return false;
+        min_off = std::min(min_off, raw_stores[i].off);
+    }
+    if (first_access[q] != ACC_READ)
+        return false;
+    const std::int32_t dst_step = deltas[q];
+    std::uint32_t covered = 0;
+    std::uint32_t span_bytes = 0;
+    for (int i = 0; i < store_count; i++) {
+        const std::uint32_t rel = static_cast<std::uint32_t>(raw_stores[i].off - min_off);
+        if (rel + raw_stores[i].width > 32)
+            return false;
+        const std::uint32_t mask = ((raw_stores[i].width == 4) ? 0xFu : (raw_stores[i].width == 2) ? 0x3u
+                                                                                                   : 0x1u)
+            << rel;
+        if (covered & mask)
+            return false; // overlapping bytes: order-dependent, reject
+        covered |= mask;
+        span_bytes = std::max(span_bytes, rel + raw_stores[i].width);
+    }
+    if (covered != ((span_bytes >= 32) ? 0xFFFFFFFFu : ((1u << span_bytes) - 1)))
+        return false; // gaps in the written span
+    if (span_bytes > 8)
+        return false;
+    if (dst_step < static_cast<std::int32_t>(span_bytes))
+        return false; // must advance past what it wrote (also rejects step<=0)
+
+    // Load: positive stride.
+    if (have_load) {
+        if (first_access[src_reg] != ACC_READ)
+            return false;
+        if (deltas[src_reg] <= 0)
+            return false;
+    }
+
+    // Store values: only const / chain-of-load / invariant-register.
+    for (int i = 0; i < store_count; i++) {
+        const accel_sym &v = raw_stores[i].val;
+        if (v.kind == accel_sym::S_CHAIN && !have_load)
+            return false;
+        if (v.kind == accel_sym::S_AFFINE && deltas[v.reg] != 0)
+            return false;
+    }
+
+    // Build the descriptor.
+    out = loop_accel_inst{};
+    out.has_load = have_load ? 1 : 0;
+    out.load_width = load_width;
+    out.load_signed = load_signed;
+    out.src_reg = src_reg;
+    out.src_off = src_off;
+    out.src_step = have_load ? deltas[src_reg] : 0;
+    out.dst_reg = q;
+    out.dst_min_off = min_off;
+    out.dst_step = dst_step;
+    out.span = static_cast<std::uint8_t>(span_bytes);
+    out.store_count = static_cast<std::uint8_t>(store_count);
+    for (int i = 0; i < store_count; i++) {
+        accel_store &s = out.stores[i];
+        s.off = raw_stores[i].off;
+        s.width = raw_stores[i].width;
+        const accel_sym &v = raw_stores[i].val;
+        if (v.kind == accel_sym::S_CONST) {
+            s.kind = ACC_VAL_CONST;
+            s.cval = v.c;
+        } else if (v.kind == accel_sym::S_AFFINE) {
+            s.kind = ACC_VAL_REG;
+            s.reg = v.reg;
+            s.cval = v.c;
+        } else {
+            s.kind = ACC_VAL_CHAIN;
+            s.nops = v.nops;
+            for (int k = 0; k < v.nops; k++) {
+                s.ops[k].op = v.ops[k].op;
+                s.ops[k].imm = v.ops[k].imm;
+            }
+        }
+    }
+    out.ind_count = 0;
+    for (int r = 0; r < 8; r++) {
+        if (first_access[r] == ACC_READ && deltas[r] != 0) {
+            if (out.ind_count >= 8)
+                return false;
+            out.ind[out.ind_count].reg = static_cast<std::uint8_t>(r);
+            out.ind[out.ind_count].delta = deltas[r];
+            out.ind_count++;
+        }
+    }
+    out.counter_reg = static_cast<std::uint8_t>(rc);
+    out.body_len = static_cast<std::uint16_t>(count);
+    return true;
+}
+
+// Execute up to `want` full iterations natively through the dyncom TLB.
+// Returns the number of iterations actually performed; the caller advances
+// the induction registers by that count. Stops early at any TLB miss so the
+// interpreter (and its slow path / fault behaviour) takes over exactly where
+// the bulk run left off.
+static std::uint32_t run_accel_bulk(ARMul_State *cpu, const loop_accel_inst *d, std::uint32_t want) {
+    eka2l1::arm::r12l1::tlb *tlb = cpu->mem_cache_;
+    const std::uint32_t page_size = static_cast<std::uint32_t>(tlb->page_mask) + 1;
+
+    std::uint32_t src = d->has_load ? (cpu->Reg[d->src_reg] + d->src_off) : 0;
+    std::uint32_t dst = cpu->Reg[d->dst_reg] + d->dst_min_off;
+
+    // Pre-resolve invariant register store values.
+    std::uint32_t reg_vals[4];
+    for (int i = 0; i < d->store_count; i++)
+        reg_vals[i] = (d->stores[i].kind == ACC_VAL_REG)
+            ? (cpu->Reg[d->stores[i].reg] + d->stores[i].cval)
+            : d->stores[i].cval;
+
+    std::uint32_t done = 0;
+    while (done < want) {
+        std::uint8_t *hs = nullptr;
+        std::uint32_t it = want - done;
+
+        if (d->has_load) {
+            hs = tlb->lookup(src);
+            if (!hs)
+                break;
+            const std::uint32_t room = page_size - (src & static_cast<std::uint32_t>(tlb->page_mask));
+            if (room < d->load_width)
+                break;
+            it = std::min<std::uint32_t>(it, (room - d->load_width) / static_cast<std::uint32_t>(d->src_step) + 1);
+        }
+
+        std::uint8_t *hd = tlb->lookup(dst);
+        if (!hd)
+            break;
+        const std::uint32_t room_d = page_size - (dst & static_cast<std::uint32_t>(tlb->page_mask));
+        if (room_d < d->span)
+            break;
+        it = std::min<std::uint32_t>(it, (room_d - d->span) / static_cast<std::uint32_t>(d->dst_step) + 1);
+        if (!it)
+            break;
+
+        for (std::uint32_t i = 0; i < it; i++) {
+            std::uint32_t lv = 0;
+            if (d->has_load) {
+                switch (d->load_width) {
+                case 1:
+                    lv = *hs;
+                    break;
+                case 2: {
+                    std::uint16_t t;
+                    std::memcpy(&t, hs, 2);
+                    lv = t;
+                    break;
+                }
+                default: {
+                    std::memcpy(&lv, hs, 4);
+                    break;
+                }
+                }
+                hs += d->src_step;
+            }
+            for (int s = 0; s < d->store_count; s++) {
+                const accel_store &st = d->stores[s];
+                std::uint32_t v;
+                if (st.kind == ACC_VAL_CHAIN) {
+                    v = lv;
+                    for (int k = 0; k < st.nops; k++)
+                        v = accel_apply_op(v, st.ops[k].op, st.ops[k].imm);
+                } else {
+                    v = reg_vals[s];
+                }
+                std::uint8_t *p = hd + (st.off - d->dst_min_off);
+                switch (st.width) {
+                case 1:
+                    *p = static_cast<std::uint8_t>(v);
+                    break;
+                case 2: {
+                    const std::uint16_t t = static_cast<std::uint16_t>(v);
+                    std::memcpy(p, &t, 2);
+                    break;
+                }
+                default:
+                    std::memcpy(p, &v, 4);
+                    break;
+                }
+            }
+            hd += d->dst_step;
+        }
+
+        src += it * static_cast<std::uint32_t>(d->src_step);
+        dst += it * static_cast<std::uint32_t>(d->dst_step);
+        done += it;
+    }
+#if defined(EKA2L1_DYNCOM_DIFFTEST)
+    g_loop_accel_bulk_iterations += done;
+#endif
+    return done;
 }
 
 static unsigned int DPO(Immediate)(ARMul_State *cpu, unsigned int sht_oper) {
@@ -227,6 +1167,55 @@ static unsigned int DPO(RotateRightByRegister)(ARMul_State *cpu, unsigned int sh
     return shifter_operand;
 }
 
+// Inlined shifter-operand evaluation. This used to be a statement expression so
+// it could stay usable where a plain expression was expected; MSVC has no such
+// extension, and a force-inlined function does the same job everywhere.
+static DYNCOM_FORCE_INLINE unsigned int compute_shifter_operand(ARMul_State *cpu,
+    const shtop_fp_t f_, const unsigned int so_) {
+    unsigned int v_;
+    if (f_ == DataProcessingOperandsImmediate) {
+        v_ = ROTATE_RIGHT_32(BITS(so_, 0, 7), BITS(so_, 8, 11) * 2);
+        cpu->shifter_carry_out = (BITS(so_, 8, 11) == 0) ? cpu->CFlag : BIT(v_, 31);
+    } else if (f_ == DataProcessingOperandsRegister) {
+        v_ = CHECK_READ_REG15(cpu, BITS(so_, 0, 3));
+        cpu->shifter_carry_out = cpu->CFlag;
+    } else if (f_ == DataProcessingOperandsLogicalShiftLeftByImmediate) {
+        const unsigned int rm_ = CHECK_READ_REG15(cpu, BITS(so_, 0, 3));
+        const unsigned int imm_ = BITS(so_, 7, 11);
+        if (imm_ == 0) {
+            v_ = rm_;
+            cpu->shifter_carry_out = cpu->CFlag;
+        } else {
+            v_ = rm_ << imm_;
+            cpu->shifter_carry_out = BIT(rm_, 32 - imm_);
+        }
+    } else if (f_ == DataProcessingOperandsArithmeticShiftRightByImmediate) {
+        const unsigned int rm_ = CHECK_READ_REG15(cpu, BITS(so_, 0, 3));
+        const unsigned int imm_ = BITS(so_, 7, 11);
+        if (imm_ == 0) {
+            v_ = BIT(rm_, 31) ? 0xFFFFFFFF : 0;
+            cpu->shifter_carry_out = BIT(rm_, 31);
+        } else {
+            v_ = static_cast<unsigned int>(static_cast<int>(rm_) >> imm_);
+            cpu->shifter_carry_out = BIT(rm_, imm_ - 1);
+        }
+    } else if (f_ == DataProcessingOperandsLogicalShiftRightByImmediate) {
+        const unsigned int rm_ = CHECK_READ_REG15(cpu, BITS(so_, 0, 3));
+        const unsigned int imm_ = BITS(so_, 7, 11);
+        if (imm_ == 0) {
+            v_ = 0;
+            cpu->shifter_carry_out = BIT(rm_, 31);
+        } else {
+            v_ = rm_ >> imm_;
+            cpu->shifter_carry_out = BIT(rm_, imm_ - 1);
+        }
+    } else {
+        v_ = f_(cpu, so_);
+    }
+    return v_;
+}
+
+
 #define DEBUG_MSG                                        \
     LOG_DEBUG(eka2l1::CPU_DYNCOM, "inst is {:x}", inst); \
     CITRA_IGNORE_EXIT(0)
@@ -252,6 +1241,59 @@ static void LnSWoUB(ImmediateOffset)(ARMul_State *cpu, unsigned int inst, unsign
 
     virt_addr = addr;
 }
+
+// Fast path for the dominant single load/store addressing form: immediate
+// offset, no write-back (`[Rn, #+/-imm12]`). The generic path calls
+// inst_cream->get_addr through a function pointer -- a polymorphic indirect
+// branch at the shared handler site. This inlines the trivial base +/- imm12
+// computation for that common form and only falls back to the pointer for the
+// rarer modes; the pointer compare is one well-predicted branch.
+#define LS_GET_ADDR(addr_out)                                                        \
+    do {                                                                             \
+        if (inst_cream->get_addr == LnSWoUBImmediateOffset) {                        \
+            const unsigned int ls_inst_ = inst_cream->inst;                          \
+            const std::uint32_t ls_base_ =                                           \
+                CHECK_READ_REG15_WA(cpu, BITS(ls_inst_, 16, 19));                    \
+            (addr_out) = BIT(ls_inst_, 23) ? (ls_base_ + BITS(ls_inst_, 0, 11))      \
+                                           : (ls_base_ - BITS(ls_inst_, 0, 11));     \
+        } else if (inst_cream->get_addr == LnSWoUBRegisterOffset) {                  \
+            const unsigned int ls_inst_ = inst_cream->inst;                          \
+            const std::uint32_t ls_base_ =                                           \
+                CHECK_READ_REG15_WA(cpu, BITS(ls_inst_, 16, 19));                    \
+            const std::uint32_t ls_off_ =                                            \
+                CHECK_READ_REG15_WA(cpu, BITS(ls_inst_, 0, 3));                      \
+            (addr_out) = BIT(ls_inst_, 23) ? (ls_base_ + ls_off_)                    \
+                                           : (ls_base_ - ls_off_);                   \
+        } else {                                                                     \
+            inst_cream->get_addr(cpu, inst_cream->inst, (addr_out));                 \
+        }                                                                            \
+    } while (0)
+
+// LS_GET_ADDR for the miscellaneous (halfword/doubleword) load/store family,
+// whose dominant addressing forms are the split-immediate and register
+// offsets computed by MLnSImmediateOffset / MLnSRegisterOffset.
+#define MLS_GET_ADDR(addr_out)                                                       \
+    do {                                                                             \
+        if (inst_cream->get_addr == MLnSImmediateOffset) {                           \
+            const unsigned int ls_inst_ = inst_cream->inst;                          \
+            const std::uint32_t ls_base_ =                                           \
+                CHECK_READ_REG15_WA(cpu, BITS(ls_inst_, 16, 19));                    \
+            const std::uint32_t ls_off_ =                                            \
+                (BITS(ls_inst_, 8, 11) << 4) | BITS(ls_inst_, 0, 3);                 \
+            (addr_out) = BIT(ls_inst_, 23) ? (ls_base_ + ls_off_)                    \
+                                           : (ls_base_ - ls_off_);                   \
+        } else if (inst_cream->get_addr == MLnSRegisterOffset) {                     \
+            const unsigned int ls_inst_ = inst_cream->inst;                          \
+            const std::uint32_t ls_base_ =                                           \
+                CHECK_READ_REG15_WA(cpu, BITS(ls_inst_, 16, 19));                    \
+            const std::uint32_t ls_off_ =                                            \
+                CHECK_READ_REG15_WA(cpu, BITS(ls_inst_, 0, 3));                      \
+            (addr_out) = BIT(ls_inst_, 23) ? (ls_base_ + ls_off_)                    \
+                                           : (ls_base_ - ls_off_);                   \
+        } else {                                                                     \
+            inst_cream->get_addr(cpu, inst_cream->inst, (addr_out));                 \
+        }                                                                            \
+    } while (0)
 
 static void LnSWoUB(RegisterOffset)(ARMul_State *cpu, unsigned int inst, unsigned int &virt_addr) {
     unsigned int Rn = BITS(inst, 16, 19);
@@ -541,16 +1583,15 @@ static void MLnS(RegisterPostIndexed)(ARMul_State *cpu, unsigned int inst,
     }
 }
 
+// Register count of an LDM/STM register list, replacing the former 1..16
+// iteration shift loop executed on every block transfer.
+static inline int CountSetBits16(unsigned int v) {
+    return std::popcount(v & 0xFFFFu);
+}
+
 static void LdnStM(DecrementBefore)(ARMul_State *cpu, unsigned int inst, unsigned int &virt_addr) {
     unsigned int Rn = BITS(inst, 16, 19);
-    unsigned int i = BITS(inst, 0, 15);
-    int count = 0;
-
-    while (i) {
-        if (i & 1)
-            count++;
-        i = i >> 1;
-    }
+    const int count = CountSetBits16(BITS(inst, 0, 15));
 
     virt_addr = CHECK_READ_REG15_WA(cpu, Rn) - count * 4;
 
@@ -560,14 +1601,7 @@ static void LdnStM(DecrementBefore)(ARMul_State *cpu, unsigned int inst, unsigne
 
 static void LdnStM(IncrementBefore)(ARMul_State *cpu, unsigned int inst, unsigned int &virt_addr) {
     unsigned int Rn = BITS(inst, 16, 19);
-    unsigned int i = BITS(inst, 0, 15);
-    int count = 0;
-
-    while (i) {
-        if (i & 1)
-            count++;
-        i = i >> 1;
-    }
+    const int count = CountSetBits16(BITS(inst, 0, 15));
 
     virt_addr = CHECK_READ_REG15_WA(cpu, Rn) + 4;
 
@@ -577,14 +1611,7 @@ static void LdnStM(IncrementBefore)(ARMul_State *cpu, unsigned int inst, unsigne
 
 static void LdnStM(IncrementAfter)(ARMul_State *cpu, unsigned int inst, unsigned int &virt_addr) {
     unsigned int Rn = BITS(inst, 16, 19);
-    unsigned int i = BITS(inst, 0, 15);
-    int count = 0;
-
-    while (i) {
-        if (i & 1)
-            count++;
-        i = i >> 1;
-    }
+    const int count = CountSetBits16(BITS(inst, 0, 15));
 
     virt_addr = CHECK_READ_REG15_WA(cpu, Rn);
 
@@ -594,13 +1621,7 @@ static void LdnStM(IncrementAfter)(ARMul_State *cpu, unsigned int inst, unsigned
 
 static void LdnStM(DecrementAfter)(ARMul_State *cpu, unsigned int inst, unsigned int &virt_addr) {
     unsigned int Rn = BITS(inst, 16, 19);
-    unsigned int i = BITS(inst, 0, 15);
-    int count = 0;
-    while (i) {
-        if (i & 1)
-            count++;
-        i = i >> 1;
-    }
+    const int count = CountSetBits16(BITS(inst, 0, 15));
     unsigned int rn = CHECK_READ_REG15_WA(cpu, Rn);
     unsigned int start_addr = rn - count * 4 + 4;
 
@@ -842,6 +1863,26 @@ static int InterpreterTranslateBlock(ARMul_State *cpu, std::size_t &bb_start, st
     std::uint32_t phys_addr = addr;
     std::uint32_t pc_start = cpu->Reg[15];
 
+    // Bulk-loop acceleration pre-pass: if this Thumb block is a canonical
+    // copy/convert/fill do-while loop, prepend a synthetic instruction that
+    // batches iterations natively (see loop_accel_inst above). The block body
+    // itself is still translated normally right after it.
+    if (cpu->TFlag) {
+        loop_accel_inst accel_desc;
+        if (analyze_thumb_bulk_loop(cpu, pc_start, accel_desc)) {
+            const std::size_t alloc_size = sizeof(arm_inst) + sizeof(loop_accel_inst);
+            arm_inst *accel_base = reinterpret_cast<arm_inst *>(&cpu->trans_cache_buf[cpu->trans_cache_buf_top]);
+            cpu->trans_cache_buf_top += ((alloc_size + 7) >> 3) << 3;
+            accel_base->idx = LOOP_ACCEL_IDX;
+            accel_base->cond = ConditionCode::AL;
+            accel_base->br = TransExtData::NON_BRANCH;
+            *reinterpret_cast<loop_accel_inst *>(accel_base->component) = accel_desc;
+#if defined(EKA2L1_DYNCOM_DIFFTEST)
+            ++g_loop_accel_attaches;
+#endif
+        }
+    }
+
     while (ret == TransExtData::NON_BRANCH) {
         unsigned int inst_size = InterpreterTranslateInstruction(cpu, phys_addr, inst_base);
 
@@ -855,7 +1896,7 @@ static int InterpreterTranslateBlock(ARMul_State *cpu, std::size_t &bb_start, st
         ret = inst_base->br;
     };
 
-    cpu->instruction_cache[pc_start] = bb_start;
+    cpu->instruction_cache[cpu->make_instruction_cache_key(pc_start)] = bb_start;
 
     return KEEP_GOING;
 }
@@ -873,7 +1914,7 @@ static int InterpreterTranslateSingle(ARMul_State *cpu, std::size_t &bb_start, s
         inst_base->br = TransExtData::SINGLE_STEP;
     }
 
-    cpu->instruction_cache[pc_start] = bb_start;
+    cpu->instruction_cache[cpu->make_instruction_cache_key(pc_start)] = bb_start;
 
     return KEEP_GOING;
 }
@@ -920,7 +1961,15 @@ unsigned InterpreterMainLoop(ARMul_State *cpu, std::uint32_t &num_instrs) {
 #define RDLO cpu->Reg[inst_cream->RdLo]
 #define LINK_RTN_ADDR (cpu->Reg[14] = cpu->Reg[15] + 4)
 #define SET_PC (cpu->Reg[15] = cpu->Reg[15] + 8 + inst_cream->signed_immed_24)
-#define SHIFTER_OPERAND inst_cream->shtop_func(cpu, inst_cream->shifter_operand)
+// Like LS_GET_ADDR, but for the data-processing shifter operand: inline the
+// dominant forms at the call site behind well-predicted pointer compares,
+// instead of the polymorphic indirect shtop_func() call. Immediate (`#imm` ->
+// rotate of imm8), plain register (`Rm`, no shift -- the dominant form in
+// Thumb-translated code) and the immediate LSL/ASR/LSR shifts are handled
+// inline; register-specified shifts and rotates fall back. A
+// statement-expression keeps it usable wherever the old macro was an
+// expression.
+#define SHIFTER_OPERAND compute_shifter_operand(cpu, inst_cream->shtop_func, inst_cream->shifter_operand)
 
 #define FETCH_INST                                 \
     if (inst_base->br != TransExtData::NON_BRANCH) \
@@ -934,12 +1983,14 @@ unsigned InterpreterMainLoop(ARMul_State *cpu, std::uint32_t &num_instrs) {
 // clunky switch statement.
 #if defined __GNUC__ || defined __clang__
 #define GOTO_NEXT_INST                         \
+    PROF_STEP(cpu, inst_base->idx);            \
     if (num_instrs >= cpu->NumInstrsToExecute) \
         goto END;                              \
     num_instrs++;                              \
     goto *InstLabel[inst_base->idx]
 #else
 #define GOTO_NEXT_INST                         \
+    PROF_STEP(cpu, inst_base->idx);            \
     if (num_instrs >= cpu->NumInstrsToExecute) \
         goto END;                              \
     num_instrs++;                              \
@@ -1354,6 +2405,8 @@ unsigned InterpreterMainLoop(ARMul_State *cpu, std::uint32_t &num_instrs) {
         goto INIT_INST_LENGTH;                 \
     case 204:                                  \
         goto END;                              \
+    case 205:                                  \
+        goto LOOP_ACCEL_INST;                  \
     }
 #endif
 
@@ -1580,7 +2633,8 @@ unsigned InterpreterMainLoop(ARMul_State *cpu, std::uint32_t &num_instrs) {
         &&BLX_1_THUMB,
         &&DISPATCH,
         &&INIT_INST_LENGTH,
-        &&END };
+        &&END,
+        &&LOOP_ACCEL_INST };
 #endif
     arm_inst *inst_base;
     unsigned int addr;
@@ -1589,6 +2643,7 @@ unsigned InterpreterMainLoop(ARMul_State *cpu, std::uint32_t &num_instrs) {
 
     LOAD_NZCVT;
 DISPATCH : {
+    PROF_BLOCK_ENTER(cpu);
     if (!cpu->NirqSig) {
         if (!(cpu->Cpsr & 0x80)) {
             goto END;
@@ -1601,18 +2656,73 @@ DISPATCH : {
         cpu->Reg[15] &= 0xfffffffc;
 
     // Find the cached instruction cream, otherwise translate it...
-    auto itr = cpu->instruction_cache.find(cpu->Reg[15]);
-    if (itr != cpu->instruction_cache.end()) {
-        ptr = itr->second;
-    } else if (cpu->NumInstrsToExecute != 1) {
-        if (InterpreterTranslateBlock(cpu, ptr, cpu->Reg[15]) == FETCH_EXCEPTION)
-            goto END;
+    const std::uint64_t block_key = cpu->make_instruction_cache_key(cpu->Reg[15]);
+    ARMul_State::block_l1_entry &l1 = cpu->block_l1_cache[ARMul_State::block_l1_index(block_key)];
+    if (l1.key == block_key) {
+        // Fast path: hot blocks skip the unordered_map entirely.
+        ptr = l1.ptr;
     } else {
-        if (InterpreterTranslateSingle(cpu, ptr, cpu->Reg[15]) == FETCH_EXCEPTION)
-            goto END;
+        auto itr = cpu->instruction_cache.find(block_key);
+        if (itr != cpu->instruction_cache.end()) {
+            ptr = itr->second;
+        } else {
+            // The translation buffer is a bump allocator that is no longer reset
+            // on every context switch (blocks are kept across processes via the
+            // asid tag). Flush everything if a fresh block could run past the
+            // buffer end. TRANS_CACHE_FLUSH_RESERVE comfortably exceeds the
+            // largest possible single basic block (capped at one page).
+            constexpr std::size_t TRANS_CACHE_FLUSH_RESERVE = 2 * 1024 * 1024;
+            if (cpu->trans_cache_buf_top + TRANS_CACHE_FLUSH_RESERVE > TRANS_CACHE_SIZE) {
+                cpu->instruction_cache.clear();
+                cpu->trans_cache_buf_top = 0;
+                cpu->flush_block_l1_cache();
+            }
+
+            if (cpu->NumInstrsToExecute != 1) {
+                if (InterpreterTranslateBlock(cpu, ptr, cpu->Reg[15]) == FETCH_EXCEPTION)
+                    goto END;
+            } else {
+                if (InterpreterTranslateSingle(cpu, ptr, cpu->Reg[15]) == FETCH_EXCEPTION)
+                    goto END;
+            }
+        }
+
+        // Re-index: a flush above may have moved the slot; refill from the live
+        // key so the next visit hits. (l1 reference is still valid -- the cache
+        // is a fixed array -- but recompute defensively after a possible flush.)
+        ARMul_State::block_l1_entry &slot = cpu->block_l1_cache[ARMul_State::block_l1_index(block_key)];
+        slot.key = block_key;
+        slot.ptr = ptr;
     }
 
     inst_base = (arm_inst *)&cpu->trans_cache_buf[ptr];
+    GOTO_NEXT_INST;
+}
+LOOP_ACCEL_INST : {
+    loop_accel_inst *const inst_cream = (loop_accel_inst *)inst_base->component;
+    const std::uint32_t iter_left = cpu->Reg[inst_cream->counter_reg];
+    if (iter_left > 1) {
+        // Bulk at most iter_left-1 iterations: the last one always runs
+        // interpreted so flags, scratch registers and the loop exit come from
+        // real interpretation. Cap by the remaining quantum so blocking /
+        // reschedule behaviour keeps its granularity.
+        const std::uint64_t quantum_rem = (cpu->NumInstrsToExecute > num_instrs)
+            ? (cpu->NumInstrsToExecute - num_instrs)
+            : 0;
+        const std::uint64_t cap = quantum_rem / inst_cream->body_len + 1;
+        const std::uint32_t want = static_cast<std::uint32_t>(
+            std::min<std::uint64_t>(cap, iter_left - 1));
+        if (want) {
+            const std::uint32_t done = run_accel_bulk(cpu, inst_cream, want);
+            if (done) {
+                for (int i = 0; i < inst_cream->ind_count; i++)
+                    cpu->Reg[inst_cream->ind[i].reg] += static_cast<std::uint32_t>(inst_cream->ind[i].delta) * done;
+                num_instrs += static_cast<std::uint64_t>(done) * inst_cream->body_len;
+            }
+        }
+    }
+    INC_PC(sizeof(loop_accel_inst));
+    FETCH_INST;
     GOTO_NEXT_INST;
 }
 ADC_INST : {
@@ -1655,8 +2765,11 @@ ADD_INST : {
         std::uint32_t rn_val = 0;
 
         // The ADR thumb instruction got disguised, under ADD. However unlike the other,
-        // it uses aligned PC. So have to check
-        if (cpu->TFlag) {
+        // it uses aligned PC. So have to check -- but the distinction only matters when
+        // Rn is the PC, so ordinary registers skip the per-execution code re-read.
+        if (inst_cream->Rn != 15) {
+            rn_val = cpu->Reg[inst_cream->Rn];
+        } else if (cpu->TFlag) {
             std::uint32_t inst = cpu->ReadCode(cpu->Reg[15] & 0xFFFFFFFC);
             inst = GetThumbInstruction(inst, cpu->Reg[15]);
 
@@ -2014,34 +3127,38 @@ LDM_INST : {
         ldst_inst *inst_cream = (ldst_inst *)inst_base->component;
         inst_cream->get_addr(cpu, inst_cream->inst, addr);
 
+        // The register list maps to contiguous, ascending addresses -- resolve the
+        // host page once and reuse it for the whole run (see block_cursor).
+        ARMul_State::block_cursor ldm_cur;
+
         unsigned int inst = inst_cream->inst;
         if (BIT(inst, 22) && !BIT(inst, 15)) {
             for (int i = 0; i < 13; i++) {
                 if (BIT(inst, i)) {
-                    cpu->Reg[i] = cpu->ReadMemory32(addr);
+                    cpu->Reg[i] = cpu->ReadMemory32Block(addr, ldm_cur);
                     addr += 4;
                 }
             }
             if (BIT(inst, 13)) {
                 if (cpu->Mode == USER32MODE)
-                    cpu->Reg[13] = cpu->ReadMemory32(addr);
+                    cpu->Reg[13] = cpu->ReadMemory32Block(addr, ldm_cur);
                 else
-                    cpu->Reg_usr[0] = cpu->ReadMemory32(addr);
+                    cpu->Reg_usr[0] = cpu->ReadMemory32Block(addr, ldm_cur);
 
                 addr += 4;
             }
             if (BIT(inst, 14)) {
                 if (cpu->Mode == USER32MODE)
-                    cpu->Reg[14] = cpu->ReadMemory32(addr);
+                    cpu->Reg[14] = cpu->ReadMemory32Block(addr, ldm_cur);
                 else
-                    cpu->Reg_usr[1] = cpu->ReadMemory32(addr);
+                    cpu->Reg_usr[1] = cpu->ReadMemory32Block(addr, ldm_cur);
 
                 addr += 4;
             }
         } else if (!BIT(inst, 22)) {
             for (int i = 0; i < 16; i++) {
                 if (BIT(inst, i)) {
-                    unsigned int ret = cpu->ReadMemory32(addr);
+                    unsigned int ret = cpu->ReadMemory32Block(addr, ldm_cur);
 
                     // For armv5t, should enter thumb when bits[0] is non-zero.
                     if (i == 15) {
@@ -2056,7 +3173,7 @@ LDM_INST : {
         } else if (BIT(inst, 22) && BIT(inst, 15)) {
             for (int i = 0; i < 15; i++) {
                 if (BIT(inst, i)) {
-                    cpu->Reg[i] = cpu->ReadMemory32(addr);
+                    cpu->Reg[i] = cpu->ReadMemory32Block(addr, ldm_cur);
                     addr += 4;
                 }
             }
@@ -2067,7 +3184,7 @@ LDM_INST : {
                 LOAD_NZCVT;
             }
 
-            cpu->Reg[15] = cpu->ReadMemory32(addr);
+            cpu->Reg[15] = cpu->ReadMemory32Block(addr, ldm_cur);
         }
 
         if (BIT(inst, 15)) {
@@ -2099,7 +3216,7 @@ SXTH_INST : {
 }
 LDR_INST : {
     ldst_inst *inst_cream = (ldst_inst *)inst_base->component;
-    inst_cream->get_addr(cpu, inst_cream->inst, addr);
+    LS_GET_ADDR(addr);
 
     unsigned int value = cpu->ReadMemory32(addr);
     cpu->Reg[BITS(inst_cream->inst, 12, 15)] = value;
@@ -2120,7 +3237,7 @@ LDR_INST : {
 LDRCOND_INST : {
     if (CondPassed(cpu, inst_base->cond)) {
         ldst_inst *inst_cream = (ldst_inst *)inst_base->component;
-        inst_cream->get_addr(cpu, inst_cream->inst, addr);
+        LS_GET_ADDR(addr);
 
         unsigned int value = cpu->ReadMemory32(addr);
         cpu->Reg[BITS(inst_cream->inst, 12, 15)] = value;
@@ -2163,7 +3280,7 @@ UXTAH_INST : {
 LDRB_INST : {
     if (inst_base->cond == ConditionCode::AL || CondPassed(cpu, inst_base->cond)) {
         ldst_inst *inst_cream = (ldst_inst *)inst_base->component;
-        inst_cream->get_addr(cpu, inst_cream->inst, addr);
+        LS_GET_ADDR(addr);
 
         cpu->Reg[BITS(inst_cream->inst, 12, 15)] = cpu->ReadMemory8(addr);
     }
@@ -2175,7 +3292,7 @@ LDRB_INST : {
 LDRBT_INST : {
     if (inst_base->cond == ConditionCode::AL || CondPassed(cpu, inst_base->cond)) {
         ldst_inst *inst_cream = (ldst_inst *)inst_base->component;
-        inst_cream->get_addr(cpu, inst_cream->inst, addr);
+        LS_GET_ADDR(addr);
 
         const std::uint32_t dest_index = BITS(inst_cream->inst, 12, 15);
         const std::uint32_t previous_mode = cpu->Mode;
@@ -2196,7 +3313,7 @@ LDRD_INST : {
         ldst_inst *inst_cream = (ldst_inst *)inst_base->component;
         // Should check if RD is even-numbered, Rd != 14, addr[0:1] == 0, (CP15_reg1_U == 1 ||
         // addr[2] == 0)
-        inst_cream->get_addr(cpu, inst_cream->inst, addr);
+        MLS_GET_ADDR(addr);
 
         // The 3DS doesn't have LPAE (Large Physical Access Extension), so it
         // wouldn't do this as a single read.
@@ -2267,7 +3384,7 @@ LDREXD_INST : {
 LDRH_INST : {
     if (inst_base->cond == ConditionCode::AL || CondPassed(cpu, inst_base->cond)) {
         ldst_inst *inst_cream = (ldst_inst *)inst_base->component;
-        inst_cream->get_addr(cpu, inst_cream->inst, addr);
+        MLS_GET_ADDR(addr);
 
         cpu->Reg[BITS(inst_cream->inst, 12, 15)] = cpu->ReadMemory16(addr);
     }
@@ -2279,7 +3396,7 @@ LDRH_INST : {
 LDRSB_INST : {
     if (inst_base->cond == ConditionCode::AL || CondPassed(cpu, inst_base->cond)) {
         ldst_inst *inst_cream = (ldst_inst *)inst_base->component;
-        inst_cream->get_addr(cpu, inst_cream->inst, addr);
+        MLS_GET_ADDR(addr);
         unsigned int value = cpu->ReadMemory8(addr);
         if (BIT(value, 7)) {
             value |= 0xffffff00;
@@ -2294,7 +3411,7 @@ LDRSB_INST : {
 LDRSH_INST : {
     if (inst_base->cond == ConditionCode::AL || CondPassed(cpu, inst_base->cond)) {
         ldst_inst *inst_cream = (ldst_inst *)inst_base->component;
-        inst_cream->get_addr(cpu, inst_cream->inst, addr);
+        MLS_GET_ADDR(addr);
 
         unsigned int value = cpu->ReadMemory16(addr);
         if (BIT(value, 15)) {
@@ -2310,7 +3427,7 @@ LDRSH_INST : {
 LDRT_INST : {
     if (inst_base->cond == ConditionCode::AL || CondPassed(cpu, inst_base->cond)) {
         ldst_inst *inst_cream = (ldst_inst *)inst_base->component;
-        inst_cream->get_addr(cpu, inst_cream->inst, addr);
+        LS_GET_ADDR(addr);
 
         const std::uint32_t dest_index = BITS(inst_cream->inst, 12, 15);
         const std::uint32_t previous_mode = cpu->Mode;
@@ -3525,39 +4642,43 @@ STM_INST : {
         unsigned int old_RN = cpu->Reg[Rn];
 
         inst_cream->get_addr(cpu, inst_cream->inst, addr);
+
+        // Contiguous, ascending stores -- resolve the host page once (see block_cursor).
+        ARMul_State::block_cursor stm_cur;
+
         if (BIT(inst_cream->inst, 22) == 1) {
             for (int i = 0; i < 13; i++) {
                 if (BIT(inst_cream->inst, i)) {
-                    cpu->WriteMemory32(addr, cpu->Reg[i]);
+                    cpu->WriteMemory32Block(addr, cpu->Reg[i], stm_cur);
                     addr += 4;
                 }
             }
             if (BIT(inst_cream->inst, 13)) {
                 if (cpu->Mode == USER32MODE)
-                    cpu->WriteMemory32(addr, cpu->Reg[13]);
+                    cpu->WriteMemory32Block(addr, cpu->Reg[13], stm_cur);
                 else
-                    cpu->WriteMemory32(addr, cpu->Reg_usr[0]);
+                    cpu->WriteMemory32Block(addr, cpu->Reg_usr[0], stm_cur);
 
                 addr += 4;
             }
             if (BIT(inst_cream->inst, 14)) {
                 if (cpu->Mode == USER32MODE)
-                    cpu->WriteMemory32(addr, cpu->Reg[14]);
+                    cpu->WriteMemory32Block(addr, cpu->Reg[14], stm_cur);
                 else
-                    cpu->WriteMemory32(addr, cpu->Reg_usr[1]);
+                    cpu->WriteMemory32Block(addr, cpu->Reg_usr[1], stm_cur);
 
                 addr += 4;
             }
             if (BIT(inst_cream->inst, 15)) {
-                cpu->WriteMemory32(addr, cpu->Reg[15] + 8);
+                cpu->WriteMemory32Block(addr, cpu->Reg[15] + 8, stm_cur);
             }
         } else {
             for (unsigned int i = 0; i < 15; i++) {
                 if (BIT(inst_cream->inst, i)) {
                     if (i == Rn)
-                        cpu->WriteMemory32(addr, old_RN);
+                        cpu->WriteMemory32Block(addr, old_RN, stm_cur);
                     else
-                        cpu->WriteMemory32(addr, cpu->Reg[i]);
+                        cpu->WriteMemory32Block(addr, cpu->Reg[i], stm_cur);
 
                     addr += 4;
                 }
@@ -3565,7 +4686,7 @@ STM_INST : {
 
             // Check PC reg
             if (BIT(inst_cream->inst, 15)) {
-                cpu->WriteMemory32(addr, cpu->Reg[15] + 8);
+                cpu->WriteMemory32Block(addr, cpu->Reg[15] + 8, stm_cur);
             }
         }
     }
@@ -3594,7 +4715,7 @@ SXTB_INST : {
 STR_INST : {
     if (inst_base->cond == ConditionCode::AL || CondPassed(cpu, inst_base->cond)) {
         ldst_inst *inst_cream = (ldst_inst *)inst_base->component;
-        inst_cream->get_addr(cpu, inst_cream->inst, addr);
+        LS_GET_ADDR(addr);
 
         unsigned int reg = BITS(inst_cream->inst, 12, 15);
         unsigned int value = cpu->Reg[reg];
@@ -3634,7 +4755,7 @@ UXTAB_INST : {
 STRB_INST : {
     if (inst_base->cond == ConditionCode::AL || CondPassed(cpu, inst_base->cond)) {
         ldst_inst *inst_cream = (ldst_inst *)inst_base->component;
-        inst_cream->get_addr(cpu, inst_cream->inst, addr);
+        LS_GET_ADDR(addr);
         unsigned int value = cpu->Reg[BITS(inst_cream->inst, 12, 15)] & 0xff;
         cpu->WriteMemory8(addr, value);
     }
@@ -3646,7 +4767,7 @@ STRB_INST : {
 STRBT_INST : {
     if (inst_base->cond == ConditionCode::AL || CondPassed(cpu, inst_base->cond)) {
         ldst_inst *inst_cream = (ldst_inst *)inst_base->component;
-        inst_cream->get_addr(cpu, inst_cream->inst, addr);
+        LS_GET_ADDR(addr);
 
         const std::uint32_t previous_mode = cpu->Mode;
         const std::uint32_t value = cpu->Reg[BITS(inst_cream->inst, 12, 15)] & 0xff;
@@ -3663,7 +4784,7 @@ STRBT_INST : {
 STRD_INST : {
     if (inst_base->cond == ConditionCode::AL || CondPassed(cpu, inst_base->cond)) {
         ldst_inst *inst_cream = (ldst_inst *)inst_base->component;
-        inst_cream->get_addr(cpu, inst_cream->inst, addr);
+        MLS_GET_ADDR(addr);
 
         // The 3DS doesn't have the Large Physical Access Extension (LPAE)
         // so STRD wouldn't store these as a single write.
@@ -3735,7 +4856,7 @@ STREXH_INST : {
 STRH_INST : {
     if (inst_base->cond == ConditionCode::AL || CondPassed(cpu, inst_base->cond)) {
         ldst_inst *inst_cream = (ldst_inst *)inst_base->component;
-        inst_cream->get_addr(cpu, inst_cream->inst, addr);
+        MLS_GET_ADDR(addr);
 
         unsigned int value = cpu->Reg[BITS(inst_cream->inst, 12, 15)] & 0xffff;
         cpu->WriteMemory16(addr, value);
@@ -3748,7 +4869,7 @@ STRH_INST : {
 STRT_INST : {
     if (inst_base->cond == ConditionCode::AL || CondPassed(cpu, inst_base->cond)) {
         ldst_inst *inst_cream = (ldst_inst *)inst_base->component;
-        inst_cream->get_addr(cpu, inst_cream->inst, addr);
+        LS_GET_ADDR(addr);
 
         const std::uint32_t previous_mode = cpu->Mode;
         const std::uint32_t rt_index = BITS(inst_cream->inst, 12, 15);

--- a/src/emu/cpu/src/dyncom/armstate.cpp
+++ b/src/emu/cpu/src/dyncom/armstate.cpp
@@ -11,6 +11,7 @@
 
 ARMul_State::ARMul_State(eka2l1::arm::dyncom_core *core, PrivilegeMode initial_mode)
     : core(core) {
+    flush_block_l1_cache();
     Reset();
     ChangePrivilegeMode(initial_mode);
 }
@@ -189,12 +190,7 @@ void ARMul_State::RaiseSystemCall(std::uint32_t val) {
     core->system_call_handler(val);
 }
 
-std::uint8_t ARMul_State::ReadMemory8(std::uint32_t address) const {
-    eka2l1::arm::r12l1::tlb *cache = core->mem_cache();
-    if (std::uint8_t *ptr = cache->lookup(address)) {
-        return *ptr;
-    }
-
+std::uint8_t ARMul_State::ReadMemory8Slow(std::uint32_t address) const {
     std::uint8_t value = 0;
     bool result = core->read_8bit(address, &value);
 
@@ -211,12 +207,7 @@ std::uint8_t ARMul_State::ReadMemory8(std::uint32_t address) const {
     return value;
 }
 
-std::uint16_t ARMul_State::ReadMemory16(std::uint32_t address) const {
-    eka2l1::arm::r12l1::tlb *cache = core->mem_cache();
-    if (std::uint16_t *ptr = reinterpret_cast<std::uint16_t *>(cache->lookup(address))) {
-        return *ptr;
-    }
-
+std::uint16_t ARMul_State::ReadMemory16Slow(std::uint32_t address) const {
     std::uint16_t value = 0;
     bool result = core->read_16bit(address, &value);
 
@@ -236,12 +227,7 @@ std::uint16_t ARMul_State::ReadMemory16(std::uint32_t address) const {
     return value;
 }
 
-std::uint32_t ARMul_State::ReadMemory32(std::uint32_t address) const {
-    eka2l1::arm::r12l1::tlb *cache = core->mem_cache();
-    if (std::uint32_t *ptr = reinterpret_cast<std::uint32_t *>(cache->lookup(address))) {
-        return *ptr;
-    }
-
+std::uint32_t ARMul_State::ReadMemory32Slow(std::uint32_t address) const {
     std::uint32_t value = 0;
     bool result = core->read_32bit(address, &value);
 
@@ -262,6 +248,15 @@ std::uint32_t ARMul_State::ReadMemory32(std::uint32_t address) const {
 }
 
 std::uint32_t ARMul_State::ReadCode(std::uint32_t address) const {
+    // Instruction fetch can use the same direct-mapped TLB as data reads: a code
+    // page that is already cached (its host pointer was resolved on a prior fetch
+    // or data read) skips the page-directory walk. SMC invalidates the entry via
+    // make_dirty just like data, so this stays consistent.
+    eka2l1::arm::r12l1::tlb *cache = core->mem_cache();
+    if (std::uint32_t *ptr = reinterpret_cast<std::uint32_t *>(cache->lookup(address))) {
+        return *ptr;
+    }
+
     std::uint32_t value = 0;
     bool result = core->read_code(address, &value);
 
@@ -278,12 +273,7 @@ std::uint32_t ARMul_State::ReadCode(std::uint32_t address) const {
     return value;
 }
 
-std::uint64_t ARMul_State::ReadMemory64(std::uint32_t address) const {
-    eka2l1::arm::r12l1::tlb *cache = core->mem_cache();
-    if (std::uint64_t *ptr = reinterpret_cast<std::uint64_t *>(cache->lookup(address))) {
-        return *ptr;
-    }
-
+std::uint64_t ARMul_State::ReadMemory64Slow(std::uint32_t address) const {
     std::uint64_t value = 0;
     bool result = core->read_64bit(address, &value);
 
@@ -303,13 +293,7 @@ std::uint64_t ARMul_State::ReadMemory64(std::uint32_t address) const {
     return value;
 }
 
-void ARMul_State::WriteMemory8(std::uint32_t address, std::uint8_t data) {
-    eka2l1::arm::r12l1::tlb *cache = core->mem_cache();
-    if (std::uint8_t *ptr = cache->lookup(address)) {
-        *ptr = data;
-        return;
-    }
-
+void ARMul_State::WriteMemory8Slow(std::uint32_t address, std::uint8_t data) {
     bool result = core->write_8bit(address, &data);
 
     if (!result) {
@@ -323,16 +307,7 @@ void ARMul_State::WriteMemory8(std::uint32_t address, std::uint8_t data) {
     }
 }
 
-void ARMul_State::WriteMemory16(std::uint32_t address, std::uint16_t data) {
-    if (InBigEndianMode())
-        data = eka2l1::common::byte_swap(data);
-
-    eka2l1::arm::r12l1::tlb *cache = core->mem_cache();
-    if (std::uint16_t *ptr = reinterpret_cast<std::uint16_t *>(cache->lookup(address))) {
-        *ptr = data;
-        return;
-    }
-
+void ARMul_State::WriteMemory16Slow(std::uint32_t address, std::uint16_t data) {
     bool result = core->write_16bit(address, &data);
 
     if (!result) {
@@ -346,16 +321,7 @@ void ARMul_State::WriteMemory16(std::uint32_t address, std::uint16_t data) {
     }
 }
 
-void ARMul_State::WriteMemory32(std::uint32_t address, std::uint32_t data) {
-    if (InBigEndianMode())
-        data = eka2l1::common::byte_swap(data);
-
-    eka2l1::arm::r12l1::tlb *cache = core->mem_cache();
-    if (std::uint32_t *ptr = reinterpret_cast<std::uint32_t *>(cache->lookup(address))) {
-        *ptr = data;
-        return;
-    }
-
+void ARMul_State::WriteMemory32Slow(std::uint32_t address, std::uint32_t data) {
     bool result = core->write_32bit(address, &data);
 
     if (!result) {
@@ -369,16 +335,7 @@ void ARMul_State::WriteMemory32(std::uint32_t address, std::uint32_t data) {
     }
 }
 
-void ARMul_State::WriteMemory64(std::uint32_t address, std::uint64_t data) {
-    if (InBigEndianMode())
-        data = eka2l1::common::byte_swap(data);
-
-    eka2l1::arm::r12l1::tlb *cache = core->mem_cache();
-    if (std::uint64_t *ptr = reinterpret_cast<std::uint64_t *>(cache->lookup(address))) {
-        *ptr = data;
-        return;
-    }
-
+void ARMul_State::WriteMemory64Slow(std::uint32_t address, std::uint64_t data) {
     bool result = core->write_64bit(address, &data);
 
     if (!result) {

--- a/src/emu/cpu/src/dyncom/armsupp.cpp
+++ b/src/emu/cpu/src/dyncom/armsupp.cpp
@@ -25,21 +25,7 @@ std::uint8_t ARMul_UnsignedAbsoluteDifference(std::uint8_t left, std::uint8_t ri
     return right - left;
 }
 
-// Add with carry, indicates if a carry-out or signed overflow occurred.
-std::uint32_t AddWithCarry(std::uint32_t left, std::uint32_t right, std::uint32_t carry_in, bool *carry_out_occurred,
-    bool *overflow_occurred) {
-    std::uint64_t unsigned_sum = (std::uint64_t)left + (std::uint64_t)right + (std::uint64_t)carry_in;
-    std::int64_t signed_sum = (std::int64_t)(std::int32_t)left + (std::int64_t)(std::int32_t)right + (std::int64_t)carry_in;
-    std::uint64_t result = (unsigned_sum & 0xFFFFFFFF);
-
-    if (carry_out_occurred)
-        *carry_out_occurred = (result != unsigned_sum);
-
-    if (overflow_occurred)
-        *overflow_occurred = ((std::int64_t)(std::int32_t)result != signed_sum);
-
-    return (std::uint32_t)result;
-}
+// AddWithCarry is now an inline hot-path helper in armsupp.h.
 
 // Compute whether an addition of A and B, giving RESULT, overflowed.
 bool AddOverflow(std::uint32_t a, std::uint32_t b, std::uint32_t result) {

--- a/src/emu/cpu/src/dyncom/tests/dyncom_difftest.cpp
+++ b/src/emu/cpu/src/dyncom/tests/dyncom_difftest.cpp
@@ -1,0 +1,1931 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * Differential test harness for the dyncom interpreter.
+ *
+ * Standalone host tool (no Catch2 dependency) that runs randomized ARM
+ * instruction cases through the dyncom interpreter and checks the guest-visible
+ * result against:
+ *   (a) an independent golden ALU model (data-processing semantics + the ARM
+ *       barrel-shifter carry-out rules) -- the fixed reference that the
+ *       semantic optimizations (shifter specialization, lazy flags, inline
+ *       AddWithCarry) must keep matching, and
+ *   (b) a second dyncom instance (self-A/B) -- so a dispatch-shape optimization
+ *       gated behind a flag can be proven behaviour-preserving by toggling it
+ *       on one side.
+ *
+ * A negative-control case deliberately perturbs the result to prove the
+ * comparator actually detects a divergence (a harness that can never fail is
+ * useless).
+ *
+ * Build:  cmake -DEKA2L1_BUILD_DYNCOM_DIFFTEST=ON ...   (needs dynarmic)
+ * Run:    scripts/cpu_difftest.sh   (exits non-zero on the first divergence)
+ */
+
+#include <cpu/arm_dynarmic.h>
+#include <cpu/dyncom/arm_dyncom.h>
+#include <cpu/dyncom/vfp/asm_vfp.h>
+#include <cpu/dyncom/vfp/vfp.h>
+#include <cpu/12l1r/exclusive_monitor.h>
+
+#include <common/types.h>
+
+#include <bit>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <random>
+#include <vector>
+
+using namespace eka2l1;
+using namespace eka2l1::arm;
+
+namespace {
+
+constexpr std::uint32_t MEM_SIZE = 0x10000; // 64 KB flat memory
+constexpr std::size_t PAGE_BITS = 12;
+constexpr std::uint32_t PAGE_MASK = (1u << PAGE_BITS) - 1;
+
+// ---------------------------------------------------------------------------
+// dyncom core over a flat memory buffer
+// ---------------------------------------------------------------------------
+struct diff_env {
+    std::vector<std::uint8_t> mem;
+    r12l1::exclusive_monitor monitor;
+    diff_env()
+        : mem(MEM_SIZE, 0)
+        , monitor(1) {
+    }
+};
+
+std::unique_ptr<dyncom_core> make_core(diff_env &env) {
+    auto core = std::make_unique<dyncom_core>(&env.monitor, PAGE_BITS);
+    std::uint8_t *base = env.mem.data();
+    dyncom_core *cp = core.get();
+
+    auto seed_tlb = [cp, base](std::uint32_t addr) {
+        const std::uint32_t page = addr & ~PAGE_MASK;
+        cp->set_tlb_page(page, base + page, prot_read_write);
+    };
+
+    core->read_code = [base](const address a, std::uint32_t *r) -> bool {
+        if (a + 4 > MEM_SIZE)
+            return false;
+        std::memcpy(r, base + a, 4);
+        return true;
+    };
+    core->read_8bit = [base, seed_tlb](const address a, std::uint8_t *r) -> bool {
+        if (a >= MEM_SIZE)
+            return false;
+        *r = base[a];
+        seed_tlb(a);
+        return true;
+    };
+    core->read_16bit = [base, seed_tlb](const address a, std::uint16_t *r) -> bool {
+        if (a + 2 > MEM_SIZE)
+            return false;
+        std::memcpy(r, base + a, 2);
+        seed_tlb(a);
+        return true;
+    };
+    core->read_32bit = [base, seed_tlb](const address a, std::uint32_t *r) -> bool {
+        if (a + 4 > MEM_SIZE)
+            return false;
+        std::memcpy(r, base + a, 4);
+        seed_tlb(a);
+        return true;
+    };
+    core->read_64bit = [base, seed_tlb](const address a, std::uint64_t *r) -> bool {
+        if (a + 8 > MEM_SIZE)
+            return false;
+        std::memcpy(r, base + a, 8);
+        seed_tlb(a);
+        return true;
+    };
+    core->write_8bit = [base, seed_tlb](const address a, std::uint8_t *v) -> bool {
+        if (a >= MEM_SIZE)
+            return false;
+        base[a] = *v;
+        seed_tlb(a);
+        return true;
+    };
+    core->write_16bit = [base, seed_tlb](const address a, std::uint16_t *v) -> bool {
+        if (a + 2 > MEM_SIZE)
+            return false;
+        std::memcpy(base + a, v, 2);
+        seed_tlb(a);
+        return true;
+    };
+    core->write_32bit = [base, seed_tlb](const address a, std::uint32_t *v) -> bool {
+        if (a + 4 > MEM_SIZE)
+            return false;
+        std::memcpy(base + a, v, 4);
+        seed_tlb(a);
+        return true;
+    };
+    core->write_64bit = [base, seed_tlb](const address a, std::uint64_t *v) -> bool {
+        if (a + 8 > MEM_SIZE)
+            return false;
+        std::memcpy(base + a, v, 8);
+        seed_tlb(a);
+        return true;
+    };
+
+    core->exception_handler = [](exception_type, const std::uint32_t) -> bool { return false; };
+    core->system_call_handler = [](const std::uint32_t) {};
+
+    return core;
+}
+
+// ---------------------------------------------------------------------------
+// Guest-visible state snapshot
+// ---------------------------------------------------------------------------
+struct cpu_state {
+    std::uint32_t reg[16];
+    std::uint32_t cpsr;
+
+    bool operator==(const cpu_state &o) const {
+        return std::memcmp(this, &o, sizeof(cpu_state)) == 0;
+    }
+};
+
+cpu_state read_state(dyncom_core &c) {
+    cpu_state s{};
+    for (std::size_t i = 0; i < 16; i++) {
+        s.reg[i] = c.get_reg(i);
+    }
+    s.cpsr = c.get_cpsr();
+    return s;
+}
+
+void write_state(dyncom_core &c, const cpu_state &s) {
+    for (std::size_t i = 0; i < 16; i++) {
+        c.set_reg(i, s.reg[i]);
+    }
+    c.set_cpsr(s.cpsr);
+}
+
+// ---------------------------------------------------------------------------
+// Golden ALU model (independent reference) -- ARM data-processing
+// ---------------------------------------------------------------------------
+constexpr std::uint32_t N_BIT = 1u << 31;
+constexpr std::uint32_t Z_BIT = 1u << 30;
+constexpr std::uint32_t C_BIT = 1u << 29;
+constexpr std::uint32_t V_BIT = 1u << 28;
+
+bool cond_passed(std::uint32_t cond, std::uint32_t cpsr) {
+    const bool n = cpsr & N_BIT, z = cpsr & Z_BIT, c = cpsr & C_BIT, v = cpsr & V_BIT;
+    switch (cond) {
+    case 0x0: return z;                       // EQ
+    case 0x1: return !z;                      // NE
+    case 0x2: return c;                       // CS
+    case 0x3: return !c;                      // CC
+    case 0x4: return n;                       // MI
+    case 0x5: return !n;                      // PL
+    case 0x6: return v;                       // VS
+    case 0x7: return !v;                      // VC
+    case 0x8: return c && !z;                 // HI
+    case 0x9: return !c || z;                 // LS
+    case 0xA: return n == v;                  // GE
+    case 0xB: return n != v;                  // LT
+    case 0xC: return !z && (n == v);          // GT
+    case 0xD: return z || (n != v);           // LE
+    case 0xE: return true;                    // AL
+    default: return true;
+    }
+}
+
+// Independent add-with-carry (64-bit; deliberately NOT the interpreter's
+// __builtin version, so it cross-checks rather than mirrors a bug).
+std::uint32_t golden_addc(std::uint32_t a, std::uint32_t b, std::uint32_t cin, bool *carry, bool *overflow) {
+    const std::uint64_t usum = (std::uint64_t)a + (std::uint64_t)b + (std::uint64_t)cin;
+    const std::int64_t ssum = (std::int64_t)(std::int32_t)a + (std::int64_t)(std::int32_t)b + (std::int64_t)cin;
+    const std::uint32_t r = (std::uint32_t)usum;
+    *carry = (usum >> 32) != 0;
+    *overflow = ((std::int64_t)(std::int32_t)r != ssum);
+    return r;
+}
+
+// Barrel shifter (immediate-specified shifts + the immediate-operand rotate).
+// Returns the operand value and the shifter carry-out.
+std::uint32_t golden_shifter(std::uint32_t op2_field, bool is_immediate, const std::uint32_t *regs,
+    bool carry_in, bool *carry_out) {
+    if (is_immediate) {
+        const std::uint32_t imm8 = op2_field & 0xFF;
+        const std::uint32_t rot = ((op2_field >> 8) & 0xF) * 2;
+        const std::uint32_t val = (rot == 0) ? imm8 : ((imm8 >> rot) | (imm8 << (32 - rot)));
+        *carry_out = (rot == 0) ? carry_in : ((val >> 31) & 1);
+        return val;
+    }
+
+    const std::uint32_t rm = regs[op2_field & 0xF];
+    const std::uint32_t shift_type = (op2_field >> 5) & 0x3;
+
+    // Register-specified shift (bit 4 set): the amount is the low byte of Rs and
+    // the >=32 cases have their own carry-out rules.
+    if (op2_field & 0x10) {
+        const std::uint32_t amt = regs[(op2_field >> 8) & 0xF] & 0xFF;
+        if (amt == 0) {
+            *carry_out = carry_in;
+            return rm;
+        }
+        switch (shift_type) {
+        case 0: // LSL
+            if (amt < 32) { *carry_out = (rm >> (32 - amt)) & 1; return rm << amt; }
+            if (amt == 32) { *carry_out = rm & 1; return 0; }
+            *carry_out = false; return 0;
+        case 1: // LSR
+            if (amt < 32) { *carry_out = (rm >> (amt - 1)) & 1; return rm >> amt; }
+            if (amt == 32) { *carry_out = (rm >> 31) & 1; return 0; }
+            *carry_out = false; return 0;
+        case 2: // ASR
+            if (amt < 32) { *carry_out = (rm >> (amt - 1)) & 1; return (std::uint32_t)((std::int32_t)rm >> amt); }
+            *carry_out = (rm >> 31) & 1; return (rm & N_BIT) ? 0xFFFFFFFF : 0;
+        default: { // ROR
+            const std::uint32_t a = amt & 0x1F;
+            if (a == 0) { *carry_out = (rm >> 31) & 1; return rm; } // amount a non-zero multiple of 32
+            *carry_out = (rm >> (a - 1)) & 1;
+            return (rm >> a) | (rm << (32 - a));
+        }
+        }
+    }
+
+    const std::uint32_t amount = (op2_field >> 7) & 0x1F; // immediate shift amount
+
+    switch (shift_type) {
+    case 0: // LSL
+        if (amount == 0) {
+            *carry_out = carry_in;
+            return rm;
+        }
+        *carry_out = (rm >> (32 - amount)) & 1;
+        return rm << amount;
+    case 1: // LSR (amount 0 means 32)
+        if (amount == 0) {
+            *carry_out = (rm >> 31) & 1;
+            return 0;
+        }
+        *carry_out = (rm >> (amount - 1)) & 1;
+        return rm >> amount;
+    case 2: // ASR (amount 0 means 32)
+        if (amount == 0) {
+            *carry_out = (rm >> 31) & 1;
+            return (rm & N_BIT) ? 0xFFFFFFFF : 0;
+        }
+        *carry_out = (rm >> (amount - 1)) & 1;
+        return (std::uint32_t)((std::int32_t)rm >> amount);
+    default:  // ROR / RRX (amount 0 means RRX)
+        if (amount == 0) { // RRX
+            *carry_out = rm & 1;
+            return (rm >> 1) | (carry_in ? N_BIT : 0);
+        }
+        *carry_out = (rm >> (amount - 1)) & 1;
+        return (rm >> amount) | (rm << (32 - amount));
+    }
+}
+
+// Apply one data-processing instruction to a golden state. Returns the expected
+// post-state. Mirrors ARM semantics for the 16 DP opcodes (no PC writes, no
+// S+Rd==15 SPSR restore -- the generator never emits those).
+cpu_state golden_data_processing(std::uint32_t inst, const cpu_state &in) {
+    cpu_state out = in;
+    out.reg[15] = in.reg[15] + 4; // PC advances one ARM instruction
+
+    const std::uint32_t cond = inst >> 28;
+    if (!cond_passed(cond, in.cpsr)) {
+        return out; // condition failed: only PC advanced
+    }
+
+    const bool is_imm = (inst >> 25) & 1;
+    const std::uint32_t opcode = (inst >> 21) & 0xF;
+    const bool S = (inst >> 20) & 1;
+    const std::uint32_t rn = (inst >> 16) & 0xF;
+    const std::uint32_t rd = (inst >> 12) & 0xF;
+    const std::uint32_t op2_field = inst & 0xFFF;
+
+    const bool cin = (in.cpsr & C_BIT) != 0;
+    bool shifter_carry = cin;
+    const std::uint32_t b = golden_shifter(op2_field, is_imm, in.reg, cin, &shifter_carry);
+    const std::uint32_t a = in.reg[rn];
+
+    std::uint32_t result = 0;
+    bool write_rd = true;
+    bool logical = true;
+    bool carry = cin, overflow = (in.cpsr & V_BIT) != 0;
+
+    switch (opcode) {
+    case 0x0: result = a & b; break;                                   // AND
+    case 0x1: result = a ^ b; break;                                   // EOR
+    case 0x2: result = golden_addc(a, ~b, 1, &carry, &overflow); logical = false; break;       // SUB
+    case 0x3: result = golden_addc(~a, b, 1, &carry, &overflow); logical = false; break;       // RSB
+    case 0x4: result = golden_addc(a, b, 0, &carry, &overflow); logical = false; break;        // ADD
+    case 0x5: result = golden_addc(a, b, cin, &carry, &overflow); logical = false; break;      // ADC
+    case 0x6: result = golden_addc(a, ~b, cin, &carry, &overflow); logical = false; break;     // SBC
+    case 0x7: result = golden_addc(~a, b, cin, &carry, &overflow); logical = false; break;     // RSC
+    case 0x8: result = a & b; write_rd = false; break;                 // TST
+    case 0x9: result = a ^ b; write_rd = false; break;                 // TEQ
+    case 0xA: result = golden_addc(a, ~b, 1, &carry, &overflow); logical = false; write_rd = false; break; // CMP
+    case 0xB: result = golden_addc(a, b, 0, &carry, &overflow); logical = false; write_rd = false; break;  // CMN
+    case 0xC: result = a | b; break;                                   // ORR
+    case 0xD: result = b; break;                                       // MOV
+    case 0xE: result = a & ~b; break;                                  // BIC
+    case 0xF: result = ~b; break;                                      // MVN
+    default: break;
+    }
+
+    if (write_rd) {
+        out.reg[rd] = result;
+    }
+
+    if (S) {
+        std::uint32_t cpsr = out.cpsr & ~(N_BIT | Z_BIT | C_BIT | V_BIT);
+        if (result & N_BIT) cpsr |= N_BIT;
+        if (result == 0) cpsr |= Z_BIT;
+        if (logical) {
+            if (shifter_carry) cpsr |= C_BIT;
+            cpsr |= (in.cpsr & V_BIT); // V unchanged for logical
+        } else {
+            if (carry) cpsr |= C_BIT;
+            if (overflow) cpsr |= V_BIT;
+        }
+        out.cpsr = cpsr;
+    }
+
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// Random instruction + state generation
+// ---------------------------------------------------------------------------
+struct rng {
+    std::mt19937 e;
+    explicit rng(std::uint32_t seed)
+        : e(seed) {
+    }
+    std::uint32_t u32() { return e(); }
+    std::uint32_t range(std::uint32_t n) { return e() % n; }
+    bool flip() { return e() & 1; }
+};
+
+std::uint32_t random_normal_f32(rng &r) {
+    // Keep most products away from overflow/underflow so the host envelope is
+    // exercised heavily, while still varying signs and every significand bit.
+    const std::uint32_t sign = r.u32() & 0x80000000u;
+    const std::uint32_t exponent = 80u + r.range(96u);
+    return sign | (exponent << 23) | (r.u32() & 0x007FFFFFu);
+}
+
+std::uint32_t run_vfp_mac_differential(diff_env &env_a, diff_env &env_b,
+    dyncom_core &core_a, dyncom_core &core_b, std::uint32_t base_seed,
+    std::uint32_t count) {
+    struct mac_op {
+        const char *name;
+        std::uint32_t inst;
+    };
+    // vmla/vmls/vnmla/vnmls.f32 s0, s1, s2 (ARM state, AL condition).
+    static constexpr mac_op ops[] = {
+        { "vmla.f32", 0xEE000A81u },
+        { "vmls.f32", 0xEE000AC1u },
+        { "vnmla.f32", 0xEE100AC1u },
+        { "vnmls.f32", 0xEE100A81u },
+    };
+
+    const std::uint32_t cases = count < 50000u ? count : 50000u;
+    std::uint32_t failures = 0;
+    vfp_reset_single_host_fast_hits_for_test();
+
+    for (std::uint32_t i = 0; i < cases && failures < 20; ++i) {
+        const std::uint32_t case_seed = base_seed ^ (0x9E3779B9u * (i + 1u));
+        rng r(case_seed);
+        const std::uint32_t accumulator = random_normal_f32(r);
+        const std::uint32_t multiplicand = random_normal_f32(r);
+        const std::uint32_t multiplier = random_normal_f32(r);
+
+        for (const mac_op &op : ops) {
+            std::memcpy(env_a.mem.data(), &op.inst, 4);
+            std::memcpy(env_b.mem.data(), &op.inst, 4);
+            core_a.imb_range(0, 8);
+            core_b.imb_range(0, 8);
+
+            for (dyncom_core *core : { &core_a, &core_b }) {
+                core->set_cpsr(0x10); // USER mode, ARM state
+                core->set_pc(0);
+                core->set_fpscr(0);   // RN, gradual underflow, propagated NaNs
+                core->set_vfp(0, accumulator);
+                core->set_vfp(1, multiplicand);
+                core->set_vfp(2, multiplier);
+            }
+
+            vfp_set_single_host_fast_for_test(false);
+            core_a.run(1);
+            vfp_set_single_host_fast_for_test(true);
+            core_b.run(1);
+
+            const std::uint32_t slow = core_a.get_vfp(0);
+            const std::uint32_t fast = core_b.get_vfp(0);
+            // IXC is excluded: the host fast path trades the INEXACT cumulative
+            // flag for speed, uniformly across every operation it handles.
+            constexpr std::uint32_t IXC = 0x10u;
+            const std::uint32_t slow_fpscr = core_a.get_fpscr() & ~IXC;
+            const std::uint32_t fast_fpscr = core_b.get_fpscr() & ~IXC;
+            if (slow != fast || slow_fpscr != fast_fpscr) {
+                std::printf("[DIVERGENCE] %s host-fast != softfloat seed=%u "
+                            "a=%08X n=%08X m=%08X slow=%08X fast=%08X "
+                            "slow_fpscr=%08X fast_fpscr=%08X\n",
+                    op.name, case_seed, accumulator, multiplicand,
+                    multiplier, slow, fast, slow_fpscr, fast_fpscr);
+                ++failures;
+                if (failures >= 20)
+                    break;
+            }
+        }
+    }
+
+    const std::uint64_t hits = vfp_single_host_fast_hits_for_test();
+    if (hits == 0) {
+        std::printf("[HARNESS BUG] VFP MAC host-fast envelope was never exercised\n");
+        ++failures;
+    } else {
+        std::printf("dyncom_difftest: VFP MAC host-fast %llu hits across %u randomized inputs\n",
+            static_cast<unsigned long long>(hits), cases);
+    }
+    vfp_set_single_host_fast_for_test(true);
+    return failures;
+}
+
+std::uint32_t benchmark_vfp_mac(diff_env &env_a, diff_env &env_b,
+    dyncom_core &core_a, dyncom_core &core_b) {
+    constexpr std::uint32_t inst = 0xEE000A81u; // vmla.f32 s0, s1, s2
+    constexpr std::uint32_t instructions = 8192;
+    constexpr std::uint32_t rounds = 20;
+    static_assert(instructions * sizeof(inst) <= MEM_SIZE);
+
+    for (std::uint32_t offset = 0; offset < instructions * sizeof(inst); offset += sizeof(inst)) {
+        std::memcpy(env_a.mem.data() + offset, &inst, sizeof(inst));
+        std::memcpy(env_b.mem.data() + offset, &inst, sizeof(inst));
+    }
+    core_a.imb_range(0, instructions * sizeof(inst));
+    core_b.imb_range(0, instructions * sizeof(inst));
+
+    auto prepare = [](dyncom_core &core) {
+        core.set_cpsr(0x10);
+        core.set_pc(0);
+        core.set_fpscr(0);
+        core.set_vfp(0, 0x3F800000u); // 1.0
+        core.set_vfp(1, 0x35800000u); // 2^-20
+        core.set_vfp(2, 0x3F800000u); // 1.0
+    };
+    using clock = std::chrono::steady_clock;
+    std::chrono::nanoseconds slow_time{ 0 }, fast_time{ 0 };
+    vfp_reset_single_host_fast_hits_for_test();
+
+    for (std::uint32_t round = 0; round < rounds; ++round) {
+        prepare(core_a);
+        vfp_set_single_host_fast_for_test(false);
+        const auto slow_start = clock::now();
+        core_a.run(instructions);
+        slow_time += clock::now() - slow_start;
+
+        prepare(core_b);
+        vfp_set_single_host_fast_for_test(true);
+        const auto fast_start = clock::now();
+        core_b.run(instructions);
+        fast_time += clock::now() - fast_start;
+    }
+
+    const std::uint32_t slow = core_a.get_vfp(0);
+    const std::uint32_t fast = core_b.get_vfp(0);
+    const std::uint64_t hits = vfp_single_host_fast_hits_for_test();
+    vfp_set_single_host_fast_for_test(true);
+    if (slow != fast || hits != static_cast<std::uint64_t>(instructions) * rounds) {
+        std::printf("[HARNESS BUG] VFP MAC benchmark mismatch slow=%08X fast=%08X "
+                    "hits=%llu expected=%u\n",
+            slow, fast, static_cast<unsigned long long>(hits), instructions * rounds);
+        return 1;
+    }
+
+    const double slow_ms = std::chrono::duration<double, std::milli>(slow_time).count();
+    const double fast_ms = std::chrono::duration<double, std::milli>(fast_time).count();
+    std::printf("dyncom_difftest: VFP MAC microbenchmark soft=%.2fms host-fast=%.2fms (%.2fx)\n",
+        slow_ms, fast_ms, slow_ms / fast_ms);
+    return 0;
+}
+
+// A random data-processing instruction. cond is AL most of the time but
+// sometimes a real condition (to exercise the conditional path). Operand
+// registers are kept out of R15 (PC) so there are no PC-as-operand / PC-write
+// edge cases -- those belong in a dedicated edge corpus.
+std::uint32_t gen_data_processing(rng &r) {
+    const std::uint32_t cond = (r.range(4) == 0) ? r.range(14) : 0xE; // 0..13 or AL
+    std::uint32_t opcode = r.range(16);
+    const bool is_imm = r.flip();
+    bool S = r.flip();
+    if (opcode >= 0x8 && opcode <= 0xB) {
+        S = true; // TST/TEQ/CMP/CMN always set flags
+    }
+    const std::uint32_t rn = r.range(15);  // 0..14
+    const std::uint32_t rd = r.range(15);  // 0..14 (never PC)
+
+    std::uint32_t op2;
+    if (is_imm) {
+        op2 = (r.range(16) << 8) | r.range(256); // rotate(4) + imm8(8)
+    } else {
+        const std::uint32_t rm = r.range(15);     // 0..14
+        const std::uint32_t shtype = r.range(4);
+        if (r.flip()) {
+            // Register-specified shift: bit4 = 1, amount = Rs[11:8] (0..14).
+            const std::uint32_t rs = r.range(15);
+            op2 = (rs << 8) | (shtype << 5) | (1u << 4) | rm;
+        } else {
+            const std::uint32_t amount = r.range(32);
+            op2 = (amount << 7) | (shtype << 5) | rm; // bit4 = 0 -> immediate shift
+        }
+    }
+
+    return (cond << 28) | (0u << 26) | ((is_imm ? 1u : 0u) << 25) | (opcode << 21) | ((S ? 1u : 0u) << 20) | (rn << 16) | (rd << 12) | op2;
+}
+
+cpu_state gen_state(rng &r) {
+    cpu_state s{};
+    for (int i = 0; i < 15; i++) {
+        s.reg[i] = r.u32();
+    }
+    s.reg[15] = 0; // PC at the instruction under test
+    // USER mode, ARM state, IRQ/FIQ disabled; random NZCV.
+    s.cpsr = 0x10 | (0xF0000000u & r.u32());
+    return s;
+}
+
+// ---------------------------------------------------------------------------
+// Load/store (single data transfer: LDR/STR/LDRB/STRB, immediate offset)
+// ---------------------------------------------------------------------------
+// Two pages, so a block transfer can be made to straddle the boundary at
+// 0x2000 -- the only way to exercise the LDM/STM page cursor's re-resolve path.
+constexpr std::uint32_t LS_DATA_LO = 0x1000;
+constexpr std::uint32_t LS_DATA_HI = 0x3000;
+constexpr std::uint32_t LS_PAGE_EDGE = 0x2000;     // page boundary inside the window
+constexpr std::uint32_t LS_DATA_BASE = 0x1800;     // base register points here
+
+// Generate a single-data-transfer instruction whose base register is pointed
+// into the data window so the access always lands in mapped memory. Word
+// accesses keep an aligned offset (unaligned word rotation belongs in a later
+// edge corpus). Returns the encoding; sets init.reg[Rn] = base.
+std::uint32_t gen_load_store(rng &r, cpu_state &init) {
+    const std::uint32_t cond = (r.range(4) == 0) ? r.range(14) : 0xE;
+    const std::uint32_t P = r.flip() ? 1 : 0;
+    const std::uint32_t U = r.flip() ? 1 : 0;
+    const std::uint32_t B = r.flip() ? 1 : 0;            // 1 = byte, 0 = word
+    const std::uint32_t W = (P == 1) ? (r.flip() ? 1 : 0) : 0; // post-index: no W (would be LDRT)
+    const std::uint32_t L = r.flip() ? 1 : 0;            // 1 = load, 0 = store
+
+    const std::uint32_t rn = r.range(15);                // base, never PC
+    std::uint32_t rd = r.range(15);
+    while (rd == rn) {
+        rd = r.range(15);                                // base==dest writeback is unpredictable
+    }
+
+    init.reg[rn] = LS_DATA_BASE;
+
+    const bool reg_off = r.flip();
+    if (reg_off) {
+        // Scaled-register offset (I=1), LSL-scaled so a word access stays
+        // aligned; Rm holds a small value (!= base) so the address stays in the
+        // window. This is the classic [Rn, Rm, LSL #k] array-index form.
+        std::uint32_t rm = r.range(15);
+        while (rm == rn) {
+            rm = r.range(15);
+        }
+        const std::uint32_t shamt = (B == 0) ? 2 : (r.flip() ? 0 : 1); // word: <<2 (aligned)
+        init.reg[rm] = r.range(0x40);                    // 0..0x3F -> offset <= 0xFC
+        const std::uint32_t off_field = (shamt << 7) | (0u << 5) | rm; // LSL, bit4=0
+        return (cond << 28) | (0x1u << 26) | (1u << 25) | (P << 24) | (U << 23) | (B << 22) | (W << 21) | (L << 20) | (rn << 16) | (rd << 12) | off_field;
+    }
+
+    std::uint32_t offset = r.range(0x100);               // small immediate, stays in window
+    if (B == 0) {
+        offset &= ~0x3u;                                 // word: aligned
+    }
+
+    return (cond << 28) | (0x1u << 26) | (0u << 25) | (P << 24) | (U << 23) | (B << 22) | (W << 21) | (L << 20) | (rn << 16) | (rd << 12) | offset;
+}
+
+// Golden model for single data transfer, operating on a memory image.
+cpu_state golden_load_store(std::uint32_t inst, const cpu_state &in, std::uint8_t *mem) {
+    cpu_state out = in;
+    out.reg[15] = in.reg[15] + 4;
+
+    const std::uint32_t cond = inst >> 28;
+    if (!cond_passed(cond, in.cpsr)) {
+        return out;
+    }
+
+    const std::uint32_t P = (inst >> 24) & 1;
+    const std::uint32_t U = (inst >> 23) & 1;
+    const std::uint32_t B = (inst >> 22) & 1;
+    const std::uint32_t W = (inst >> 21) & 1;
+    const std::uint32_t L = (inst >> 20) & 1;
+    const std::uint32_t rn = (inst >> 16) & 0xF;
+    const std::uint32_t rd = (inst >> 12) & 0xF;
+
+    std::uint32_t offset;
+    if ((inst >> 25) & 1) {
+        // Scaled-register offset (same shift forms as a data-processing
+        // immediate shift, but no carry-out is needed for an address).
+        const std::uint32_t rm = in.reg[inst & 0xF];
+        const std::uint32_t shtype = (inst >> 5) & 0x3;
+        const std::uint32_t shamt = (inst >> 7) & 0x1F;
+        switch (shtype) {
+        case 0: offset = shamt ? (rm << shamt) : rm; break;                                   // LSL (#0 = Rm)
+        case 1: offset = shamt ? (rm >> shamt) : 0; break;                                     // LSR (#0 = #32 -> 0)
+        case 2: offset = shamt ? (std::uint32_t)((std::int32_t)rm >> shamt)
+                               : ((rm & N_BIT) ? 0xFFFFFFFF : 0); break;                       // ASR (#0 = #32)
+        default: offset = shamt ? ((rm >> shamt) | (rm << (32 - shamt)))
+                                : (((in.cpsr & C_BIT) ? N_BIT : 0) | (rm >> 1)); break;        // ROR / RRX
+        }
+    } else {
+        offset = inst & 0xFFF;
+    }
+
+    const std::uint32_t base = in.reg[rn];
+    const std::uint32_t off_applied = U ? (base + offset) : (base - offset);
+    const std::uint32_t addr = P ? off_applied : base;
+
+    if (L) {
+        std::uint32_t val;
+        if (B) {
+            val = mem[addr];
+        } else {
+            std::memcpy(&val, mem + addr, 4);
+        }
+        out.reg[rd] = val;
+    } else {
+        if (B) {
+            mem[addr] = static_cast<std::uint8_t>(in.reg[rd]);
+        } else {
+            std::uint32_t v = in.reg[rd];
+            std::memcpy(mem + addr, &v, 4);
+        }
+    }
+
+    if (!P) {
+        out.reg[rn] = off_applied; // post-indexed always writes back
+    } else if (W) {
+        out.reg[rn] = off_applied; // pre-indexed with W
+    }
+
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// Block transfer (LDM/STM) -- the heaviest user of the inline memory accessors
+// ---------------------------------------------------------------------------
+// Generate an LDM/STM whose base points into the data window; the register list
+// is a non-empty subset of r0..r14 excluding the base (so writeback / base-in-
+// list edge cases don't apply) and excluding PC (no branch). S (PSR/user-bank)
+// is always 0.
+std::uint32_t gen_ldm_stm(rng &r, cpu_state &init) {
+    const std::uint32_t cond = (r.range(4) == 0) ? r.range(14) : 0xE;
+    const std::uint32_t P = r.flip() ? 1 : 0;
+    const std::uint32_t U = r.flip() ? 1 : 0;
+    const std::uint32_t W = r.flip() ? 1 : 0;
+    const std::uint32_t L = r.flip() ? 1 : 0;
+    const std::uint32_t rn = r.range(15); // base, 0..14
+
+    std::uint32_t list = 0;
+    while (list == 0) {
+        list = (r.u32() & 0x7FFF) & ~(1u << rn); // bits 0..14, exclude base
+    }
+
+    // A 15-register transfer spans at most 60 bytes, so parking the base in the
+    // middle of a page means every run stays inside it and the cursor's
+    // page-crossing branch is never taken. Half the cases put the base within
+    // +/-64 bytes of the boundary instead, which makes the run straddle it.
+    if (r.flip()) {
+        init.reg[rn] = LS_PAGE_EDGE + (static_cast<std::uint32_t>(r.range(33)) - 16) * 4;
+    } else {
+        init.reg[rn] = LS_DATA_BASE;
+    }
+    return (cond << 28) | (0x4u << 25) | (P << 24) | (U << 23) | (0u << 22) | (W << 21) | (L << 20) | (rn << 16) | list;
+}
+
+cpu_state golden_ldm_stm(std::uint32_t inst, const cpu_state &in, std::uint8_t *mem) {
+    cpu_state out = in;
+    out.reg[15] = in.reg[15] + 4;
+
+    const std::uint32_t cond = inst >> 28;
+    if (!cond_passed(cond, in.cpsr)) {
+        return out;
+    }
+
+    const std::uint32_t P = (inst >> 24) & 1;
+    const std::uint32_t U = (inst >> 23) & 1;
+    const std::uint32_t W = (inst >> 21) & 1;
+    const std::uint32_t L = (inst >> 20) & 1;
+    const std::uint32_t rn = (inst >> 16) & 0xF;
+    const std::uint32_t list = inst & 0x7FFF; // bits 0..14 (PC excluded by gen)
+    const std::uint32_t n = static_cast<std::uint32_t>(std::popcount(list));
+    const std::uint32_t base = in.reg[rn];
+
+    // Lowest-numbered register always goes to the lowest address.
+    std::uint32_t addr = U ? (P ? base + 4 : base) : (P ? base - 4 * n : base - 4 * (n - 1));
+
+    for (std::uint32_t i = 0; i < 15; i++) {
+        if (!(list & (1u << i))) {
+            continue;
+        }
+        if (L) {
+            std::uint32_t v;
+            std::memcpy(&v, mem + addr, 4);
+            out.reg[i] = v;
+        } else {
+            std::uint32_t v = in.reg[i];
+            std::memcpy(mem + addr, &v, 4);
+        }
+        addr += 4;
+    }
+
+    if (W) {
+        out.reg[rn] = U ? base + 4 * n : base - 4 * n;
+    }
+
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// Halfword / signed transfers (LDRH/STRH/LDRSB/LDRSH, immediate offset)
+// ---------------------------------------------------------------------------
+std::uint32_t gen_halfword(rng &r, cpu_state &init) {
+    const std::uint32_t cond = (r.range(4) == 0) ? r.range(14) : 0xE;
+    const std::uint32_t P = r.flip() ? 1 : 0;
+    const std::uint32_t U = r.flip() ? 1 : 0;
+    const std::uint32_t W = (P == 1) ? (r.flip() ? 1 : 0) : 0;
+
+    std::uint32_t L, S, H;
+    switch (r.range(4)) {
+    case 0: L = 1; S = 0; H = 1; break; // LDRH
+    case 1: L = 0; S = 0; H = 1; break; // STRH
+    case 2: L = 1; S = 1; H = 1; break; // LDRSH
+    default: L = 1; S = 1; H = 0; break; // LDRSB (byte)
+    }
+
+    const std::uint32_t rn = r.range(15);
+    std::uint32_t rd = r.range(15);
+    while (rd == rn) {
+        rd = r.range(15);
+    }
+
+    std::uint32_t offset = r.range(0x40);
+    if (H == 1) {
+        offset &= ~1u; // halfword aligned
+    }
+    init.reg[rn] = LS_DATA_BASE;
+
+    const std::uint32_t immH = (offset >> 4) & 0xF;
+    const std::uint32_t immL = offset & 0xF;
+    return (cond << 28) | (0u << 25) | (P << 24) | (U << 23) | (1u << 22) | (W << 21) | (L << 20) | (rn << 16) | (rd << 12) | (immH << 8) | (1u << 7) | (S << 6) | (H << 5) | (1u << 4) | immL;
+}
+
+cpu_state golden_halfword(std::uint32_t inst, const cpu_state &in, std::uint8_t *mem) {
+    cpu_state out = in;
+    out.reg[15] = in.reg[15] + 4;
+
+    const std::uint32_t cond = inst >> 28;
+    if (!cond_passed(cond, in.cpsr)) {
+        return out;
+    }
+
+    const std::uint32_t P = (inst >> 24) & 1;
+    const std::uint32_t U = (inst >> 23) & 1;
+    const std::uint32_t W = (inst >> 21) & 1;
+    const std::uint32_t L = (inst >> 20) & 1;
+    const std::uint32_t S = (inst >> 6) & 1;
+    const std::uint32_t H = (inst >> 5) & 1;
+    const std::uint32_t rn = (inst >> 16) & 0xF;
+    const std::uint32_t rd = (inst >> 12) & 0xF;
+    const std::uint32_t offset = (((inst >> 8) & 0xF) << 4) | (inst & 0xF);
+
+    const std::uint32_t base = in.reg[rn];
+    const std::uint32_t off_applied = U ? (base + offset) : (base - offset);
+    const std::uint32_t addr = P ? off_applied : base;
+
+    if (L) {
+        if (!H) { // LDRSB
+            out.reg[rd] = static_cast<std::uint32_t>(static_cast<std::int32_t>(static_cast<std::int8_t>(mem[addr])));
+        } else if (S) { // LDRSH
+            std::uint16_t h;
+            std::memcpy(&h, mem + addr, 2);
+            out.reg[rd] = static_cast<std::uint32_t>(static_cast<std::int32_t>(static_cast<std::int16_t>(h)));
+        } else { // LDRH
+            std::uint16_t h;
+            std::memcpy(&h, mem + addr, 2);
+            out.reg[rd] = h;
+        }
+    } else { // STRH
+        std::uint16_t h = static_cast<std::uint16_t>(in.reg[rd]);
+        std::memcpy(mem + addr, &h, 2);
+    }
+
+    if (!P) {
+        out.reg[rn] = off_applied;
+    } else if (W) {
+        out.reg[rn] = off_applied;
+    }
+
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// Reporting
+// ---------------------------------------------------------------------------
+void dump_state(const char *tag, const cpu_state &s) {
+    std::printf("  %s:", tag);
+    for (int i = 0; i < 16; i++) {
+        std::printf(" r%d=%08X", i, s.reg[i]);
+    }
+    std::printf(" cpsr=%08X\n", s.cpsr);
+}
+
+bool report_mismatch(const char *what, std::uint32_t inst, std::uint32_t seed,
+    const cpu_state &expect, const cpu_state &got) {
+    std::printf("[DIVERGENCE] %s  inst=%08X seed=%u\n", what, inst, seed);
+    dump_state("expect", expect);
+    dump_state("got   ", got);
+    return false;
+}
+
+
+void push32(std::vector<std::uint8_t> &v, std::uint32_t w) {
+    v.push_back(static_cast<std::uint8_t>(w));
+    v.push_back(static_cast<std::uint8_t>(w >> 8));
+    v.push_back(static_cast<std::uint8_t>(w >> 16));
+    v.push_back(static_cast<std::uint8_t>(w >> 24));
+}
+
+void push16(std::vector<std::uint8_t> &v, std::uint16_t w) {
+    v.push_back(static_cast<std::uint8_t>(w));
+    v.push_back(static_cast<std::uint8_t>(w >> 8));
+}
+
+// ---------------------------------------------------------------------------
+// Program-level differential: dyncom vs dynarmic
+// ---------------------------------------------------------------------------
+// The golden-model phase above executes ONE instruction per case, which cannot
+// reach anything that only exists at block-translation time -- the block cache,
+// its direct-mapped L1, the ASID tag, or the loop accelerator. This phase runs
+// whole programs and uses dynarmic as an independent oracle instead.
+//
+// Protocol notes (established by measurement, see the spike commit):
+//  * dynarmic checks its tick budget at block granularity, so run(n) executes
+//    at least a whole block. Programs therefore end in a `b .` self-branch and
+//    get a budget larger than they need; both backends end up spinning on the
+//    same PC with identical state.
+//  * The backends disagree on whether the Thumb bit is folded into r15 while
+//    agreeing on CPSR bit 5. Bit 0 is never part of a Thumb address, so it is
+//    normalised away.
+//  * FPSCR is compared with IXC masked out: the VFP host fast path documents
+//    that it does not raise the inexact flag.
+//  * dynarmic hands some instructions to its own embedded dyncom. Such a case
+//    would be dyncom-vs-dyncom, so the fallback counter must read zero.
+
+constexpr std::uint32_t ARENA_MEM_SIZE = 0x40000; // 256 KB
+constexpr std::uint32_t PROG_DATA_LO = 0x8000;    // two pages of data
+constexpr std::uint32_t PROG_DATA_HI = 0xA000;
+constexpr std::uint32_t PROG_DATA_PTR = 0x9000;   // pointer regs start on the page edge
+constexpr std::uint32_t PROG_CODE_LO = 0x10000;
+// Entry blocks are indexed by `pc & 2047` (block_l1_index with asid 0), so a
+// 2048-byte stride makes every arena program collide in the same L1 slot.
+constexpr std::uint32_t PROG_CODE_STRIDE = 2048;
+
+struct backend_env {
+    std::vector<std::uint8_t> mem;
+    std::unique_ptr<exclusive_monitor> monitor;
+    std::unique_ptr<core> cpu;
+    const char *name;
+    std::uint64_t exceptions = 0;
+    exception_type last_exception = exception_type_unk;
+    std::uint32_t last_exception_pc = 0;
+
+    backend_env()
+        : mem(ARENA_MEM_SIZE, 0) {
+    }
+};
+
+void wire_backend(backend_env &e) {
+    std::uint8_t *base = e.mem.data();
+    core *cp = e.cpu.get();
+
+    auto seed_tlb = [cp, base](std::uint32_t addr) {
+        const std::uint32_t page = addr & ~PAGE_MASK;
+        cp->set_tlb_page(page, base + page, prot_read_write_exec);
+    };
+
+    cp->read_code = [base, seed_tlb](const address a, std::uint32_t *r) -> bool {
+        if (a + 4 > ARENA_MEM_SIZE) return false;
+        std::memcpy(r, base + a, 4);
+        seed_tlb(a);
+        return true;
+    };
+    cp->read_8bit = [base, seed_tlb](const address a, std::uint8_t *r) -> bool {
+        if (a >= ARENA_MEM_SIZE) return false;
+        *r = base[a]; seed_tlb(a); return true;
+    };
+    cp->read_16bit = [base, seed_tlb](const address a, std::uint16_t *r) -> bool {
+        if (a + 2 > ARENA_MEM_SIZE) return false;
+        std::memcpy(r, base + a, 2); seed_tlb(a); return true;
+    };
+    cp->read_32bit = [base, seed_tlb](const address a, std::uint32_t *r) -> bool {
+        if (a + 4 > ARENA_MEM_SIZE) return false;
+        std::memcpy(r, base + a, 4); seed_tlb(a); return true;
+    };
+    cp->read_64bit = [base, seed_tlb](const address a, std::uint64_t *r) -> bool {
+        if (a + 8 > ARENA_MEM_SIZE) return false;
+        std::memcpy(r, base + a, 8); seed_tlb(a); return true;
+    };
+    cp->write_8bit = [base, seed_tlb](const address a, std::uint8_t *v) -> bool {
+        if (a >= ARENA_MEM_SIZE) return false;
+        base[a] = *v; seed_tlb(a); return true;
+    };
+    cp->write_16bit = [base, seed_tlb](const address a, std::uint16_t *v) -> bool {
+        if (a + 2 > ARENA_MEM_SIZE) return false;
+        std::memcpy(base + a, v, 2); seed_tlb(a); return true;
+    };
+    cp->write_32bit = [base, seed_tlb](const address a, std::uint32_t *v) -> bool {
+        if (a + 4 > ARENA_MEM_SIZE) return false;
+        std::memcpy(base + a, v, 4); seed_tlb(a); return true;
+    };
+    cp->write_64bit = [base, seed_tlb](const address a, std::uint64_t *v) -> bool {
+        if (a + 8 > ARENA_MEM_SIZE) return false;
+        std::memcpy(base + a, v, 8); seed_tlb(a); return true;
+    };
+
+    backend_env *ep = &e;
+    cp->exception_handler = [ep](exception_type t, const std::uint32_t pc) -> bool {
+        ep->exceptions++;
+        ep->last_exception = t;
+        ep->last_exception_pc = pc;
+        return false;
+    };
+    cp->system_call_handler = [](const std::uint32_t) {};
+}
+
+std::unique_ptr<backend_env> make_dyncom_env() {
+    auto e = std::make_unique<backend_env>();
+    e->name = "dyncom";
+    e->monitor = std::make_unique<r12l1::exclusive_monitor>(1);
+    e->cpu = std::make_unique<dyncom_core>(e->monitor.get(), PAGE_BITS);
+    wire_backend(*e);
+    return e;
+}
+
+std::unique_ptr<backend_env> make_dynarmic_env() {
+    auto e = std::make_unique<backend_env>();
+    e->name = "dynarmic";
+    // dynarmic_core reinterpret_casts the monitor to its own type, so the two
+    // backends cannot share one.
+    e->monitor = std::make_unique<dynarmic_exclusive_monitor>(1);
+    e->cpu = std::make_unique<dynarmic_core>(e->monitor.get());
+    wire_backend(*e);
+    return e;
+}
+
+// A generated test program: an image, where it lives, how it starts.
+struct program {
+    std::vector<std::uint8_t> code;
+    std::uint32_t addr = PROG_CODE_LO;
+    bool thumb = false;
+    std::uint32_t init[16] = {};
+    std::uint32_t vfp_init[32] = {};
+    std::uint32_t budget = 4096;
+    const char *kind = "arm";
+};
+
+struct full_state {
+    std::uint32_t reg[16];
+    std::uint32_t cpsr;
+    std::uint32_t vfp[32];
+    std::uint32_t fpscr;
+};
+
+// IXC (bit 4) is excluded: the VFP host fast path documents that it does not
+// raise the inexact cumulative flag.
+constexpr std::uint32_t FPSCR_COMPARE_MASK = ~0x10u;
+
+full_state capture(core &c) {
+    full_state s{};
+    for (int i = 0; i < 16; i++) s.reg[i] = c.get_reg(i);
+    s.cpsr = c.get_cpsr();
+    if (s.cpsr & 0x20) s.reg[15] &= ~1u;
+    for (int i = 0; i < 32; i++) s.vfp[i] = c.get_vfp(i);
+    s.fpscr = c.get_fpscr() & FPSCR_COMPARE_MASK;
+    return s;
+}
+
+void seed_data_window(std::vector<std::uint8_t> &mem, std::uint32_t seed) {
+    rng r(seed);
+    for (std::uint32_t a = PROG_DATA_LO; a < PROG_DATA_HI; a += 4) {
+        const std::uint32_t w = r.u32();
+        std::memcpy(mem.data() + a, &w, 4);
+    }
+}
+
+// Install a program image without touching the translation caches. `warm`
+// keeps whatever the backend has cached, which is what makes block-cache and
+// L1 behaviour observable at all.
+void install(backend_env &e, const program &p) {
+    std::memcpy(e.mem.data() + p.addr, p.code.data(), p.code.size());
+}
+
+full_state execute(backend_env &e, const program &p) {
+    for (int i = 0; i < 15; i++) e.cpu->set_reg(i, p.init[i]);
+    for (int i = 0; i < 32; i++) e.cpu->set_vfp(i, p.vfp_init[i]);
+    e.cpu->set_fpscr(0);
+    e.cpu->set_cpsr(p.thumb ? (0x10u | 0x20u) : 0x10u);
+    e.cpu->set_pc(p.addr | (p.thumb ? 1u : 0u));
+    e.cpu->run(p.budget);
+    return capture(*e.cpu);
+}
+
+bool states_equal(const full_state &a, const full_state &b) {
+    if (std::memcmp(a.reg, b.reg, sizeof(a.reg)) != 0) return false;
+    if (a.cpsr != b.cpsr) return false;
+    if (std::memcmp(a.vfp, b.vfp, sizeof(a.vfp)) != 0) return false;
+    return a.fpscr == b.fpscr;
+}
+
+void dump_full(const char *tag, const full_state &s) {
+    std::printf("  %-9s cpsr=%08X fpscr=%08X\n", tag, s.cpsr, s.fpscr);
+    std::printf("           ");
+    for (int i = 0; i < 16; i++) std::printf(" r%d=%08X", i, s.reg[i]);
+    std::printf("\n");
+}
+
+// Re-run growing prefixes of a diverging program to find the first instruction
+// whose result differs. Without this, a divergence is a wall of registers and a
+// program the reader has to disassemble by hand.
+void reduce_divergence(backend_env &dc, backend_env &da, const program &p, std::uint32_t seed) {
+    const std::uint32_t step = p.thumb ? 2u : 4u;
+    const std::uint32_t body = static_cast<std::uint32_t>(p.code.size()) - step;
+
+    for (std::uint32_t n = step; n <= body; n += step) {
+        program q = p;
+        q.code.assign(p.code.begin(), p.code.begin() + n);
+        if (p.thumb) push16(q.code, 0xE7FEu);
+        else push32(q.code, 0xEAFFFFFEu);
+        q.budget = n + 64;
+
+        seed_data_window(dc.mem, seed);
+        seed_data_window(da.mem, seed);
+        install(dc, q);
+        install(da, q);
+        dc.cpu->clear_instruction_cache();
+        da.cpu->clear_instruction_cache();
+        dc.cpu->imb_range(q.addr, q.code.size());
+        da.cpu->imb_range(q.addr, q.code.size());
+
+        const full_state sd = execute(dc, q);
+        const full_state sa = execute(da, q);
+        const bool mem_ok = std::memcmp(dc.mem.data() + PROG_DATA_LO,
+                                da.mem.data() + PROG_DATA_LO,
+                                PROG_DATA_HI - PROG_DATA_LO)
+            == 0;
+        if (!states_equal(sd, sa) || !mem_ok) {
+            std::uint32_t inst = 0;
+            std::memcpy(&inst, p.code.data() + (n - step), step);
+            std::printf("  first divergence at instruction %u: %0*X\n",
+                (n / step) - 1, static_cast<int>(step * 2), inst);
+            for (int i = 0; i < 16; i++) {
+                if (sd.reg[i] != sa.reg[i])
+                    std::printf("    r%-2d dyncom=%08X dynarmic=%08X\n", i, sd.reg[i], sa.reg[i]);
+            }
+            if (sd.cpsr != sa.cpsr)
+                std::printf("    cpsr dyncom=%08X dynarmic=%08X\n", sd.cpsr, sa.cpsr);
+            for (int i = 0; i < 32; i++) {
+                if (sd.vfp[i] != sa.vfp[i])
+                    std::printf("    s%-2d dyncom=%08X dynarmic=%08X\n", i, sd.vfp[i], sa.vfp[i]);
+            }
+            if (sd.fpscr != sa.fpscr)
+                std::printf("    fpscr dyncom=%08X dynarmic=%08X\n", sd.fpscr, sa.fpscr);
+            if (!mem_ok) std::printf("    (memory differs)\n");
+            return;
+        }
+    }
+    std::printf("  no single-instruction prefix reproduces it: the divergence needs "
+                "the warm translation cache\n");
+}
+
+bool report_program_divergence(const char *suite, const program &p, std::uint32_t seed,
+    const full_state &dc, const full_state &da,
+    const std::vector<std::uint8_t> &mdc, const std::vector<std::uint8_t> &mda) {
+    std::printf("[DIVERGENCE] %s (%s) seed=%u addr=%08X %s\n", suite, p.kind, seed,
+        p.addr, p.thumb ? "thumb" : "arm");
+    dump_full("dyncom", dc);
+    dump_full("dynarmic", da);
+    for (std::uint32_t a = PROG_DATA_LO; a < PROG_DATA_HI; a += 4) {
+        std::uint32_t x, y;
+        std::memcpy(&x, mdc.data() + a, 4);
+        std::memcpy(&y, mda.data() + a, 4);
+        if (x != y) {
+            std::printf("  mem[%08X] dyncom=%08X dynarmic=%08X\n", a, x, y);
+            break;
+        }
+    }
+    std::printf("  code:");
+    for (std::size_t i = 0; i < p.code.size(); i += (p.thumb ? 2 : 4)) {
+        std::uint32_t w = 0;
+        std::memcpy(&w, p.code.data() + i, p.thumb ? 2 : 4);
+        std::printf(p.thumb ? " %04X" : " %08X", w);
+    }
+    std::printf("\n");
+    return false;
+}
+
+// ---------------------------------------------------------------------------
+// Program generators
+// ---------------------------------------------------------------------------
+// Only well-defined encodings are emitted. dyncom and dynarmic are both free to
+// do whatever they like with UNPREDICTABLE forms, so generating them would
+// produce divergences that mean nothing. The register assignment below is what
+// keeps every generated access inside the mapped data window without having to
+// simulate the program first.
+
+// ARM: r9/r10 hold data pointers, r7 holds a small scaled-index value; none of
+// the three is ever a destination, so the pointers stay in the window even with
+// base write-back (bounded to +/-32 per access, well under the window margin).
+constexpr int A_PTR1 = 9;
+constexpr int A_PTR2 = 10;
+constexpr int A_OFF = 7;
+constexpr std::uint32_t A_WRITABLE[] = { 0, 1, 2, 3, 4, 5, 6, 8, 11, 12, 13, 14 };
+constexpr std::uint32_t A_WRITABLE_N = sizeof(A_WRITABLE) / sizeof(A_WRITABLE[0]);
+
+std::uint32_t a_wreg(rng &r) { return A_WRITABLE[r.range(A_WRITABLE_N)]; }
+std::uint32_t a_anyreg(rng &r) {
+    const std::uint32_t pick = r.range(A_WRITABLE_N + 3);
+    if (pick < A_WRITABLE_N) return A_WRITABLE[pick];
+    return (pick == A_WRITABLE_N) ? A_PTR1 : ((pick == A_WRITABLE_N + 1) ? A_PTR2 : A_OFF);
+}
+std::uint32_t a_cond(rng &r) { return (r.range(4) == 0) ? r.range(14) : 0xEu; }
+
+std::uint32_t gen_arm_data_processing(rng &r) {
+    std::uint32_t opcode = r.range(16);
+    std::uint32_t s = r.flip() ? 1u : 0u;
+    if (opcode >= 8 && opcode <= 11) s = 1; // TST/TEQ/CMP/CMN always set flags
+    const std::uint32_t rd = (opcode >= 8 && opcode <= 11) ? 0u : a_wreg(r);
+    // MOV and MVN ignore Rn and require the field to be zero; TST/TEQ/CMP/CMN
+    // likewise require Rd to be zero (handled above). A non-zero SBZ field is
+    // UNPREDICTABLE, and the backends legitimately differ there -- dynarmic
+    // rejects it as undefined while dyncom executes it.
+    const bool rn_sbz = (opcode == 13) || (opcode == 15);
+    const std::uint32_t rn = rn_sbz ? 0u : a_anyreg(r);
+
+    std::uint32_t i_bit = 0, operand2 = 0;
+    switch (r.range(3)) {
+    case 0: // #imm rotated
+        i_bit = 1;
+        operand2 = (r.range(16) << 8) | r.range(256);
+        break;
+    case 1: // Rm shifted by an immediate
+        operand2 = (r.range(32) << 7) | (r.range(4) << 5) | a_anyreg(r);
+        break;
+    default: // Rm shifted by Rs
+        operand2 = (a_anyreg(r) << 8) | (r.range(4) << 5) | (1u << 4) | a_anyreg(r);
+        break;
+    }
+    return (a_cond(r) << 28) | (i_bit << 25) | (opcode << 21) | (s << 20) | (rn << 16)
+        | (rd << 12) | operand2;
+}
+
+std::uint32_t gen_arm_multiply(rng &r) {
+    const std::uint32_t rd = a_wreg(r);
+    std::uint32_t rm = a_anyreg(r);
+    if (rm == rd) rm = (rd == A_PTR1) ? A_PTR2 : A_PTR1; // Rd == Rm is UNPREDICTABLE
+    const std::uint32_t rs = a_anyreg(r);
+    const std::uint32_t s = r.flip() ? 1u : 0u;
+    if (r.flip()) { // MLA
+        const std::uint32_t rn = a_anyreg(r);
+        return (a_cond(r) << 28) | (1u << 21) | (s << 20) | (rd << 16) | (rn << 12)
+            | (rs << 8) | (9u << 4) | rm;
+    }
+    return (a_cond(r) << 28) | (s << 20) | (rd << 16) | (rs << 8) | (9u << 4) | rm;
+}
+
+std::uint32_t gen_arm_single_transfer(rng &r) {
+    const std::uint32_t p = r.flip() ? 1u : 0u;
+    const std::uint32_t u = r.flip() ? 1u : 0u;
+    const std::uint32_t b = r.flip() ? 1u : 0u;
+    const std::uint32_t l = r.flip() ? 1u : 0u;
+    // P == 0 already writes back; W == 1 there would mean the unprivileged
+    // LDRT/STRT forms, which is a different instruction.
+    const std::uint32_t w = p ? (r.flip() ? 1u : 0u) : 0u;
+    const std::uint32_t rn = r.flip() ? A_PTR1 : A_PTR2;
+    const std::uint32_t rt = a_wreg(r);
+
+    std::uint32_t i_bit = 0, offset = 0;
+    if (r.flip()) {
+        // Immediate: the magnitude is small enough that write-back cannot walk
+        // the pointer out of the window. Any form that writes the base back
+        // keeps the offset word-aligned, otherwise a later word access would
+        // become unaligned -- where the backends legally differ (rotate the
+        // loaded word vs perform a true unaligned access).
+        const bool writes_base = (w != 0) || (p == 0);
+        offset = (b && !writes_base) ? r.range(33) : (r.range(9) * 4);
+    } else {
+        // Scaled register: the index register holds a small value.
+        i_bit = 1;
+        offset = (r.range(3) << 7) | (0u << 5) | A_OFF; // LSL #0..2
+    }
+    return (a_cond(r) << 28) | (1u << 26) | (i_bit << 25) | (p << 24) | (u << 23)
+        | (b << 22) | (w << 21) | (l << 20) | (rn << 16) | (rt << 12) | offset;
+}
+
+std::uint32_t gen_arm_halfword(rng &r) {
+    const std::uint32_t p = r.flip() ? 1u : 0u;
+    const std::uint32_t u = r.flip() ? 1u : 0u;
+    const std::uint32_t w = p ? (r.flip() ? 1u : 0u) : 0u;
+    const std::uint32_t rn = r.flip() ? A_PTR1 : A_PTR2;
+    const std::uint32_t rt = a_wreg(r);
+
+    std::uint32_t l, sbit, h;
+    if (r.flip()) { // STRH
+        l = 0; sbit = 0; h = 1;
+    } else {
+        l = 1;
+        switch (r.range(3)) {
+        case 0: sbit = 0; h = 1; break;  // LDRH
+        case 1: sbit = 1; h = 0; break;  // LDRSB
+        default: sbit = 1; h = 1; break; // LDRSH
+        }
+    }
+
+    std::uint32_t i_bit, offset_field;
+    if (r.flip()) {
+        i_bit = 1;
+        const bool writes_base = (w != 0) || (p == 0);
+        const std::uint32_t off = writes_base ? (r.range(9) * 4) : (r.range(17) * 2);
+        offset_field = ((off & 0xF0u) << 4) | (off & 0x0Fu);
+    } else {
+        i_bit = 0;
+        offset_field = A_OFF;
+    }
+    return (a_cond(r) << 28) | (p << 24) | (u << 23) | (i_bit << 22) | (w << 21)
+        | (l << 20) | (rn << 16) | (rt << 12) | offset_field | (1u << 7)
+        | (sbit << 6) | (h << 5) | (1u << 4);
+}
+
+std::uint32_t gen_arm_block_transfer(rng &r, bool straddle_page) {
+    const std::uint32_t p = r.flip() ? 1u : 0u;
+    const std::uint32_t u = r.flip() ? 1u : 0u;
+    const std::uint32_t w = r.flip() ? 1u : 0u;
+    const std::uint32_t l = r.flip() ? 1u : 0u;
+    const std::uint32_t rn = straddle_page ? A_PTR1 : A_PTR2;
+
+    std::uint32_t list = 0;
+    while (list == 0) {
+        for (std::uint32_t i = 0; i < A_WRITABLE_N; i++) {
+            if (r.flip()) list |= 1u << A_WRITABLE[i];
+        }
+    }
+    return (a_cond(r) << 28) | (4u << 25) | (p << 24) | (u << 23) | (w << 21)
+        | (l << 20) | (rn << 16) | list;
+}
+
+// Thumb: r5 is the data pointer and r6 a small index; neither is ever written,
+// and the low-register forms have no write-back, so no drift is possible.
+constexpr int T_PTR = 5;
+constexpr int T_OFF = 6;
+constexpr std::uint32_t T_WRITABLE[] = { 0, 1, 2, 3, 4, 7 };
+constexpr std::uint32_t T_WRITABLE_N = sizeof(T_WRITABLE) / sizeof(T_WRITABLE[0]);
+
+std::uint32_t t_wreg(rng &r) { return T_WRITABLE[r.range(T_WRITABLE_N)]; }
+std::uint32_t t_anyreg(rng &r) {
+    const std::uint32_t pick = r.range(T_WRITABLE_N + 2);
+    if (pick < T_WRITABLE_N) return T_WRITABLE[pick];
+    return (pick == T_WRITABLE_N) ? T_PTR : T_OFF;
+}
+
+std::uint16_t gen_thumb_inst(rng &r) {
+    switch (r.range(8)) {
+    case 0: { // LSL/LSR/ASR by immediate
+        const std::uint32_t op = r.range(3);
+        return static_cast<std::uint16_t>((op << 11) | (r.range(32) << 6)
+            | (t_anyreg(r) << 3) | t_wreg(r));
+    }
+    case 1: { // ADD/SUB register or 3-bit immediate
+        const std::uint32_t i_bit = r.flip() ? 1u : 0u;
+        const std::uint32_t op = r.flip() ? 1u : 0u;
+        const std::uint32_t rn = i_bit ? r.range(8) : t_anyreg(r);
+        return static_cast<std::uint16_t>(0x1800u | (i_bit << 10) | (op << 9)
+            | (rn << 6) | (t_anyreg(r) << 3) | t_wreg(r));
+    }
+    case 2: { // MOV/CMP/ADD/SUB 8-bit immediate
+        const std::uint32_t op = r.range(4);
+        const std::uint32_t rd = (op == 1) ? t_anyreg(r) : t_wreg(r); // CMP writes nothing
+        return static_cast<std::uint16_t>(0x2000u | (op << 11) | (rd << 8) | r.range(256));
+    }
+    case 3: { // ALU operations
+        const std::uint32_t op = r.range(16);
+        const std::uint32_t rd = (op == 8 || op == 10 || op == 11) // TST/CMP/CMN
+            ? t_anyreg(r) : t_wreg(r);
+        return static_cast<std::uint16_t>(0x4000u | (op << 6) | (t_anyreg(r) << 3) | rd);
+    }
+    case 4: { // High-register ADD/CMP/MOV; never touches SP or PC
+        const std::uint32_t op = r.range(3);
+        const std::uint32_t rd = 8 + r.range(5);  // r8..r12
+        const std::uint32_t rm = t_anyreg(r);
+        return static_cast<std::uint16_t>(0x4400u | (op << 8) | (1u << 7)
+            | (rm << 3) | (rd & 7));
+    }
+    case 5: { // Register-offset load/store
+        const std::uint32_t op = r.range(8);
+        return static_cast<std::uint16_t>(0x5000u | (op << 9) | (T_OFF << 6)
+            | (T_PTR << 3) | t_wreg(r));
+    }
+    case 6: { // Word / byte immediate-offset load/store
+        const std::uint32_t b = r.flip() ? 1u : 0u;
+        const std::uint32_t l = r.flip() ? 1u : 0u;
+        const std::uint32_t off = b ? r.range(32) : r.range(24);
+        return static_cast<std::uint16_t>(0x6000u | (b << 12) | (l << 11)
+            | (off << 6) | (T_PTR << 3) | t_wreg(r));
+    }
+    default: { // Halfword immediate-offset load/store
+        const std::uint32_t l = r.flip() ? 1u : 0u;
+        return static_cast<std::uint16_t>(0x8000u | (l << 11) | (r.range(24) << 6)
+            | (T_PTR << 3) | t_wreg(r));
+    }
+    }
+}
+
+void set_common_init(program &p, rng &r) {
+    for (int i = 0; i < 15; i++) p.init[i] = r.u32();
+    if (p.thumb) {
+        p.init[T_PTR] = PROG_DATA_PTR;
+        p.init[T_OFF] = r.range(16) * 4;
+    } else {
+        p.init[A_PTR1] = PROG_DATA_PTR;
+        p.init[A_PTR2] = PROG_DATA_PTR + 0x400;
+        p.init[A_OFF] = r.range(16) * 4;
+    }
+}
+
+program gen_arm_program(rng &r, std::uint32_t addr, std::uint32_t length) {
+    program p;
+    p.addr = addr;
+    p.thumb = false;
+    p.kind = "arm-mixed";
+    set_common_init(p, r);
+
+    // Triage aid: restrict generation to one instruction class so a divergence
+    // can be attributed without hand-decoding a whole program.
+    static const char *only = std::getenv("EKA2L1_DIFFTEST_ARM_ONLY");
+
+    for (std::uint32_t i = 0; i < length; i++) {
+        std::uint32_t inst;
+        if (only) {
+            if (std::strcmp(only, "dp") == 0) inst = gen_arm_data_processing(r);
+            else if (std::strcmp(only, "ls") == 0) inst = gen_arm_single_transfer(r);
+            else if (std::strcmp(only, "hw") == 0) inst = gen_arm_halfword(r);
+            else if (std::strcmp(only, "blk") == 0) inst = gen_arm_block_transfer(r, r.flip());
+            else inst = gen_arm_multiply(r);
+            push32(p.code, inst);
+            continue;
+        }
+        switch (r.range(10)) {
+        case 0: case 1: case 2: case 3:
+            inst = gen_arm_data_processing(r);
+            break;
+        case 4: case 5:
+            inst = gen_arm_single_transfer(r);
+            break;
+        case 6:
+            inst = gen_arm_halfword(r);
+            break;
+        case 7: case 8:
+            // Half of the block transfers use the pointer sitting on the page
+            // edge, so the LDM/STM page cursor has to re-resolve mid-run.
+            inst = gen_arm_block_transfer(r, r.flip());
+            break;
+        default:
+            inst = gen_arm_multiply(r);
+            break;
+        }
+        push32(p.code, inst);
+    }
+    push32(p.code, 0xEAFFFFFEu); // b .
+    p.budget = length * 4 + 64;
+    return p;
+}
+
+program gen_thumb_program(rng &r, std::uint32_t addr, std::uint32_t length) {
+    program p;
+    p.addr = addr;
+    p.thumb = true;
+    p.kind = "thumb-mixed";
+    set_common_init(p, r);
+
+    for (std::uint32_t i = 0; i < length; i++) {
+        push16(p.code, gen_thumb_inst(r));
+    }
+    push16(p.code, 0xE7FEu); // b .
+    p.budget = length * 4 + 64;
+    return p;
+}
+
+// ---------------------------------------------------------------------------
+// Differential suites
+// ---------------------------------------------------------------------------
+
+struct coverage {
+    std::uint64_t programs = 0;
+    std::uint64_t fallback_insts = 0;
+    std::uint64_t accel_attaches = 0;
+    std::uint64_t accel_bulk_iterations = 0;
+};
+
+// Run one program on both backends and compare everything guest-visible.
+// `reset_caches` is what separates a cold case from an arena case: leaving the
+// caches warm is the only way block reuse, the L1 and the ASID tag can be
+// observed at all.
+bool run_pair(const char *suite, backend_env &dc, backend_env &da, const program &p,
+    std::uint32_t seed, bool reset_caches, coverage &cov) {
+    seed_data_window(dc.mem, seed);
+    seed_data_window(da.mem, seed);
+    install(dc, p);
+    install(da, p);
+
+    if (reset_caches) {
+        dc.cpu->clear_instruction_cache();
+        da.cpu->clear_instruction_cache();
+        dc.cpu->imb_range(p.addr, p.code.size());
+        da.cpu->imb_range(p.addr, p.code.size());
+    }
+
+    dynarmic_reset_interpreter_fallback_for_test();
+    dyncom_reset_loop_accel_counters_for_test();
+    dc.exceptions = 0;
+    da.exceptions = 0;
+
+    const full_state sd = execute(dc, p);
+    cov.accel_attaches += dyncom_loop_accel_attaches_for_test();
+    cov.accel_bulk_iterations += dyncom_loop_accel_bulk_iterations_for_test();
+
+    dynarmic_reset_interpreter_fallback_for_test();
+    const full_state sa = execute(da, p);
+    const std::uint64_t fallback = dynarmic_interpreter_fallback_for_test();
+    cov.fallback_insts += fallback;
+    cov.programs++;
+
+    if (dc.exceptions != 0 || da.exceptions != 0) {
+        // Programs are generated to be well-defined and fault-free. An exception
+        // means the generator emitted an encoding it should not have -- comparing
+        // the two backends past that point is meaningless, since they are free to
+        // handle UNDEFINED/UNPREDICTABLE forms differently.
+        std::printf("[HARNESS BUG] %s: guest exception (dyncom=%llu type=%d pc=%08X, "
+                    "dynarmic=%llu type=%d pc=%08X) addr=%08X seed=%u\n",
+            suite, static_cast<unsigned long long>(dc.exceptions),
+            static_cast<int>(dc.last_exception), dc.last_exception_pc,
+            static_cast<unsigned long long>(da.exceptions),
+            static_cast<int>(da.last_exception), da.last_exception_pc, p.addr, seed);
+        return false;
+    }
+
+    if (fallback != 0) {
+        // dynarmic executed part of this program with its own embedded dyncom,
+        // so agreement here would be dyncom-vs-dyncom. Report rather than pass.
+        std::printf("[HARNESS BUG] %s: dynarmic fell back to its interpreter for "
+                    "%llu instruction(s) at addr=%08X seed=%u -- the oracle is not "
+                    "independent for this case\n",
+            suite, static_cast<unsigned long long>(fallback), p.addr, seed);
+        return false;
+    }
+
+    const bool mem_ok = std::memcmp(dc.mem.data() + PROG_DATA_LO,
+                            da.mem.data() + PROG_DATA_LO, PROG_DATA_HI - PROG_DATA_LO)
+        == 0;
+    if (!states_equal(sd, sa) || !mem_ok) {
+        report_program_divergence(suite, p, seed, sd, sa, dc.mem, da.mem);
+        reduce_divergence(dc, da, p, seed);
+        return false;
+    }
+    return true;
+}
+
+// Cold cases: every program gets a flushed translation cache, so this isolates
+// instruction semantics -- the ALU, shifter, addressing modes, the inline
+// memory accessors, the LDM/STM cursor and the Thumb paths.
+std::uint32_t suite_cold(backend_env &dc, backend_env &da, std::uint32_t base_seed,
+    std::uint32_t count, coverage &cov) {
+    std::uint32_t failures = 0;
+    for (std::uint32_t i = 0; i < count && failures < 10; i++) {
+        const std::uint32_t seed = base_seed + i;
+        rng r(seed);
+        const bool thumb = r.flip();
+        const std::uint32_t len = 4 + r.range(20);
+        const program p = thumb ? gen_thumb_program(r, PROG_CODE_LO, len)
+                                : gen_arm_program(r, PROG_CODE_LO, len);
+        if (!run_pair("cold", dc, da, p, seed, true, cov)) failures++;
+    }
+    return failures;
+}
+
+// Arena: many programs resident at once, laid out so their entry blocks all
+// collide in the same direct-mapped L1 slot, executed in shuffled order with
+// the caches left warm. This is what makes a block-cache or L1 tagging bug
+// observable; a cold, single-address harness cannot see one.
+std::uint32_t suite_arena(backend_env &dc, backend_env &da, std::uint32_t base_seed,
+    std::uint32_t rounds, coverage &cov) {
+    constexpr std::uint32_t PROGRAMS = 24;
+    std::vector<program> progs;
+    progs.reserve(PROGRAMS);
+
+    for (std::uint32_t i = 0; i < PROGRAMS; i++) {
+        rng r(base_seed ^ (0x1000193u * (i + 1)));
+        const std::uint32_t addr = PROG_CODE_LO + i * PROG_CODE_STRIDE;
+        const bool thumb = (i & 1) != 0;
+        program p = thumb ? gen_thumb_program(r, addr, 6 + r.range(10))
+                          : gen_arm_program(r, addr, 6 + r.range(10));
+        p.kind = thumb ? "arena-thumb" : "arena-arm";
+        progs.push_back(std::move(p));
+    }
+
+    // Install everything and invalidate once; from here the caches stay warm.
+    for (const program &p : progs) {
+        install(dc, p);
+        install(da, p);
+    }
+    dc.cpu->clear_instruction_cache();
+    da.cpu->clear_instruction_cache();
+
+    std::uint32_t failures = 0;
+    for (std::uint32_t round = 0; round < rounds && failures < 10; round++) {
+        rng order(base_seed + 0x51ED2701u + round);
+        for (std::uint32_t n = 0; n < PROGRAMS; n++) {
+            const program &p = progs[order.range(PROGRAMS)];
+            if (!run_pair("arena", dc, da, p, base_seed + round, false, cov)) {
+                failures++;
+                break;
+            }
+        }
+    }
+    return failures;
+}
+
+// ASID: the same virtual address backed by different code in two address
+// spaces. dyncom is told about the switch through set_asid and must keep the
+// two translations apart without flushing; dynarmic has no ASID concept, so it
+// is flushed on every switch and is therefore the ground truth.
+std::uint32_t suite_asid(backend_env &dc, backend_env &da, std::uint32_t base_seed,
+    std::uint32_t rounds, coverage &cov) {
+    constexpr std::uint32_t VA = PROG_CODE_LO + 0x4000;
+
+    program space[2];
+    for (int i = 0; i < 2; i++) {
+        rng r(base_seed ^ (0xB5297A4Du * static_cast<std::uint32_t>(i + 1)));
+        space[i] = gen_arm_program(r, VA, 8 + r.range(8));
+        space[i].kind = (i == 0) ? "asid-space-0" : "asid-space-1";
+        // Both spaces start from the same registers so a divergence can only
+        // come from executing the wrong image.
+        rng shared(base_seed);
+        set_common_init(space[i], shared);
+    }
+
+    dc.cpu->clear_instruction_cache();
+    da.cpu->clear_instruction_cache();
+
+    std::uint32_t failures = 0;
+    for (std::uint32_t round = 0; round < rounds && failures < 10; round++) {
+        const int which = static_cast<int>(round & 1);
+        const std::uint32_t asid = 1u + static_cast<std::uint32_t>(which);
+
+        // Swap in this space's image WITHOUT invalidating dyncom's cache: a
+        // correctly ASID-tagged cache keeps one translation per space and must
+        // pick the right one. dynarmic is flushed so it always re-translates.
+        dc.cpu->set_asid(asid);
+        da.cpu->clear_instruction_cache();
+
+        if (!run_pair("asid", dc, da, space[which], base_seed + round, false, cov)) {
+            failures++;
+        }
+    }
+    dc.cpu->set_asid(0);
+    return failures;
+}
+
+// Loop accelerator: the canonical shapes its translation-time matcher accepts.
+// Run to completion so the bulk step actually executes, and assert afterwards
+// that it attached at all -- a matcher that silently stopped matching would
+// otherwise look like a clean pass.
+std::uint32_t suite_loops(backend_env &dc, backend_env &da, std::uint32_t base_seed,
+    std::uint32_t count, coverage &cov) {
+    std::uint32_t failures = 0;
+
+    for (std::uint32_t i = 0; i < count && failures < 10; i++) {
+        const std::uint32_t seed = base_seed + i;
+        rng r(seed);
+
+        program p;
+        p.addr = PROG_CODE_LO;
+        p.thumb = true;
+        set_common_init(p, r);
+
+        const std::uint32_t iterations = 3 + r.range(120);
+        p.init[1] = PROG_DATA_PTR - 0x800;             // source
+        p.init[2] = PROG_DATA_PTR - 0x800 + 0x800;     // destination
+        p.init[3] = iterations;
+        p.init[T_PTR] = PROG_DATA_PTR;
+        p.init[T_OFF] = 0;
+
+        const std::uint32_t shape = r.range(4);
+        switch (shape) {
+        case 0: // word copy
+            p.kind = "loop-word-copy";
+            push16(p.code, 0x6808); // ldr  r0, [r1]
+            push16(p.code, 0x6010); // str  r0, [r2]
+            push16(p.code, 0x3104); // adds r1, #4
+            push16(p.code, 0x3204); // adds r2, #4
+            break;
+        case 1: // halfword copy
+            p.kind = "loop-halfword-copy";
+            push16(p.code, 0x8808); // ldrh r0, [r1]
+            push16(p.code, 0x8010); // strh r0, [r2]
+            push16(p.code, 0x3102); // adds r1, #2
+            push16(p.code, 0x3202); // adds r2, #2
+            break;
+        case 2: // byte copy
+            p.kind = "loop-byte-copy";
+            push16(p.code, 0x7808); // ldrb r0, [r1]
+            push16(p.code, 0x7010); // strb r0, [r2]
+            push16(p.code, 0x3101); // adds r1, #1
+            push16(p.code, 0x3201); // adds r2, #1
+            break;
+        default: // shift/mask convert: 32bpp -> 16bpp style
+            p.kind = "loop-convert";
+            push16(p.code, 0x6808); // ldr  r0, [r1]
+            push16(p.code, 0x0A00); // lsrs r0, r0, #8
+            push16(p.code, 0x8010); // strh r0, [r2]
+            push16(p.code, 0x3104); // adds r1, #4
+            push16(p.code, 0x3202); // adds r2, #2
+            break;
+        }
+        push16(p.code, 0x3B01); // subs r3, #1
+        // Branch back to the top of the body.
+        // Thumb B<cond> is relative to (branch address + 4), i.e. two halfwords
+        // past the branch itself.
+        const std::uint32_t body_halfwords = static_cast<std::uint32_t>(p.code.size() / 2);
+        const std::int32_t back = -static_cast<std::int32_t>(body_halfwords + 2);
+        push16(p.code, static_cast<std::uint16_t>(0xD100u | (back & 0xFF))); // bne body
+        push16(p.code, 0xE7FE); // b .
+
+        p.budget = iterations * 16 + 256;
+        if (!run_pair("loops", dc, da, p, seed, true, cov)) failures++;
+    }
+    return failures;
+}
+
+// Regression test for the VMLA/VMLS product-rounding fix: s8 = s9 * s10
+// followed by s8 -= s9 * s10 must be exactly zero, because a chained (non-fused)
+// multiply-accumulate rounds the product to the destination precision before
+// accumulating it. dyncom used to carry the multiply's extra significand bits
+// into the add and leave a sub-ulp residue.
+std::uint32_t check_vfp_mac_cancellation(backend_env &dc, backend_env &da) {
+    program p;
+    p.addr = PROG_CODE_LO;
+    p.kind = "vfp-mac-cancellation";
+    p.vfp_init[9] = 0x3F800001u;  // 1.0000001f
+    p.vfp_init[10] = 0x40533333u; // 3.3f
+    push32(p.code, 0xEE244A85u);  // vmul.f32 s8, s9, s10
+    push32(p.code, 0xEE044AC5u);  // vmls.f32 s8, s9, s10
+    push32(p.code, 0xEAFFFFFEu);
+    p.budget = 64;
+
+    install(dc, p);
+    install(da, p);
+    dc.cpu->clear_instruction_cache();
+    da.cpu->clear_instruction_cache();
+    dc.cpu->imb_range(p.addr, p.code.size());
+    da.cpu->imb_range(p.addr, p.code.size());
+
+    const full_state sd = execute(dc, p);
+    const full_state sa = execute(da, p);
+    if (sd.vfp[8] == sa.vfp[8] && sd.vfp[8] == 0) {
+        return 0;
+    }
+    std::printf("[DIVERGENCE] vfp-mac-cancellation: vmls after vmul leaves dyncom "
+                "s8=%08X, dynarmic s8=%08X; expected exactly zero (the product must "
+                "be rounded to single before it is accumulated)\n",
+        sd.vfp[8], sa.vfp[8]);
+    return 1;
+}
+
+// VFP: the host-float fast path against dynarmic's own VFP implementation.
+std::uint32_t suite_vfp(backend_env &dc, backend_env &da, std::uint32_t base_seed,
+    std::uint32_t count, coverage &cov) {
+    // vadd/vsub/vmul/vdiv/vmla/vmls .f32 over s8..s15, then store the bank.
+    static constexpr std::uint32_t vfp_ops[] = {
+        0xEE344A05u, // vadd.f32 s8, s8, s10
+        0xEE344A45u, // vsub.f32 s8, s8, s10
+        0xEE244A85u, // vmul.f32 s8, s9, s10
+        0xEE844A85u, // vdiv.f32 s8, s9, s10
+        0xEE044A85u, // vmla.f32 s8, s9, s10
+        0xEE044AC5u, // vmls.f32 s8, s9, s10
+        0xEEB04AC5u, // vabs.f32 s8, s10
+        0xEEB14A45u, // vneg.f32 s8, s10
+    };
+
+    std::uint32_t failures = 0;
+    for (std::uint32_t i = 0; i < count && failures < 10; i++) {
+        const std::uint32_t seed = base_seed + i;
+        rng r(seed);
+
+        program p;
+        p.addr = PROG_CODE_LO;
+        p.thumb = false;
+        p.kind = "vfp";
+        set_common_init(p, r);
+        for (int v = 8; v < 16; v++) p.vfp_init[v] = random_normal_f32(r);
+
+        const std::uint32_t len = 4 + r.range(12);
+        for (std::uint32_t n = 0; n < len; n++) {
+            push32(p.code, vfp_ops[r.range(sizeof(vfp_ops) / sizeof(vfp_ops[0]))]);
+        }
+        // Spill the bank so a divergence also shows up in memory.
+        push32(p.code, 0xED894A00u); // vstr s8, [r9]
+        push32(p.code, 0xEDC94A01u); // vstr s9, [r9, #4]
+        push32(p.code, 0xEAFFFFFEu);
+
+        p.budget = len * 4 + 64;
+        if (!run_pair("vfp", dc, da, p, seed, true, cov)) failures++;
+    }
+    return failures;
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+    std::uint32_t base_seed = 1;
+    std::uint32_t count = 200000;
+    if (argc > 1) base_seed = static_cast<std::uint32_t>(std::strtoul(argv[1], nullptr, 0));
+    if (argc > 2) count = static_cast<std::uint32_t>(std::strtoul(argv[2], nullptr, 0));
+
+    std::printf("dyncom_difftest: phase 1 (golden model, single instruction): "
+                "data-processing + load/store + ldm/stm + halfword, %u cases from seed %u\n",
+        count, base_seed);
+
+    diff_env env_a, env_b;
+    auto core_a = make_core(env_a);
+    auto core_b = make_core(env_b);
+    std::vector<std::uint8_t> golden_mem(MEM_SIZE, 0);
+
+    std::uint32_t failures = 0;
+    auto window_eq = [](const std::vector<std::uint8_t> &x, const std::vector<std::uint8_t> &y) {
+        return std::memcmp(x.data() + LS_DATA_LO, y.data() + LS_DATA_LO, LS_DATA_HI - LS_DATA_LO) == 0;
+    };
+
+    for (std::uint32_t i = 0; i < count; i++) {
+        const std::uint32_t seed = base_seed + i;
+        rng r(seed);
+
+        cpu_state init = gen_state(r);
+        const std::uint32_t kind = r.range(5); // 0,1 data-proc; 2 single; 3 ldm/stm; 4 halfword
+        const bool touches_mem = (kind >= 2);
+        std::uint32_t inst;
+        const char *kind_name;
+        if (kind < 2) {
+            inst = gen_data_processing(r);
+            kind_name = "dyncom != golden";
+        } else if (kind == 2) {
+            inst = gen_load_store(r, init);
+            kind_name = "dyncom != golden (load/store)";
+        } else if (kind == 3) {
+            inst = gen_ldm_stm(r, init);
+            kind_name = "dyncom != golden (ldm/stm)";
+        } else {
+            inst = gen_halfword(r, init);
+            kind_name = "dyncom != golden (halfword)";
+        }
+
+        // Place the instruction at PC 0 in both envs and seed the data window
+        // identically in A, B and the golden image (memory-touching cases only).
+        std::memcpy(env_a.mem.data(), &inst, 4);
+        std::memcpy(env_b.mem.data(), &inst, 4);
+        if (touches_mem) {
+            for (std::uint32_t a = LS_DATA_LO; a < LS_DATA_HI; a += 4) {
+                const std::uint32_t w = r.u32();
+                std::memcpy(env_a.mem.data() + a, &w, 4);
+                std::memcpy(env_b.mem.data() + a, &w, 4);
+                std::memcpy(golden_mem.data() + a, &w, 4);
+            }
+        }
+
+        core_a->imb_range(0, 8);
+        core_b->imb_range(0, 8);
+
+        write_state(*core_a, init);
+        write_state(*core_b, init);
+
+        core_a->set_pc(0);
+        core_b->set_pc(0);
+        core_a->run(1);
+        core_b->run(1);
+
+        const cpu_state got_a = read_state(*core_a);
+        const cpu_state got_b = read_state(*core_b);
+        cpu_state golden;
+        if (kind < 2) {
+            golden = golden_data_processing(inst, init);
+        } else if (kind == 2) {
+            golden = golden_load_store(inst, init, golden_mem.data());
+        } else if (kind == 3) {
+            golden = golden_ldm_stm(inst, init, golden_mem.data());
+        } else {
+            golden = golden_halfword(inst, init, golden_mem.data());
+        }
+
+        // (a) dyncom vs the independent golden model (registers + memory).
+        if (!(got_a == golden) || (touches_mem && !window_eq(env_a.mem, golden_mem))) {
+            report_mismatch(kind_name, inst, seed, golden, got_a);
+            if (++failures >= 20) break;
+            continue;
+        }
+        // (b) self-A/B (determinism today; a flag-gated optimization later).
+        if (!(got_a == got_b) || (touches_mem && !window_eq(env_a.mem, env_b.mem))) {
+            report_mismatch("core A != core B", inst, seed, got_a, got_b);
+            if (++failures >= 20) break;
+        }
+    }
+
+    failures += run_vfp_mac_differential(env_a, env_b, *core_a, *core_b,
+        base_seed, count);
+    failures += benchmark_vfp_mac(env_a, env_b, *core_a, *core_b);
+
+    // Negative control: prove the comparator catches a deliberate divergence.
+    {
+        cpu_state x{}, y{};
+        y.reg[3] = 1;
+        if (x == y) {
+            std::printf("[HARNESS BUG] comparator failed to detect an injected divergence\n");
+            failures++;
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 2: whole programs, dyncom vs dynarmic.
+    // -----------------------------------------------------------------------
+    std::printf("dyncom_difftest: phase 2 (dynarmic oracle, whole programs)\n");
+
+    auto dc = make_dyncom_env();
+    auto da = make_dynarmic_env();
+    coverage cov;
+
+    const std::uint32_t programs = (count / 200 < 4) ? 4 : (count / 200);
+    const std::uint32_t rounds = (programs / 8 < 2) ? 2 : (programs / 8);
+
+    struct suite_result {
+        const char *name;
+        std::uint32_t failures;
+    };
+    const suite_result results[] = {
+        { "cold  ", suite_cold(*dc, *da, base_seed, programs, cov) },
+        { "arena ", suite_arena(*dc, *da, base_seed, rounds, cov) },
+        { "asid  ", suite_asid(*dc, *da, base_seed, rounds * 4, cov) },
+        { "loops ", suite_loops(*dc, *da, base_seed, programs / 2 + 4, cov) },
+        { "vfp   ", suite_vfp(*dc, *da, base_seed, programs / 2 + 4, cov) },
+    };
+    failures += check_vfp_mac_cancellation(*dc, *da);
+    for (const suite_result &sr : results) {
+        std::printf("  %s %s\n", sr.name, sr.failures ? "FAIL" : "ok");
+        failures += sr.failures;
+    }
+
+    std::printf("  coverage: %llu programs, %llu dynarmic interpreter-fallback insts, "
+                "%llu loop-accelerator attaches (%llu bulk iterations)\n",
+        static_cast<unsigned long long>(cov.programs),
+        static_cast<unsigned long long>(cov.fallback_insts),
+        static_cast<unsigned long long>(cov.accel_attaches),
+        static_cast<unsigned long long>(cov.accel_bulk_iterations));
+
+    // Coverage assertions. Without these a suite that silently stopped
+    // reaching its target would report a clean pass -- which is exactly how
+    // the previous harness "verified" the loop accelerator it never ran.
+    if (cov.accel_attaches == 0) {
+        std::printf("[HARNESS BUG] the loop accelerator never attached; the loop "
+                    "suite is not testing it\n");
+        failures++;
+    }
+    if (cov.fallback_insts != 0) {
+        std::printf("[HARNESS BUG] dynarmic used its embedded interpreter for %llu "
+                    "instruction(s); those cases were not independent\n",
+            static_cast<unsigned long long>(cov.fallback_insts));
+        failures++;
+    }
+
+    if (failures == 0) {
+        std::printf("dyncom_difftest: PASS (%u single-instruction cases vs golden, "
+                    "%llu programs vs dynarmic, VFP soft/host A/B, negative control)\n",
+            count, static_cast<unsigned long long>(cov.programs));
+        return 0;
+    }
+    std::printf("dyncom_difftest: FAIL (%u divergences)\n", failures);
+    return 1;
+}

--- a/src/emu/cpu/src/dyncom/vfp/vfp.cpp
+++ b/src/emu/cpu/src/dyncom/vfp/vfp.cpp
@@ -88,23 +88,23 @@ void VMOVR(ARMul_State *state, std::uint32_t single, std::uint32_t d, std::uint3
 
 /* Miscellaneous functions */
 std::int32_t vfp_get_float(ARMul_State *state, unsigned int reg) {
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP get float: s{}=[{:08x}]", reg, state->ExtReg[reg]);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP get float: s{}=[{:08x}]", reg, state->ExtReg[reg]);
     return state->ExtReg[reg];
 }
 
 void vfp_put_float(ARMul_State *state, std::int32_t val, unsigned int reg) {
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP put float: s{} <= [{:08x}]", reg, val);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP put float: s{} <= [{:08x}]", reg, val);
     state->ExtReg[reg] = val;
 }
 
 std::uint64_t vfp_get_double(ARMul_State *state, unsigned int reg) {
     std::uint64_t result = ((std::uint64_t)state->ExtReg[reg * 2 + 1]) << 32 | state->ExtReg[reg * 2];
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP get double: s[{}-{}]=[{:016x}]", reg * 2 + 1, reg * 2, result);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP get double: s[{}-{}]=[{:016x}]", reg * 2 + 1, reg * 2, result);
     return result;
 }
 
 void vfp_put_double(ARMul_State *state, std::uint64_t val, unsigned int reg) {
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP put double: s[{}-{}] <= [{:08x}-{:08x}]", reg * 2 + 1, reg * 2,
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP put double: s[{}-{}] <= [{:08x}-{:08x}]", reg * 2 + 1, reg * 2,
         (std::uint32_t)(val >> 32), (std::uint32_t)(val & 0xffffffff));
     state->ExtReg[reg * 2] = (std::uint32_t)(val & 0xffffffff);
     state->ExtReg[reg * 2 + 1] = (std::uint32_t)(val >> 32);
@@ -114,7 +114,7 @@ void vfp_put_double(ARMul_State *state, std::uint64_t val, unsigned int reg) {
  * Process bitmask of exception conditions. (from vfpmodule.c)
  */
 void vfp_raise_exceptions(ARMul_State *state, std::uint32_t exceptions, std::uint32_t inst, std::uint32_t fpscr) {
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP: raising exceptions {:08x}", exceptions);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP: raising exceptions {:08x}", exceptions);
 
     if (exceptions == VFP_EXCEPTION_ERROR) {
         LOG_CRITICAL(eka2l1::CPU_DYNCOM, "unhandled bounce {:x}", inst);

--- a/src/emu/cpu/src/dyncom/vfp/vfpdouble.cpp
+++ b/src/emu/cpu/src/dyncom/vfp/vfpdouble.cpp
@@ -52,6 +52,8 @@
  */
 
 #include <algorithm>
+#include <cstdlib>
+#include <cstring>
 #include <common/log.h>
 #include <cpu/dyncom/vfp/asm_vfp.h>
 #include <cpu/dyncom/vfp/vfp.h>
@@ -64,7 +66,7 @@ static struct vfp_double vfp_double_default_qnan = {
 };
 
 static void vfp_double_dump(const char *str, struct vfp_double *d) {
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP: {}: sign={} exponent={} significand={:016x}", str, d->sign != 0,
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP: {}: sign={} exponent={} significand={:016x}", str, d->sign != 0,
         d->exponent, d->significand);
 }
 
@@ -166,7 +168,7 @@ std::uint32_t vfp_double_normaliseround(ARMul_State *state, int dd, struct vfp_d
     } else if ((rmode == FPSCR_ROUND_PLUSINF) ^ (vd->sign != 0))
         incr = (1ULL << (VFP_DOUBLE_LOW_BITS + 1)) - 1;
 
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP: rounding increment = 0x{:08x}", incr);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP: rounding increment = 0x{:08x}", incr);
 
     /*
      * Is our rounding going to overflow?
@@ -221,11 +223,31 @@ pack:
     vfp_double_dump("pack: final", vd);
     {
         std::int64_t d = vfp_double_pack(vd);
-        LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP: {}: d(d{})={:016x} exceptions={:08x}", func, dd, d,
+        VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP: {}: d(d{})={:016x} exceptions={:08x}", func, dd, d,
             exceptions);
         vfp_put_double(state, d, dd);
     }
     return exceptions;
+}
+
+// See the single-precision counterpart: VMLA/VMLS are chained, so the product
+// is a double-precision value before it is accumulated. Rounds an intermediate
+// through a scratch slot that no guest instruction can observe.
+static std::uint32_t vfp_double_round_intermediate(ARMul_State *state, struct vfp_double *vd,
+    std::uint32_t fpscr, const char *func) {
+    constexpr int SCRATCH = 31; // d31: ExtReg has 64 single slots = 32 doubles
+    const std::uint32_t saved_lo = state->ExtReg[SCRATCH * 2];
+    const std::uint32_t saved_hi = state->ExtReg[SCRATCH * 2 + 1];
+    const std::uint32_t exceptions = vfp_double_normaliseround(state, SCRATCH, vd, fpscr, 0, func);
+    const std::uint64_t rounded = vfp_get_double(state, SCRATCH);
+    state->ExtReg[SCRATCH * 2] = saved_lo;
+    state->ExtReg[SCRATCH * 2 + 1] = saved_hi;
+
+    const std::uint32_t unpack_exceptions = vfp_double_unpack(vd, static_cast<std::int64_t>(rounded), fpscr);
+    if (vd->exponent == 0 && vd->significand)
+        vfp_double_normalise_denormal(vd);
+
+    return exceptions | unpack_exceptions;
 }
 
 /*
@@ -275,25 +297,25 @@ static std::uint32_t vfp_propagate_nan(struct vfp_double *vdd, struct vfp_double
  * Extended operations
  */
 static std::uint32_t vfp_double_fabs(ARMul_State *state, int dd, int unused, int dm, std::uint32_t fpscr) {
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
     vfp_put_double(state, vfp_double_packed_abs(vfp_get_double(state, dm)), dd);
     return 0;
 }
 
 static std::uint32_t vfp_double_fcpy(ARMul_State *state, int dd, int unused, int dm, std::uint32_t fpscr) {
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
     vfp_put_double(state, vfp_get_double(state, dm), dd);
     return 0;
 }
 
 static std::uint32_t vfp_double_fneg(ARMul_State *state, int dd, int unused, int dm, std::uint32_t fpscr) {
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
     vfp_put_double(state, vfp_double_packed_negate(vfp_get_double(state, dm)), dd);
     return 0;
 }
 
 static std::uint32_t vfp_double_fsqrt(ARMul_State *state, int dd, int unused, int dm, std::uint32_t fpscr) {
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
     vfp_double vdm, vdd, *vdp;
     int ret, tm;
     std::uint32_t exceptions = 0;
@@ -390,7 +412,7 @@ static std::uint32_t vfp_compare(ARMul_State *state, int dd, int signal_on_qnan,
     std::int64_t d;
     std::uint32_t ret = 0;
 
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}, state=0x{}, fpscr=0x{:x}", __FUNCTION__, fmt::ptr(state), fpscr);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}, state=0x{}, fpscr=0x{:x}", __FUNCTION__, fmt::ptr(state), fpscr);
     if (vfp_double_packed_exponent(m) == 2047 && vfp_double_packed_mantissa(m)) {
         ret |= FPSCR_CFLAG | FPSCR_VFLAG;
         if (signal_on_qnan || !(vfp_double_packed_mantissa(m) & (1ULL << (VFP_DOUBLE_MANTISSA_BITS - 1))))
@@ -444,28 +466,28 @@ static std::uint32_t vfp_compare(ARMul_State *state, int dd, int signal_on_qnan,
             ret |= FPSCR_CFLAG;
         }
     }
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}, state=0x{}, ret=0x{:x}", __FUNCTION__, fmt::ptr(state), ret);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}, state=0x{}, ret=0x{:x}", __FUNCTION__, fmt::ptr(state), ret);
 
     return ret;
 }
 
 static std::uint32_t vfp_double_fcmp(ARMul_State *state, int dd, int unused, int dm, std::uint32_t fpscr) {
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
     return vfp_compare(state, dd, 0, vfp_get_double(state, dm), fpscr);
 }
 
 static std::uint32_t vfp_double_fcmpe(ARMul_State *state, int dd, int unused, int dm, std::uint32_t fpscr) {
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
     return vfp_compare(state, dd, 1, vfp_get_double(state, dm), fpscr);
 }
 
 static std::uint32_t vfp_double_fcmpz(ARMul_State *state, int dd, int unused, int dm, std::uint32_t fpscr) {
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
     return vfp_compare(state, dd, 0, 0, fpscr);
 }
 
 static std::uint32_t vfp_double_fcmpez(ARMul_State *state, int dd, int unused, int dm, std::uint32_t fpscr) {
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
     return vfp_compare(state, dd, 1, 0, fpscr);
 }
 
@@ -475,7 +497,7 @@ static std::uint32_t vfp_double_fcvts(ARMul_State *state, int sd, int unused, in
     int tm;
     std::uint32_t exceptions = 0;
 
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
     exceptions |= vfp_double_unpack(&vdm, vfp_get_double(state, dm), fpscr);
 
     tm = vfp_double_type(&vdm);
@@ -516,7 +538,7 @@ static std::uint32_t vfp_double_fuito(ARMul_State *state, int dd, int unused, in
     struct vfp_double vdm;
     std::uint32_t m = vfp_get_float(state, dm);
 
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
     vdm.sign = 0;
     vdm.exponent = 1023 + 63 - 1;
     vdm.significand = (std::uint64_t)m;
@@ -528,7 +550,7 @@ static std::uint32_t vfp_double_fsito(ARMul_State *state, int dd, int unused, in
     struct vfp_double vdm;
     std::uint32_t m = vfp_get_float(state, dm);
 
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
     vdm.sign = (m & 0x80000000) >> 16;
     vdm.exponent = 1023 + 63 - 1;
     vdm.significand = vdm.sign ? (~m + 1) : m;
@@ -542,7 +564,7 @@ static std::uint32_t vfp_double_ftoui(ARMul_State *state, int sd, int unused, in
     int rmode = fpscr & FPSCR_RMODE_MASK;
     int tm;
 
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
     exceptions |= vfp_double_unpack(&vdm, vfp_get_double(state, dm), fpscr);
 
     /*
@@ -611,7 +633,7 @@ static std::uint32_t vfp_double_ftoui(ARMul_State *state, int sd, int unused, in
         }
     }
 
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP: ftoui: d(s{})={:08x} exceptions={:08x}", sd, d, exceptions);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP: ftoui: d(s{})={:08x} exceptions={:08x}", sd, d, exceptions);
 
     vfp_put_float(state, d, sd);
 
@@ -619,7 +641,7 @@ static std::uint32_t vfp_double_ftoui(ARMul_State *state, int sd, int unused, in
 }
 
 static std::uint32_t vfp_double_ftouiz(ARMul_State *state, int sd, int unused, int dm, std::uint32_t fpscr) {
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
     return vfp_double_ftoui(state, sd, unused, dm,
         (fpscr & ~FPSCR_RMODE_MASK) | FPSCR_ROUND_TOZERO);
 }
@@ -630,7 +652,7 @@ static std::uint32_t vfp_double_ftosi(ARMul_State *state, int sd, int unused, in
     int rmode = fpscr & FPSCR_RMODE_MASK;
     int tm;
 
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
     exceptions |= vfp_double_unpack(&vdm, vfp_get_double(state, dm), fpscr);
     vfp_double_dump("VDM", &vdm);
 
@@ -694,7 +716,7 @@ static std::uint32_t vfp_double_ftosi(ARMul_State *state, int sd, int unused, in
         }
     }
 
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP: ftosi: d(s{})={:08x} exceptions={:08x}", sd, d, exceptions);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP: ftosi: d(s{})={:08x} exceptions={:08x}", sd, d, exceptions);
 
     vfp_put_float(state, (std::int32_t)d, sd);
 
@@ -702,7 +724,7 @@ static std::uint32_t vfp_double_ftosi(ARMul_State *state, int sd, int unused, in
 }
 
 static std::uint32_t vfp_double_ftosiz(ARMul_State *state, int dd, int unused, int dm, std::uint32_t fpscr) {
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
     return vfp_double_ftosi(state, dd, unused, dm,
         (fpscr & ~FPSCR_RMODE_MASK) | FPSCR_ROUND_TOZERO);
 }
@@ -849,7 +871,7 @@ std::uint32_t vfp_double_multiply(struct vfp_double *vdd, struct vfp_double *vdn
      */
     if (vdn->exponent < vdm->exponent) {
         std::swap(vdm, vdn);
-        LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP: swapping M <-> N");
+        VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP: swapping M <-> N");
     }
 
     vdd->sign = vdn->sign ^ vdm->sign;
@@ -908,6 +930,11 @@ static std::uint32_t vfp_double_multiply_accumulate(ARMul_State *state, int dd, 
         vfp_double_normalise_denormal(&vdm);
 
     exceptions |= vfp_double_multiply(&vdp, &vdn, &vdm, fpscr);
+
+    // Chained, not fused: round the product to double precision before it is
+    // accumulated (ARM pseudocode FPAdd(D[d], FPMul(D[n], D[m]))).
+    exceptions |= vfp_double_round_intermediate(state, &vdp, fpscr, func);
+
     if (negate & NEG_MULTIPLY)
         vdp.sign = vfp_sign_negate(vdp.sign);
 
@@ -931,7 +958,7 @@ static std::uint32_t vfp_double_multiply_accumulate(ARMul_State *state, int dd, 
  * sd = sd + (sn * sm)
  */
 static std::uint32_t vfp_double_fmac(ARMul_State *state, int dd, int dn, int dm, std::uint32_t fpscr) {
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
     return vfp_double_multiply_accumulate(state, dd, dn, dm, fpscr, 0, "fmac");
 }
 
@@ -939,7 +966,7 @@ static std::uint32_t vfp_double_fmac(ARMul_State *state, int dd, int dn, int dm,
  * sd = sd - (sn * sm)
  */
 static std::uint32_t vfp_double_fnmac(ARMul_State *state, int dd, int dn, int dm, std::uint32_t fpscr) {
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
     return vfp_double_multiply_accumulate(state, dd, dn, dm, fpscr, NEG_MULTIPLY, "fnmac");
 }
 
@@ -947,7 +974,7 @@ static std::uint32_t vfp_double_fnmac(ARMul_State *state, int dd, int dn, int dm
  * sd = -sd + (sn * sm)
  */
 static std::uint32_t vfp_double_fmsc(ARMul_State *state, int dd, int dn, int dm, std::uint32_t fpscr) {
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
     return vfp_double_multiply_accumulate(state, dd, dn, dm, fpscr, NEG_SUBTRACT, "fmsc");
 }
 
@@ -955,7 +982,7 @@ static std::uint32_t vfp_double_fmsc(ARMul_State *state, int dd, int dn, int dm,
  * sd = -sd - (sn * sm)
  */
 static std::uint32_t vfp_double_fnmsc(ARMul_State *state, int dd, int dn, int dm, std::uint32_t fpscr) {
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
     return vfp_double_multiply_accumulate(state, dd, dn, dm, fpscr, NEG_SUBTRACT | NEG_MULTIPLY,
         "fnmsc");
 }
@@ -967,7 +994,7 @@ static std::uint32_t vfp_double_fmul(ARMul_State *state, int dd, int dn, int dm,
     struct vfp_double vdd, vdn, vdm;
     std::uint32_t exceptions = 0;
 
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
     exceptions |= vfp_double_unpack(&vdn, vfp_get_double(state, dn), fpscr);
     if (vdn.exponent == 0 && vdn.significand)
         vfp_double_normalise_denormal(&vdn);
@@ -987,7 +1014,7 @@ static std::uint32_t vfp_double_fnmul(ARMul_State *state, int dd, int dn, int dm
     struct vfp_double vdd, vdn, vdm;
     std::uint32_t exceptions = 0;
 
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
     exceptions |= vfp_double_unpack(&vdn, vfp_get_double(state, dn), fpscr);
     if (vdn.exponent == 0 && vdn.significand)
         vfp_double_normalise_denormal(&vdn);
@@ -1009,7 +1036,7 @@ static std::uint32_t vfp_double_fadd(ARMul_State *state, int dd, int dn, int dm,
     struct vfp_double vdd, vdn, vdm;
     std::uint32_t exceptions = 0;
 
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
     exceptions |= vfp_double_unpack(&vdn, vfp_get_double(state, dn), fpscr);
     if (vdn.exponent == 0 && vdn.significand)
         vfp_double_normalise_denormal(&vdn);
@@ -1030,7 +1057,7 @@ static std::uint32_t vfp_double_fsub(ARMul_State *state, int dd, int dn, int dm,
     struct vfp_double vdd, vdn, vdm;
     std::uint32_t exceptions = 0;
 
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
     exceptions |= vfp_double_unpack(&vdn, vfp_get_double(state, dn), fpscr);
     if (vdn.exponent == 0 && vdn.significand)
         vfp_double_normalise_denormal(&vdn);
@@ -1057,7 +1084,7 @@ static std::uint32_t vfp_double_fdiv(ARMul_State *state, int dd, int dn, int dm,
     std::uint32_t exceptions = 0;
     int tm, tn;
 
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
     exceptions |= vfp_double_unpack(&vdn, vfp_get_double(state, dn), fpscr);
     exceptions |= vfp_double_unpack(&vdm, vfp_get_double(state, dm), fpscr);
 
@@ -1172,6 +1199,17 @@ static struct op fops[] = {
 #define FREG_BANK(x) ((x)&0x0c)
 #define FREG_IDX(x) ((x)&3)
 
+// Host-double fast path for VFP double-precision arithmetic; see the matching
+// comment in vfpsingle.cpp. Same envelope (scalar, default FPSCR mode,
+// normalized operands+result) where host arm64 IEEE-754 RN is bit-identical to
+// the softfloat reference.
+static constexpr bool g_vfp_host_fast = true;
+
+static inline bool vfp_f64_normalized(std::uint64_t bits) {
+    const std::uint64_t e = bits & 0x7FF0000000000000ull;
+    return e != 0ull && e != 0x7FF0000000000000ull;
+}
+
 std::uint32_t vfp_double_cpdo(ARMul_State *state, std::uint32_t inst, std::uint32_t fpscr) {
     std::uint32_t op = inst & FOP_MASK;
     std::uint32_t exceptions = 0;
@@ -1181,7 +1219,7 @@ std::uint32_t vfp_double_cpdo(ARMul_State *state, std::uint32_t inst, std::uint3
     unsigned int vecitr, veclen, vecstride;
     struct op *fop;
 
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "In {}", __FUNCTION__);
     vecstride = (1 + ((fpscr & FPSCR_STRIDE_MASK) == FPSCR_STRIDE_MASK));
 
     fop = (op == FOP_EXT) ? &fops_ext[FEXT_TO_IDX(inst)] : &fops[FOP_TO_IDX(op)];
@@ -1212,12 +1250,45 @@ std::uint32_t vfp_double_cpdo(ARMul_State *state, std::uint32_t inst, std::uint3
     else
         veclen = fpscr & FPSCR_LENGTH_MASK;
 
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP: vecstride={} veclen={}", vecstride,
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP: vecstride={} veclen={}", vecstride,
         (veclen >> FPSCR_LENGTH_BIT) + 1);
 
     if (!fop->fn) {
-        LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP: could not find double op {}", FEXT_TO_IDX(inst));
+        VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP: could not find double op {}", FEXT_TO_IDX(inst));
         goto invalid;
+    }
+
+    // Host-double fast path (see vfp_f64_normalized comment above).
+    if (g_vfp_host_fast && veclen == 0 && op != FOP_EXT
+        && (fop->flags & (OP_SD | OP_SM)) == 0
+        && (fpscr & (FPSCR_RMODE_MASK | FPSCR_FLUSH_TO_ZERO | FPSCR_DEFAULT_NAN)) == 0) {
+        const std::uint64_t nb = vfp_get_double(state, dn);
+        const std::uint64_t mb = vfp_get_double(state, dm);
+        if (vfp_f64_normalized(nb) && vfp_f64_normalized(mb)) {
+            double dnv, dmv, drv;
+            std::memcpy(&dnv, &nb, sizeof(double));
+            std::memcpy(&dmv, &mb, sizeof(double));
+            bool handled = true;
+            if (fop->fn == vfp_double_fadd)
+                drv = dnv + dmv;
+            else if (fop->fn == vfp_double_fsub)
+                drv = dnv - dmv;
+            else if (fop->fn == vfp_double_fmul)
+                drv = dnv * dmv;
+            else if (fop->fn == vfp_double_fdiv)
+                drv = dnv / dmv;
+            else
+                handled = false;
+
+            if (handled) {
+                std::uint64_t rb;
+                std::memcpy(&rb, &drv, sizeof(double));
+                if (vfp_f64_normalized(rb)) {
+                    vfp_put_double(state, rb, dest);
+                    return 0;
+                }
+            }
+        }
     }
 
     for (vecitr = 0; vecitr <= veclen; vecitr += 1 << FPSCR_LENGTH_BIT) {
@@ -1226,14 +1297,14 @@ std::uint32_t vfp_double_cpdo(ARMul_State *state, std::uint32_t inst, std::uint3
 
         type = (fop->flags & OP_SD) ? 's' : 'd';
         if (op == FOP_EXT)
-            LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP: itr{} ({}{}) = op[{}] (d{})", vecitr >> FPSCR_LENGTH_BIT,
+            VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP: itr{} ({}{}) = op[{}] (d{})", vecitr >> FPSCR_LENGTH_BIT,
                 type, dest, dn, dm);
         else
-            LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP: itr{} ({}{}) = (d{}) op[{}] (d{})",
+            VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP: itr{} ({}{}) = (d{}) op[{}] (d{})",
                 vecitr >> FPSCR_LENGTH_BIT, type, dest, dn, FOP_TO_IDX(op), dm);
 
         except = fop->fn(state, dest, dn, dm, fpscr);
-        LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP: itr{}: exceptions={:08x}", vecitr >> FPSCR_LENGTH_BIT, except);
+        VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "VFP: itr{}: exceptions={:08x}", vecitr >> FPSCR_LENGTH_BIT, except);
 
         exceptions |= except & ~VFP_NAN_FLAG;
 

--- a/src/emu/cpu/src/dyncom/vfp/vfpsingle.cpp
+++ b/src/emu/cpu/src/dyncom/vfp/vfpsingle.cpp
@@ -52,6 +52,9 @@
  */
 
 #include <algorithm>
+#include <bit>
+#include <cstdlib>
+#include <cstring>
 #include <common/log.h>
 #include <common/types.h>
 #include <cpu/dyncom/vfp/asm_vfp.h>
@@ -65,7 +68,7 @@ static struct vfp_single vfp_single_default_qnan = {
 };
 
 static void vfp_single_dump(const char *str, struct vfp_single *s) {
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "{}: sign={} exponent={} significand={:08x}", str, s->sign != 0,
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "{}: sign={} exponent={} significand={:08x}", str, s->sign != 0,
         s->exponent, s->significand);
 }
 
@@ -167,7 +170,7 @@ std::uint32_t vfp_single_normaliseround(ARMul_State *state, int sd, struct vfp_s
     } else if ((rmode == FPSCR_ROUND_PLUSINF) ^ (vs->sign != 0))
         incr = (1 << (VFP_SINGLE_LOW_BITS + 1)) - 1;
 
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "rounding increment = 0x{:08x}", incr);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "rounding increment = 0x{:08x}", incr);
 
     /*
      * Is our rounding going to overflow?
@@ -222,11 +225,33 @@ pack:
     vfp_single_dump("pack: final", vs);
     {
         std::int32_t d = vfp_single_pack(vs);
-        LOG_TRACE(eka2l1::CPU_DYNCOM, "{}: d(s{})={:08x} exceptions={:08x}", func, sd, d, exceptions);
+        VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "{}: d(s{})={:08x} exceptions={:08x}", func, sd, d, exceptions);
         vfp_put_float(state, d, sd);
     }
 
     return exceptions;
+}
+
+// Round an intermediate to single precision without committing it to a
+// register. Multiply-accumulate needs this: VFPv2/v3 VMLA/VMLS are chained,
+// not fused, so the product is a single-precision value before it is
+// accumulated. Reuses normaliseround by routing it through a scratch slot.
+static std::uint32_t vfp_single_round_intermediate(ARMul_State *state, struct vfp_single *vs,
+    std::uint32_t fpscr, const char *func) {
+    // ExtReg has 64 slots; the single-precision register file only uses the
+    // first 32, so the upper half is free for a scratch value that no guest
+    // instruction can observe.
+    constexpr int SCRATCH = 63;
+    const std::int32_t saved = state->ExtReg[SCRATCH];
+    const std::uint32_t exceptions = vfp_single_normaliseround(state, SCRATCH, vs, fpscr, 0, func);
+    const std::int32_t rounded = state->ExtReg[SCRATCH];
+    state->ExtReg[SCRATCH] = saved;
+
+    std::uint32_t unpack_exceptions = vfp_single_unpack(vs, rounded, fpscr);
+    if (vs->exponent == 0 && vs->significand)
+        vfp_single_normalise_denormal(vs);
+
+    return exceptions | unpack_exceptions;
 }
 
 /*
@@ -333,7 +358,7 @@ std::uint32_t vfp_estimate_sqrt_significand(std::uint32_t exponent, std::uint32_
     std::uint32_t z, a;
 
     if ((significand & 0xc0000000) != 0x40000000) {
-        LOG_TRACE(eka2l1::CPU_DYNCOM, "invalid significand");
+        VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "invalid significand");
     }
 
     a = significand << 1;
@@ -423,7 +448,7 @@ static std::uint32_t vfp_single_fsqrt(ARMul_State *state, int sd, std::int32_t u
             term = (std::uint64_t)vsd.significand * vsd.significand;
             rem = ((std::uint64_t)vsm.significand << 32) - term;
 
-            LOG_TRACE(eka2l1::CPU_DYNCOM, "term={} rem={}", term, rem);
+            VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "term={} rem={}", term, rem);
 
             while (rem < 0) {
                 vsd.significand -= 1;
@@ -660,7 +685,7 @@ static std::uint32_t vfp_single_ftoui(ARMul_State *state, int sd, std::int32_t u
         }
     }
 
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "ftoui: d(s{})={:08x} exceptions={:08x}", sd, d, exceptions);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "ftoui: d(s{})={:08x} exceptions={:08x}", sd, d, exceptions);
 
     vfp_put_float(state, d, sd);
 
@@ -741,7 +766,7 @@ static std::uint32_t vfp_single_ftosi(ARMul_State *state, int sd, std::int32_t u
         }
     }
 
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "ftosi: d(s{})={:08x} exceptions={:08x}", sd, d, exceptions);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "ftosi: d(s{})={:08x} exceptions={:08x}", sd, d, exceptions);
 
     vfp_put_float(state, (std::int32_t)d, sd);
 
@@ -893,7 +918,7 @@ static std::uint32_t vfp_single_multiply(struct vfp_single *vsd, struct vfp_sing
      */
     if (vsn->exponent < vsm->exponent) {
         std::swap(vsm, vsn);
-        LOG_TRACE(eka2l1::CPU_DYNCOM, "swapping M <-> N");
+        VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "swapping M <-> N");
     }
 
     vsd->sign = vsn->sign ^ vsm->sign;
@@ -945,7 +970,7 @@ static std::uint32_t vfp_single_multiply_accumulate(ARMul_State *state, int sd, 
     std::int32_t v;
 
     v = vfp_get_float(state, sn);
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "s{} = {:08x}", sn, v);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "s{} = {:08x}", sn, v);
     exceptions |= vfp_single_unpack(&vsn, v, fpscr);
     if (vsn.exponent == 0 && vsn.significand)
         vfp_single_normalise_denormal(&vsn);
@@ -956,11 +981,19 @@ static std::uint32_t vfp_single_multiply_accumulate(ARMul_State *state, int sd, 
 
     exceptions |= vfp_single_multiply(&vsp, &vsn, &vsm, fpscr);
 
+    // VMLA/VMLS are chained multiply-accumulates, not fused ones (VFMA arrived
+    // in VFPv4): the ARM pseudocode is FPAdd(S[d], FPMul(S[n], S[m])), so the
+    // product is rounded to single precision here. Carrying the multiply's
+    // extra significand bits into the add instead makes `vmul` followed by
+    // `vmls` with the same operands leave a sub-ulp residue where the result
+    // must be exactly zero.
+    exceptions |= vfp_single_round_intermediate(state, &vsp, fpscr, func);
+
     if (negate & NEG_MULTIPLY)
         vsp.sign = vfp_sign_negate(vsp.sign);
 
     v = vfp_get_float(state, sd);
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "s{} = {:08x}", sd, v);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "s{} = {:08x}", sd, v);
     exceptions |= vfp_single_unpack(&vsn, v, fpscr);
     if (vsn.exponent == 0 && vsn.significand != 0)
         vfp_single_normalise_denormal(&vsn);
@@ -981,7 +1014,7 @@ static std::uint32_t vfp_single_multiply_accumulate(ARMul_State *state, int sd, 
  * sd = sd + (sn * sm)
  */
 static std::uint32_t vfp_single_fmac(ARMul_State *state, int sd, int sn, std::int32_t m, std::uint32_t fpscr) {
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "s{} = {:08x}", sn, sd);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "s{} = {:08x}", sn, sd);
     return vfp_single_multiply_accumulate(state, sd, sn, m, fpscr, 0, "fmac");
 }
 
@@ -990,7 +1023,7 @@ static std::uint32_t vfp_single_fmac(ARMul_State *state, int sd, int sn, std::in
  */
 static std::uint32_t vfp_single_fnmac(ARMul_State *state, int sd, int sn, std::int32_t m, std::uint32_t fpscr) {
     // TODO: this one has its arguments inverted, investigate.
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "s{} = {:08x}", sd, sn);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "s{} = {:08x}", sd, sn);
     return vfp_single_multiply_accumulate(state, sd, sn, m, fpscr, NEG_MULTIPLY, "fnmac");
 }
 
@@ -998,7 +1031,7 @@ static std::uint32_t vfp_single_fnmac(ARMul_State *state, int sd, int sn, std::i
  * sd = -sd + (sn * sm)
  */
 static std::uint32_t vfp_single_fmsc(ARMul_State *state, int sd, int sn, std::int32_t m, std::uint32_t fpscr) {
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "s{} = {:08x}", sn, sd);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "s{} = {:08x}", sn, sd);
     return vfp_single_multiply_accumulate(state, sd, sn, m, fpscr, NEG_SUBTRACT, "fmsc");
 }
 
@@ -1006,7 +1039,7 @@ static std::uint32_t vfp_single_fmsc(ARMul_State *state, int sd, int sn, std::in
  * sd = -sd - (sn * sm)
  */
 static std::uint32_t vfp_single_fnmsc(ARMul_State *state, int sd, int sn, std::int32_t m, std::uint32_t fpscr) {
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "s{} = {:08x}", sn, sd);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "s{} = {:08x}", sn, sd);
     return vfp_single_multiply_accumulate(state, sd, sn, m, fpscr, NEG_SUBTRACT | NEG_MULTIPLY,
         "fnmsc");
 }
@@ -1019,7 +1052,7 @@ static std::uint32_t vfp_single_fmul(ARMul_State *state, int sd, int sn, std::in
     std::uint32_t exceptions = 0;
     std::int32_t n = vfp_get_float(state, sn);
 
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "s{} = {:08x}", sn, n);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "s{} = {:08x}", sn, n);
 
     exceptions |= vfp_single_unpack(&vsn, n, fpscr);
     if (vsn.exponent == 0 && vsn.significand)
@@ -1041,7 +1074,7 @@ static std::uint32_t vfp_single_fnmul(ARMul_State *state, int sd, int sn, std::i
     std::uint32_t exceptions = 0;
     std::int32_t n = vfp_get_float(state, sn);
 
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "s{} = {:08x}", sn, n);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "s{} = {:08x}", sn, n);
 
     exceptions |= vfp_single_unpack(&vsn, n, fpscr);
     if (vsn.exponent == 0 && vsn.significand)
@@ -1064,7 +1097,7 @@ static std::uint32_t vfp_single_fadd(ARMul_State *state, int sd, int sn, std::in
     std::uint32_t exceptions = 0;
     std::int32_t n = vfp_get_float(state, sn);
 
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "s{} = {:08x}", sn, n);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "s{} = {:08x}", sn, n);
 
     /*
      * Unpack and normalise denormals.
@@ -1086,7 +1119,7 @@ static std::uint32_t vfp_single_fadd(ARMul_State *state, int sd, int sn, std::in
  * sd = sn - sm
  */
 static std::uint32_t vfp_single_fsub(ARMul_State *state, int sd, int sn, std::int32_t m, std::uint32_t fpscr) {
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "s{} = {:08x}", sn, sd);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "s{} = {:08x}", sn, sd);
     /*
      * Subtraction is addition with one sign inverted. Unpack the second operand to perform FTZ if
      * necessary, we can't let fadd do this because a denormal in m might get flushed to +0 in FTZ
@@ -1115,7 +1148,7 @@ static std::uint32_t vfp_single_fdiv(ARMul_State *state, int sd, int sn, std::in
     std::int32_t n = vfp_get_float(state, sn);
     int tm, tn;
 
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "s{} = {:08x}", sn, n);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "s{} = {:08x}", sn, n);
 
     exceptions |= vfp_single_unpack(&vsn, n, fpscr);
     exceptions |= vfp_single_unpack(&vsm, m, fpscr);
@@ -1228,6 +1261,75 @@ static struct op fops[] = {
 #define FREG_BANK(x) ((x)&0x18)
 #define FREG_IDX(x) ((x)&7)
 
+// Host fast path for VFP single-precision arithmetic. The interpreter's
+// VFP is the bit-accurate ARM softfloat reference (vfp_single_f*), which is the
+// dominant cost for float-heavy guest code. The host is arm64 / IEEE-754, so for
+// the common case -- scalar op, default FPSCR mode (round-to-nearest, no
+// flush-to-zero / default-NaN), and *normalized* finite operands AND result --
+// a native float op is bit-identical to the reference (both are IEEE-754 RN),
+// at a fraction of the cost. Anything outside that envelope (NaN/Inf/denormal/
+// zero in or out, non-default mode, vectors) falls back to softfloat, which
+// keeps exact flag/special-value semantics. VFPv3 VMLA/VMLS retain extra
+// product precision, but are not IEEE fused-FMA; their packed fast helper below
+// mirrors that guard/sticky sequence directly. The differential
+// harness covers both paths (see scripts/cpu_difftest.sh).
+#if defined(EKA2L1_DYNCOM_DIFFTEST)
+static bool g_vfp_host_fast = true;
+static std::uint64_t g_vfp_host_fast_hits = 0;
+
+void vfp_set_single_host_fast_for_test(bool enabled) {
+    g_vfp_host_fast = enabled;
+}
+
+void vfp_reset_single_host_fast_hits_for_test() {
+    g_vfp_host_fast_hits = 0;
+}
+
+std::uint64_t vfp_single_host_fast_hits_for_test() {
+    return g_vfp_host_fast_hits;
+}
+#else
+static constexpr bool g_vfp_host_fast = true;
+#endif
+
+static inline bool vfp_f32_normalized(std::int32_t bits) {
+    const std::uint32_t e = static_cast<std::uint32_t>(bits) & 0x7F800000u;
+    return e != 0u && e != 0x7F800000u; // exclude zero/denormal (e==0) and Inf/NaN (e==0xFF)
+}
+
+// Host fast path for the multiply-accumulate family. Because VMLA/VMLS are
+// chained, the architectural result is exactly two correctly-rounded
+// single-precision operations, which is what the host gives natively -- no
+// significand bookkeeping needed. The envelope is the same as for the plain
+// arithmetic ops, extended to the rounded product: everything in and out must
+// be a normalized finite number, so the softfloat reference keeps every
+// denormal / overflow / underflow / NaN case along with its exception flags.
+// Like the other fast-path operations it does not raise the INEXACT cumulative
+// flag; the reference path does. (The previous packed implementation raised it
+// for MAC only, which was inconsistent with add/sub/mul/div.)
+static inline bool vfp_host_f32_mac(std::int32_t nb, std::int32_t mb,
+    std::int32_t ab, std::uint32_t negate, std::int32_t &rb) {
+    float fn, fm, fa;
+    std::memcpy(&fn, &nb, sizeof(float));
+    std::memcpy(&fm, &mb, sizeof(float));
+    std::memcpy(&fa, &ab, sizeof(float));
+
+    float product = fn * fm;
+    std::int32_t pb;
+    std::memcpy(&pb, &product, sizeof(float));
+    if (!vfp_f32_normalized(pb))
+        return false;
+
+    if (negate & NEG_MULTIPLY)
+        product = -product;
+    if (negate & NEG_SUBTRACT)
+        fa = -fa;
+
+    const float result = fa + product;
+    std::memcpy(&rb, &result, sizeof(float));
+    return vfp_f32_normalized(rb);
+}
+
 std::uint32_t vfp_single_cpdo(ARMul_State *state, std::uint32_t inst, std::uint32_t fpscr) {
     std::uint32_t op = inst & FOP_MASK;
     std::uint32_t exceptions = 0;
@@ -1261,13 +1363,79 @@ std::uint32_t vfp_single_cpdo(ARMul_State *state, std::uint32_t inst, std::uint3
     else
         veclen = fpscr & FPSCR_LENGTH_MASK;
 
-    LOG_TRACE(eka2l1::CPU_DYNCOM, "vecstride={} veclen={}", vecstride, (veclen >> FPSCR_LENGTH_BIT) + 1);
+    VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "vecstride={} veclen={}", vecstride, (veclen >> FPSCR_LENGTH_BIT) + 1);
 
     if (!fop->fn) {
         LOG_CRITICAL(eka2l1::CPU_DYNCOM, "could not find single op {}, inst=0x{:x}@0x{:x}",
             FEXT_TO_IDX(inst), inst, state->Reg[15]);
         //Crash();
         goto invalid;
+    }
+
+    // Host-float fast path (see vfp_f32_normalized comment above).
+    if (g_vfp_host_fast && veclen == 0 && op != FOP_EXT
+        && (fpscr & (FPSCR_RMODE_MASK | FPSCR_FLUSH_TO_ZERO | FPSCR_DEFAULT_NAN
+               | FPSCR_IDE | FPSCR_IXE | FPSCR_UFE | FPSCR_OFE | FPSCR_DZE | FPSCR_IOE)) == 0) {
+        const std::int32_t nb = state->ExtReg[sn];
+        const std::int32_t mb = state->ExtReg[sm];
+        if (vfp_f32_normalized(nb) && vfp_f32_normalized(mb)) {
+            float fn, fm, fr = 0.0f;
+            std::memcpy(&fn, &nb, sizeof(float));
+            std::memcpy(&fm, &mb, sizeof(float));
+            bool handled = true;
+            if (fop->fn == vfp_single_fadd)
+                fr = fn + fm;
+            else if (fop->fn == vfp_single_fsub)
+                fr = fn - fm;
+            else if (fop->fn == vfp_single_fmul)
+                fr = fn * fm;
+            else if (fop->fn == vfp_single_fdiv)
+                fr = fn / fm;
+            else if (fop->fn == vfp_single_fmac || fop->fn == vfp_single_fnmac
+                || fop->fn == vfp_single_fmsc || fop->fn == vfp_single_fnmsc) {
+                const std::int32_t ab = state->ExtReg[dest];
+                if (!vfp_f32_normalized(ab)) {
+                    handled = false;
+                } else {
+                    std::uint32_t negate = 0;
+                    if (fop->fn == vfp_single_fmac)
+                        negate = 0;
+                    else if (fop->fn == vfp_single_fnmac)
+                        negate = NEG_MULTIPLY;
+                    else if (fop->fn == vfp_single_fmsc)
+                        negate = NEG_SUBTRACT;
+                    else
+                        negate = NEG_MULTIPLY | NEG_SUBTRACT;
+
+                    std::int32_t rb;
+                    if (vfp_host_f32_mac(nb, mb, ab, negate, rb)) {
+                        state->ExtReg[dest] = rb;
+#if defined(EKA2L1_DYNCOM_DIFFTEST)
+                        ++g_vfp_host_fast_hits;
+#endif
+                        return 0;
+                    }
+                    handled = false;
+                }
+            } else {
+                handled = false;
+            }
+
+            if (handled) {
+                std::int32_t rb;
+                std::memcpy(&rb, &fr, sizeof(float));
+                // Only commit when the result is also normalized -- otherwise the
+                // reference would set overflow/underflow/inexact + apply FZ, which
+                // we don't replicate here.
+                if (vfp_f32_normalized(rb)) {
+                    state->ExtReg[dest] = rb;
+#if defined(EKA2L1_DYNCOM_DIFFTEST)
+                    ++g_vfp_host_fast_hits;
+#endif
+                    return 0;
+                }
+            }
+        }
     }
 
     for (vecitr = 0; vecitr <= veclen; vecitr += 1 << FPSCR_LENGTH_BIT) {
@@ -1277,14 +1445,14 @@ std::uint32_t vfp_single_cpdo(ARMul_State *state, std::uint32_t inst, std::uint3
 
         type = (fop->flags & OP_DD) ? 'd' : 's';
         if (op == FOP_EXT)
-            LOG_TRACE(eka2l1::CPU_DYNCOM, "itr{} ({}{}) = op[{}] (s{}={:08x})", vecitr >> FPSCR_LENGTH_BIT,
+            VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "itr{} ({}{}) = op[{}] (s{}={:08x})", vecitr >> FPSCR_LENGTH_BIT,
                 type, dest, sn, sm, m);
         else
-            LOG_TRACE(eka2l1::CPU_DYNCOM, "itr{} ({}{}) = (s{}) op[{}] (s{}={:08x})",
+            VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "itr{} ({}{}) = (s{}) op[{}] (s{}={:08x})",
                 vecitr >> FPSCR_LENGTH_BIT, type, dest, sn, FOP_TO_IDX(op), sm, m);
 
         except = fop->fn(state, dest, sn, m, fpscr);
-        LOG_TRACE(eka2l1::CPU_DYNCOM, "itr{}: exceptions={:08x}", vecitr >> FPSCR_LENGTH_BIT, except);
+        VFP_LOG_TRACE(eka2l1::CPU_DYNCOM, "itr{}: exceptions={:08x}", vecitr >> FPSCR_LENGTH_BIT, except);
 
         exceptions |= except & ~VFP_NAN_FLAG;
 

--- a/src/emu/kernel/src/scheduler.cpp
+++ b/src/emu/kernel/src/scheduler.cpp
@@ -116,8 +116,9 @@ namespace eka2l1::kernel {
 
                 run_core->flush_tlb();
 
-                // NOTE: This is not needed now
-                //run_core->set_asid(mm_process->address_space_id());
+                // Let the core tag its translation cache with the new address
+                // space so blocks survive this switch instead of being discarded.
+                run_core->set_asid(mm_process->address_space_id());
             }
 
             run_core->load_context(crr_thread->ctx);

--- a/src/emu/mem/src/mmu.cpp
+++ b/src/emu/mem/src/mmu.cpp
@@ -237,14 +237,22 @@ namespace eka2l1::mem {
     }
 
     bool mmu_base::read_code(const vm_address addr, std::uint32_t *data) {
-        std::uint32_t *code = reinterpret_cast<std::uint32_t *>(manager_->get_host_pointer(
-            current_addr_space(), addr));
-
-        if (!code) {
+        // Mirror the data readers: resolve via page_info and seed the CPU TLB so
+        // repeated fetches from the same code page (block translation, runtime
+        // re-reads) skip the page-directory walk. The TLB caches the host page
+        // pointer, not the instruction word, so reads stay current; SMC still
+        // invalidates the entry through make_dirty / imb_range.
+        page_info *inf = manager_->get_page_info(current_addr_space(), addr);
+        if (!inf || !inf->host_addr) {
             return false;
         }
 
-        *data = *code;
+        *data = *reinterpret_cast<std::uint32_t *>(
+            reinterpret_cast<std::uint8_t *>(inf->host_addr) + (addr & manager_->offset_mask_));
+
+        cpu_->set_tlb_page(addr & ~manager_->offset_mask_, reinterpret_cast<std::uint8_t *>(inf->host_addr),
+            inf->perm);
+
         return true;
     }
 }


### PR DESCRIPTION
On iOS dyncom is the production CPU backend, not just dynarmic's fallback — the
App Store sandbox never grants a JIT the right to map executable memory, so the
interpreter's cost is the frame budget. This is profiling that path and removing
what showed up, plus a differential test that keeps it honest. All of it is in
shared CPU code.

## Interpreter

**Translation cache**

- **Tag the block cache by ASID.** It was wiped on every context switch, so
  IPC-heavy guests re-decoded their hot loop after each round trip —
  `decode_arm_instruction` was ~17% of the CPU thread. Keyed by
  `(asid << 32) | vpc` it survives switches; the scheduler feeds the asid
  through the previously stubbed-out `core::set_asid()` hook. The dyncom
  instance embedded inside dynarmic never gets an asid and keeps the old
  behaviour, so that backend is unaffected.
- **A 2048-entry direct-mapped L1** in front of the block map's `unordered_map`,
  which DISPATCH hits on every taken branch.

**Memory path**

- **Route `ReadCode` through the TLB** — it was the only accessor still
  page-walking every fetch. Self-time ~90 → ~22 samples.
- **Inline the TLB-hit case** of `Read/WriteMemory8/16/32/64`, slow path moved
  out of line. `ReadMemory32` ~161 → ~7, `WriteMemory32` ~112 → ~2.
- **A page cursor for LDM/STM**, so a register-list transfer resolves the host
  page once instead of once per register.

**Hot handlers** — these were paying an indirect call per instruction:

- **Inline `AddWithCarry`** (every ADD/ADC/SUB/SBC/RSB/RSC/CMP/CMN).
- **Inline the dominant forms of `get_addr` / `shtop_func`** at their call
  sites, behind one well-predicted pointer compare; other addressing modes and
  shifter forms still go through the pointer. These are the two hottest
  instruction classes and the pointers are polymorphic at the shared call sites,
  so they mispredict. Same-binary A/B on Snakes: ~37.3 → ~39.5 FPS for the
  load/store path, a further ~38.4 → ~40.3 for the shifter.
- **A second pass for Thumb-heavy titles**: Thumb `ADD` no longer re-reads guest
  code to spot ADR unless Rn is the PC, `CondPassed` becomes a force-inlined
  16×16 table lookup, the fast paths extend to the register forms, register-list
  counting uses popcount. Brothers in Arms 36 → 38 FPS.
- **Translation-time bulk acceleration for guest copy loops.** Brothers in Arms
  spends 14% of gameplay in one per-pixel RGB565→32bpp loop inside its own
  engine, out of reach of any export-level HLE. When a translated Thumb block is
  a single-block do-while loop of a canonical shape, a symbolic one-iteration
  simulation proves it at translation time and a synthetic instruction runs the
  bulk natively through the TLB. The last iteration is always interpreted, so
  flags and the loop exit come from real interpretation, and a TLB miss hands
  the remainder back, preserving fault semantics. 38 → 40 FPS, the game's cap.

**VFP**

- **Host-float fast path for single/double arithmetic.** In the common envelope
  (scalar op, default FPSCR mode, normalized finite operands *and* result) a
  native IEEE-754 op is the unique correctly-rounded answer, i.e. bit-identical
  to the softfloat reference at a fraction of the cost. Everything else falls
  back untouched. It does not raise the INEXACT cumulative flag.
- **Fix VMLA/VMLS** — they are *chained* multiply-accumulates, not fused
  (`FPAdd(S[d], FPMul(S[n], S[m]))`; VFMA arrived in VFPv4), but dyncom carried
  the multiply's extra significand bits into the add. So a value minus itself
  wasn't zero: `vmul.f32 s8,s9,s10` then `vmls.f32 s8,s9,s10` left a sub-ulp
  residue where the architecture requires exactly +0. Rounding the product first
  also makes the fast path *simpler and faster* — the result is then exactly two
  correctly-rounded host ops, 2.63ms → 2.10ms on the harness microbenchmark.
- **Make `EKA2L1_DYNCOM_VFP_TRACE` work.** The option exists on master but no
  source consumes the macro, so one synchronously flushed log line per float
  loaded, stored, packed or rounded stayed compiled in everywhere.

## Differential test

`scripts/cpu_difftest.sh`, `EKA2L1_BUILD_DYNCOM_DIFFTEST` default OFF, added to
CI as a gating job.

- **Phase 1** — randomized single ARM instructions through dyncom, diffed
  against an independently written golden ALU model.
- **Phase 2** — randomized *whole programs* on both dyncom and dynarmic,
  comparing 16 registers, CPSR, 32 VFP registers, FPSCR and a data window. Five
  suites: **cold** (instruction semantics, LDM/STM straddling a page), **arena**
  (24 programs 2048 bytes apart so their entry blocks collide in the same L1
  slot, run shuffled with warm caches), **asid** (one virtual address backed by
  different code in two address spaces; dynarmic is flushed at every switch and
  is the ground truth), **loops** (the accelerator's canonical shapes, run to
  completion), **vfp**.
- **Guards**, because a green run has to be able to go red: dynarmic must not
  have fallen back to its embedded dyncom, no guest exception may be raised, and
  the run fails if the loop accelerator never attached. Divergences are reduced
  automatically by re-running growing prefixes to find the first differing
  instruction.

Mutation-tested — one realistic bug injected per optimization above, all
detected. The VMLA/VMLS bug was found this way; a phase-1-only harness could not
have found it, since its VFP check compared dyncom's fast path against dyncom's
own softfloat and both were wrong the same way.

## Verification

- `dyncom_difftest` passes on three seeds: 20000 single-instruction cases and
  544 programs each.
- `ekatests` 118/118 on a desktop (dynarmic-enabled) Release build.
- GCC/clang builtins picked up along the way are replaced with C++20
  equivalents, since dyncom is compiled on MSVC too. I can only build Apple
  platforms locally, so that part is review-by-inspection plus CI.
- Only two files outside `src/emu/cpu/`: one line in `scheduler.cpp` for the
  asid hook, ~13 in `mmu.cpp` to seed the TLB from `read_code`.
