### PR TITLE
cpu/dyncom: report instructions the interpreter cannot execute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ out
 .metadata
 cmake-build-*
 .idea
+
+# Emulator log written by any binary that calls log::setup_log (including the
+# dyncom differential test harness).
+EKA2L1.log
+EKA2L1_TakeThis.log

--- a/src/emu/cpu/src/dyncom/arm_dyncom_interpreter.cpp
+++ b/src/emu/cpu/src/dyncom/arm_dyncom_interpreter.cpp
@@ -1264,8 +1264,11 @@ static void LnSWoUB(ImmediateOffset)(ARMul_State *cpu, unsigned int inst, unsign
                 CHECK_READ_REG15_WA(cpu, BITS(ls_inst_, 0, 3));                      \
             (addr_out) = BIT(ls_inst_, 23) ? (ls_base_ + ls_off_)                    \
                                            : (ls_base_ - ls_off_);                   \
-        } else {                                                                     \
+        } else if (inst_cream->get_addr) {                                           \
             inst_cream->get_addr(cpu, inst_cream->inst, (addr_out));                 \
+        } else {                                                                     \
+            undef_inst = inst_cream->inst;                                           \
+            goto UNDEFINED_ADDRESSING_MODE;                                          \
         }                                                                            \
     } while (0)
 
@@ -1290,8 +1293,11 @@ static void LnSWoUB(ImmediateOffset)(ARMul_State *cpu, unsigned int inst, unsign
                 CHECK_READ_REG15_WA(cpu, BITS(ls_inst_, 0, 3));                      \
             (addr_out) = BIT(ls_inst_, 23) ? (ls_base_ + ls_off_)                    \
                                            : (ls_base_ - ls_off_);                   \
-        } else {                                                                     \
+        } else if (inst_cream->get_addr) {                                           \
             inst_cream->get_addr(cpu, inst_cream->inst, (addr_out));                 \
+        } else {                                                                     \
+            undef_inst = inst_cream->inst;                                           \
+            goto UNDEFINED_ADDRESSING_MODE;                                          \
         }                                                                            \
     } while (0)
 
@@ -1843,7 +1849,9 @@ static unsigned int InterpreterTranslateInstruction(ARMul_State *cpu, const std:
             inst);
         LOG_ERROR(eka2l1::CPU_DYNCOM, "cpsr={:#X}, cpu->TFlag={}, r15={:#010X}", cpu->Cpsr, cpu->TFlag,
             cpu->Reg[15]);
-        CITRA_IGNORE_EXIT(-1);
+        cpu->RaiseException(eka2l1::arm::exception_type_undefined_inst, phys_addr);
+        inst_base = nullptr;
+        return 0;
     }
     inst_base = arm_instruction_trans[idx](cpu, inst, idx);
 
@@ -1886,6 +1894,10 @@ static int InterpreterTranslateBlock(ARMul_State *cpu, std::size_t &bb_start, st
     while (ret == TransExtData::NON_BRANCH) {
         unsigned int inst_size = InterpreterTranslateInstruction(cpu, phys_addr, inst_base);
 
+        if (!inst_base) {
+            return FETCH_EXCEPTION;
+        }
+
         size++;
 
         phys_addr += inst_size;
@@ -1909,6 +1921,10 @@ static int InterpreterTranslateSingle(ARMul_State *cpu, std::size_t &bb_start, s
     std::uint32_t pc_start = cpu->Reg[15];
 
     InterpreterTranslateInstruction(cpu, phys_addr, inst_base);
+
+    if (!inst_base) {
+        return FETCH_EXCEPTION;
+    }
 
     if (inst_base->br == TransExtData::NON_BRANCH) {
         inst_base->br = TransExtData::SINGLE_STEP;
@@ -2638,6 +2654,7 @@ unsigned InterpreterMainLoop(ARMul_State *cpu, std::uint32_t &num_instrs) {
 #endif
     arm_inst *inst_base;
     unsigned int addr;
+    unsigned int undef_inst = 0;
 
     std::size_t ptr;
 
@@ -5635,6 +5652,22 @@ YIELD_INST : {
 #define VFP_INTERPRETER_IMPL
 #include <cpu/dyncom/vfp/vfpinstr.h>
 #undef VFP_INTERPRETER_IMPL
+
+UNDEFINED_ADDRESSING_MODE : {
+    // GetAddressingOp() has no entry for this encoding, so the translator stored
+    // a null addressing function. That means the guest is running an undefined
+    // or unpredictable load/store form (data executed as code, for instance).
+    // Report it as an undefined instruction: calling through the null pointer
+    // would take the host process down instead of the offending guest thread.
+    LOG_ERROR(eka2l1::CPU_DYNCOM, "Undefined load/store addressing mode (instruction 0x{:08X}) at 0x{:08X}",
+        undef_inst, cpu->Reg[15]);
+
+    SAVE_NZCVT;
+    cpu->RaiseException(eka2l1::arm::exception_type_undefined_inst, cpu->Reg[15]);
+    cpu->NumInstrsToExecute = 0;
+
+    return num_instrs;
+}
 
 END : {
     SAVE_NZCVT;

--- a/src/emu/cpu/src/dyncom/arm_dyncom_thumb.cpp
+++ b/src/emu/cpu/src/dyncom/arm_dyncom_thumb.cpp
@@ -258,9 +258,11 @@ ThumbDecodeStatus TranslateThumbInstruction(std::uint32_t addr, std::uint32_t in
                               : 0xE28DDF00) // ADD
                 | (tinstr & 0x007F); // off7
         } else if ((tinstr & 0x0F00) == 0x0e00) {
-            // BKPT
-            *ainstr = 0xEF000000 // base
-                | BITS(tinstr, 0, 3) // imm4 field;
+            // BKPT. 0xEF000000 is SVC, not BKPT: a guest breakpoint was being
+            // translated into a system call, so it entered the SVC handler
+            // instead of ever reaching the breakpoint exception.
+            *ainstr = 0xE1200070 // BKPT
+                | BITS(tinstr, 0, 3) // imm4 field
                 | (BITS(tinstr, 4, 7) << 8); // beginning 4 bits of imm12
         } else if ((tinstr & 0x0F00) == 0x0200) {
             static const std::uint32_t subset[4] = {

--- a/src/emu/cpu/src/dyncom/tests/dyncom_difftest.cpp
+++ b/src/emu/cpu/src/dyncom/tests/dyncom_difftest.cpp
@@ -28,6 +28,7 @@
 #include <cpu/dyncom/vfp/vfp.h>
 #include <cpu/12l1r/exclusive_monitor.h>
 
+#include <common/log.h>
 #include <common/types.h>
 
 #include <bit>
@@ -907,6 +908,7 @@ struct backend_env {
     std::uint64_t exceptions = 0;
     exception_type last_exception = exception_type_unk;
     std::uint32_t last_exception_pc = 0;
+    std::uint64_t syscalls = 0;
 
     backend_env()
         : mem(ARENA_MEM_SIZE, 0) {
@@ -968,7 +970,7 @@ void wire_backend(backend_env &e) {
         ep->last_exception_pc = pc;
         return false;
     };
-    cp->system_call_handler = [](const std::uint32_t) {};
+    cp->system_call_handler = [ep](const std::uint32_t) { ep->syscalls++; };
 }
 
 std::unique_ptr<backend_env> make_dyncom_env() {
@@ -1718,6 +1720,99 @@ std::uint32_t check_vfp_mac_cancellation(backend_env &dc, backend_env &da) {
     return 1;
 }
 
+// ---------------------------------------------------------------------------
+// Instructions dyncom cannot execute must become guest exceptions
+// ---------------------------------------------------------------------------
+// A guest that jumps into data executes whatever the bytes decode to. Three of
+// those paths used to end somewhere other than a guest exception:
+//
+//  * GetAddressingOp() covers fewer encodings than the ldr/str and misc
+//    load/store decode patterns accept, and returns null for the rest. The
+//    handlers called through that pointer -- host death at pc = 0, with the
+//    guest instruction still sitting in an argument register.
+//  * decode_arm_instruction() failure left `idx` uninitialised and the
+//    translator indexed arm_instruction_trans[] with it.
+//  * Thumb BKPT was translated to 0xEF000000, which is SVC. A guest breakpoint
+//    entered the system-call handler and never raised a breakpoint exception.
+//
+// dynarmic is not an oracle here: what a backend does with an UNPREDICTABLE or
+// unallocated encoding is its own business. The assertion is only that dyncom
+// reports it to the guest instead of acting on it.
+
+struct undef_case {
+    const char *name;
+    std::uint32_t inst; // ARM encoding, or Thumb halfword when `thumb`
+    bool thumb;
+    bool cond_hi;       // prefix with a compare that makes cond = HI pass
+    exception_type want;
+    const char *why;
+};
+
+std::uint32_t check_undefined_instructions(backend_env &dc) {
+    // The ARM cases are unconditional so that no flag setup is needed, except
+    // the first: that one is the exact instruction from the crash report, and
+    // it carries cond = HI.
+    static const undef_case cases[] = {
+        { "mls-null-addr-field", 0x80A3EEF8u, false, true, exception_type_undefined_inst,
+            "post-indexed STRD with write-back (BITS(21,22) == 1), the encoding that "
+            "killed the host in the field" },
+        { "mls-null-addr", 0xE02000B0u, false, false, exception_type_undefined_inst,
+            "post-indexed STRH with write-back" },
+        { "ls-null-addr", 0xE6000010u, false, false, exception_type_undefined_inst,
+            "media-space encoding the STR decode pattern accepts because it does not "
+            "exclude bit 4" },
+        { "undecodable", 0xE0500090u, false, false, exception_type_undefined_inst,
+            "unallocated encoding in the multiply space" },
+        { "thumb-bkpt", 0x0000BEABu, true, false, exception_type_breakpoint,
+            "Thumb BKPT #0xAB" },
+    };
+
+    std::uint32_t failures = 0;
+    for (const undef_case &c : cases) {
+        program p;
+        p.addr = PROG_CODE_LO;
+        p.thumb = c.thumb;
+        p.kind = c.name;
+        p.budget = 64;
+
+        if (c.cond_hi) {
+            p.init[0] = 1;
+            p.init[1] = 2;
+            push32(p.code, 0xE1510000u); // cmp r1, r0 -> C set, Z clear, so HI passes
+        }
+        if (c.thumb) {
+            push16(p.code, static_cast<std::uint16_t>(c.inst));
+            push16(p.code, 0xE7FEu); // b .
+        } else {
+            push32(p.code, c.inst);
+            push32(p.code, 0xEAFFFFFEu); // b .
+        }
+
+        install(dc, p);
+        dc.cpu->clear_instruction_cache();
+        dc.cpu->imb_range(p.addr, p.code.size());
+        dc.exceptions = 0;
+        dc.syscalls = 0;
+        dc.last_exception = exception_type_unk;
+
+        // Reaching the next line at all is half the assertion: unfixed, three
+        // of these cases branch through a null or garbage function pointer.
+        execute(dc, p);
+
+        if (dc.exceptions == 1 && dc.last_exception == c.want && dc.syscalls == 0) {
+            continue;
+        }
+        std::printf("[DIVERGENCE] %s: %s should raise exception %d, got %llu exception(s) "
+                    "(last = %d) and %llu system call(s)\n",
+            c.name, c.why, static_cast<int>(c.want),
+            static_cast<unsigned long long>(dc.exceptions),
+            static_cast<int>(dc.last_exception),
+            static_cast<unsigned long long>(dc.syscalls));
+        failures++;
+    }
+    return failures;
+}
+
 // VFP: the host-float fast path against dynarmic's own VFP implementation.
 std::uint32_t suite_vfp(backend_env &dc, backend_env &da, std::uint32_t base_seed,
     std::uint32_t count, coverage &cov) {
@@ -1763,6 +1858,15 @@ std::uint32_t suite_vfp(backend_env &dc, backend_env &da, std::uint32_t base_see
 } // namespace
 
 int main(int argc, char **argv) {
+    // Without this every LOG_* in the code under test dereferences a null
+    // `log::filterings` (the non-scripting COND_CHECK does not guard it), so
+    // any interpreter path that logs would take the harness down instead of
+    // reporting. Diagnostics are then muted, because the cases below execute
+    // instructions the interpreter is *expected* to complain about; the harness
+    // prints its own message when one of them fails.
+    eka2l1::log::setup_log(nullptr);
+    eka2l1::log::filterings->reset_all(spdlog::level::critical);
+
     std::uint32_t base_seed = 1;
     std::uint32_t count = 200000;
     if (argc > 1) base_seed = static_cast<std::uint32_t>(std::strtoul(argv[1], nullptr, 0));
@@ -1893,6 +1997,7 @@ int main(int argc, char **argv) {
         { "vfp   ", suite_vfp(*dc, *da, base_seed, programs / 2 + 4, cov) },
     };
     failures += check_vfp_mac_cancellation(*dc, *da);
+    failures += check_undefined_instructions(*dc);
     for (const suite_result &sr : results) {
         std::printf("  %s %s\n", sr.name, sr.failures ? "FAIL" : "ok");
         failures += sr.failures;
@@ -1922,7 +2027,8 @@ int main(int argc, char **argv) {
 
     if (failures == 0) {
         std::printf("dyncom_difftest: PASS (%u single-instruction cases vs golden, "
-                    "%llu programs vs dynarmic, VFP soft/host A/B, negative control)\n",
+                    "%llu programs vs dynarmic, VFP soft/host A/B, undefined-instruction "
+                    "reporting, negative control)\n",
             count, static_cast<unsigned long long>(cov.programs));
         return 0;
     }


### PR DESCRIPTION
A guest that jumps into data executes whatever the bytes decode to. Three of
those paths ended somewhere other than a guest exception:

- **Null addressing function.** `GetAddressingOp()` covers fewer encodings than
  the ldr/str and misc load/store decode patterns accept, and returns `nullptr`
  for the rest — which the handlers then called. A post-indexed `STRD` with
  write-back (`0x80A3EEF8`, UNPREDICTABLE) killed an iOS build with
  `EXC_BAD_ACCESS` at `pc = 0`. `LS_GET_ADDR` needs the same guard, since the
  ldr/str decode patterns do not exclude bit 4 and media-space encodings reach
  `GetAddressingOp()` too. Both now raise `exception_type_undefined_inst`, with
  the instruction and the guest PC logged.
- **Decode failure.** `decode_arm_instruction()` failing left `idx`
  uninitialised, and `arm_instruction_trans[]` was indexed with it. It now
  raises the same exception and stops translating the block; the main loop's
  `FETCH_EXCEPTION` path was unreachable before this.
- **Thumb `BKPT`.** Translated to `0xEF000000`, which is `SVC` — a guest
  breakpoint entered the system-call handler and never raised a breakpoint
  exception.

Five cases in `dyncom_difftest`, one per path plus the encoding from the crash
report, so the `dyncom-difftest` job added by #604 gates them. The harness also
has to call `log::setup_log()` now: without scripting enabled `COND_CHECK` does
not guard `log::filterings`, so any path under test that logs took the harness
down with a null dereference — which is why nothing had reached these paths
before.

Reverting each fix on its own, seed 1:

| reverted | result |
|---|---|
| `LS_GET_ADDR` guard | SIGSEGV during `ls-null-addr` |
| `MLS_GET_ADDR` guard | SIGSEGV during `mls-null-addr-field` |
| translate-failure exit | `undecodable` fails: 0 exceptions raised (the uninitialised index is undefined behaviour, so a crash is luck rather than a guarantee) |
| Thumb `BKPT` encoding | `thumb-bkpt` fails: 0 exceptions, 1 system call |
| harness `log::setup_log()` | SIGSEGV inside the fix's own `LOG_ERROR` |

All six CI jobs are green on the fork, MSVC and iOS included.
