### PR TITLE
ci: Run the unit tests under ASan and UBSan, and fix what that found

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -335,22 +335,77 @@ jobs:
     - name: Run the dyncom differential test
       run: ./scripts/cpu_difftest.sh 1 20000
 
+  sanitisers:
+    name: sanitisers
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up build environment
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install build-essential clang libc6-dev libgtk-3-dev \
+          libpulse-dev libasound2-dev libsdl2-dev qt6-base-dev \
+          qt6-base-private-dev qt6-tools-dev qt6-tools-dev-tools \
+          qt6-l10n-tools libqt6svg6-dev
+
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    # Its own build directory, like the difftest job: the sanitisers change code
+    # generation everywhere, so this tree must not be shared with the jobs that
+    # publish artifacts. XZ_SANDBOX=no is xz's own instruction when it sees
+    # -fsanitize=: its Landlock sandbox and the sanitisers cannot both be on.
+    #
+    # Every C source in this tree is vendored -- the emulator itself is C++ -- and
+    # some of those libraries read unaligned on purpose: miniz turns on
+    # MINIZ_USE_UNALIGNED_LOADS_AND_STORES for x86, which is what CI runs on. So
+    # the alignment check is dropped for C, and kept everywhere it can find one of
+    # our own bugs.
+    - name: CMake configure
+      env:
+        CC: clang
+        CXX: clang++
+        SANITISER_FLAGS: -fsanitize=address,undefined -fno-omit-frame-pointer
+      run: >
+        cmake -B build-sanitisers -DCI=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        -DEKA2L1_ENABLE_SCRIPTING_ABILITY=OFF -DXZ_SANDBOX=no
+        -DCMAKE_C_FLAGS="$SANITISER_FLAGS -fno-sanitize=alignment"
+        -DCMAKE_CXX_FLAGS="$SANITISER_FLAGS"
+        -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined"
+
+    - name: Build the unit tests
+      run: cmake --build build-sanitisers --parallel 4 --target ekatests
+
+    # halt_on_error makes an undefined-behaviour report fail the job; without it
+    # UBSan only prints and the test still passes. Leak detection stays off for
+    # now: the suite exits with objects the emulator never frees on purpose, and
+    # sorting those out is a separate piece of work from catching memory errors
+    # and undefined behaviour.
+    - name: Run the unit tests under the sanitisers
+      env:
+        ASAN_OPTIONS: detect_leaks=0
+        UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+      run: ctest --test-dir build-sanitisers --output-on-failure
+
   ci:
     name: CI
-    needs: [build-android, build-desktop, build-ios, dyncom-difftest]
+    needs: [build-android, build-desktop, build-ios, dyncom-difftest, sanitisers]
     if: always()
     runs-on: ubuntu-latest
     steps:
     - name: Check the build and test jobs
       run: |
-        echo "android:  ${{ needs.build-android.result }}"
-        echo "desktop:  ${{ needs.build-desktop.result }}"
-        echo "ios:      ${{ needs.build-ios.result }}"
-        echo "difftest: ${{ needs.dyncom-difftest.result }}"
+        echo "android:    ${{ needs.build-android.result }}"
+        echo "desktop:    ${{ needs.build-desktop.result }}"
+        echo "ios:        ${{ needs.build-ios.result }}"
+        echo "difftest:   ${{ needs.dyncom-difftest.result }}"
+        echo "sanitisers: ${{ needs.sanitisers.result }}"
         if [ "${{ needs.build-android.result }}" != "success" ] || \
            [ "${{ needs.build-desktop.result }}" != "success" ] || \
            [ "${{ needs.build-ios.result }}" != "success" ] || \
-           [ "${{ needs.dyncom-difftest.result }}" != "success" ]; then
+           [ "${{ needs.dyncom-difftest.result }}" != "success" ] || \
+           [ "${{ needs.sanitisers.result }}" != "success" ]; then
           echo "::error::A build or test job did not pass"
           exit 1
         fi

--- a/src/emu/common/include/common/chunkyseri.h
+++ b/src/emu/common/include/common/chunkyseri.h
@@ -68,6 +68,10 @@ namespace eka2l1::common {
         std::uint8_t *org;
         std::uint8_t *end;
 
+        // Measure mode has no buffer to walk: it is handed a null pointer, and
+        // advancing that is undefined behaviour rather than a way to count.
+        std::size_t measured = 0;
+
         chunkyseri_mode mode;
 
         bool do_marker(const std::string &name, std::uint16_t cookie = 0x18);
@@ -77,11 +81,11 @@ namespace eka2l1::common {
             : buf(buf)
             , org(buf)
             , mode(mode)
-            , end(org + max) {
+            , end(buf ? buf + max : nullptr) {
         }
 
         std::size_t size() {
-            return buf - org;
+            return (mode == SERI_MODE_MEASURE) ? measured : static_cast<std::size_t>(buf - org);
         }
 
         std::size_t left() {
@@ -97,6 +101,15 @@ namespace eka2l1::common {
         }
 
         bool backwards(std::size_t len_back) {
+            if (mode == SERI_MODE_MEASURE) {
+                if (len_back > measured) {
+                    return false;
+                }
+
+                measured -= len_back;
+                return true;
+            }
+
             if (buf - len_back < org) {
                 return false;
             }

--- a/src/emu/common/include/common/pystr.h
+++ b/src/emu/common/include/common/pystr.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 #include <string>
 #include <vector>

--- a/src/emu/common/src/allocator.cpp
+++ b/src/emu/common/src/allocator.cpp
@@ -168,7 +168,10 @@ namespace eka2l1::common {
             mask = 0xFFFFFFFFU;
             end_bit -= 32;
 
-            if (end_bit < 32) {
+            // Only a positive remainder describes a partial last word. A negative
+            // one would shift by more than 32 bits, and the loop is about to end
+            // with the mask unused anyway.
+            if ((end_bit > 0) && (end_bit < 32)) {
                 mask = ~(mask >> static_cast<std::uint32_t>(end_bit));
             }
         }

--- a/src/emu/common/src/chunkyseri.cpp
+++ b/src/emu/common/src/chunkyseri.cpp
@@ -27,14 +27,16 @@
 
 namespace eka2l1::common {
     void chunkyseri::absorb_impl(std::uint8_t *dat, const std::size_t s) {
-        if (buf + s > end && mode != SERI_MODE_MEASURE) {
+        if (mode == SERI_MODE_MEASURE) {
+            measured += s;
+            return;
+        }
+
+        if (buf + s > end) {
             return;
         }
 
         switch (mode) {
-        case SERI_MODE_MEASURE:
-            break;
-
         case SERI_MODE_WRITE: {
             if (dat)
                 memcpy(reinterpret_cast<void *>(buf), reinterpret_cast<const void *>(dat), s);
@@ -57,10 +59,12 @@ namespace eka2l1::common {
     }
 
     bool chunkyseri::expect(const std::uint8_t *dat, const std::size_t s) {
-        switch (mode) {
-        case SERI_MODE_MEASURE:
-            break;
+        if (mode == SERI_MODE_MEASURE) {
+            measured += s;
+            return true;
+        }
 
+        switch (mode) {
         case SERI_MODE_WRITE: {
             memcpy(reinterpret_cast<void *>(buf), reinterpret_cast<const void *>(dat), s);
             break;

--- a/src/emu/kernel/src/libmanager.cpp
+++ b/src/emu/kernel/src/libmanager.cpp
@@ -666,7 +666,9 @@ namespace eka2l1::hle {
 
     drive_number lib_manager::get_drive_rom() {
         if (rom_drv_ == drive_invalid) {
-            for (drive_number drv = drive_z; drv >= drive_a; drv = static_cast<drive_number>(static_cast<int>(drv) - 1)) {
+            // Stepping one below drive_a would leave the enum's value range.
+            for (int drv_index = drive_z; drv_index >= drive_a; drv_index--) {
+                const drive_number drv = static_cast<drive_number>(drv_index);
                 if (auto ent = io_->get_drive_entry(drv)) {
                     if (ent->media_type == drive_media::rom) {
                         rom_drv_ = drv;

--- a/src/emu/mem/src/model/flexible/pagearray.cpp
+++ b/src/emu/mem/src/model/flexible/pagearray.cpp
@@ -108,7 +108,7 @@ namespace eka2l1::mem::flexible {
             }
         }
 
-        delete segments_;
+        delete[] segments_;
     }
 
     void page_array::alter(const std::uint32_t index, const std::uint32_t count, const prot perm, const bool is_clear) {

--- a/src/emu/package/src/manager.cpp
+++ b/src/emu/package/src/manager.cpp
@@ -74,7 +74,9 @@ namespace eka2l1 {
         void packages::install_sis_stubs() {
             static constexpr const char16_t *STUB_SIS_DIRECTORY = u"{}:\\system\\install\\";
 
-            for (drive_number drv = drive_z; drv >= drive_a; drv--) {
+            // Stepping one below drive_a would leave the enum's value range.
+            for (int drv_index = drive_z; drv_index >= drive_a; drv_index--) {
+                const drive_number drv = static_cast<drive_number>(drv_index);
                 if (sys->get_drive_entry(drv)) {
                     const std::u16string stub_directory = fmt::format(STUB_SIS_DIRECTORY, drive_to_char16(drv));
                     std::unique_ptr<directory> stub_dir_iterator = sys->open_dir(stub_directory, {}, io_attrib_include_file);

--- a/src/emu/services/src/applist/applist.cpp
+++ b/src/emu/services/src/applist/applist.cpp
@@ -516,7 +516,9 @@ namespace eka2l1 {
         std::atomic_bool global_modified = false;
 
         if (avail_drives_ == 0) {
-            for (drive_number drv = drive_z; drv >= drive_a; drv--) {
+            // Stepping one below drive_a would leave the enum's value range.
+            for (int drv_index = drive_z; drv_index >= drive_a; drv_index--) {
+                const drive_number drv = static_cast<drive_number>(drv_index);
                 if (io->get_drive_entry(drv)) {
                     avail_drives_ |= 1 << (drv - drive_a);
                 }

--- a/src/emu/services/src/fbs/impls/font.cpp
+++ b/src/emu/services/src/fbs/impls/font.cpp
@@ -1217,7 +1217,9 @@ namespace eka2l1 {
     // Linked typefaces are assembled once every font is in the store: their
     // components can sit on a different drive than the link.ini naming them.
     void fbs_server::load_linked_fonts(eka2l1::io_system *io) {
-        for (drive_number drv = drive_z; drv >= drive_a; drv = static_cast<drive_number>(static_cast<int>(drv) - 1)) {
+        // Stepping one below drive_a would leave the enum's value range.
+        for (int drv_index = drive_z; drv_index >= drive_a; drv_index--) {
+            const drive_number drv = static_cast<drive_number>(drv_index);
             if (io->get_drive_entry(drv)) {
                 load_linked_fonts_from_directory(io, std::u16string{ drive_to_char16(drv) } + (kern->is_eka1() ? u":\\System\\Fonts\\" : u":\\Resource\\Fonts\\"));
             }
@@ -1252,7 +1254,9 @@ namespace eka2l1 {
 
     void fbs_server::load_fonts(eka2l1::io_system *io) {
         // Search all drives
-        for (drive_number drv = drive_z; drv >= drive_a; drv = static_cast<drive_number>(static_cast<int>(drv) - 1)) {
+        // Stepping one below drive_a would leave the enum's value range.
+        for (int drv_index = drive_z; drv_index >= drive_a; drv_index--) {
+            const drive_number drv = static_cast<drive_number>(drv_index);
             if (io->get_drive_entry(drv)) {
                 const std::u16string fonts_folder_path = std::u16string{ drive_to_char16(drv) } + (kern->is_eka1() ? u":\\System\\Fonts\\" : u":\\Resource\\Fonts\\");
                 auto folder = io->open_dir(fonts_folder_path, {}, io_attrib_include_file);

--- a/src/emu/services/src/fs/fs.cpp
+++ b/src/emu/services/src/fs/fs.cpp
@@ -496,7 +496,9 @@ namespace eka2l1 {
             io_system *io = sys->get_io_system();
 
             // Ignore drive z.
-            for (drive_number drv = drive_y; drv >= drive_a; drv--) {
+            // Stepping one below drive_a would leave the enum's value range.
+            for (int drv_index = drive_y; drv_index >= drive_a; drv_index--) {
+                const drive_number drv = static_cast<drive_number>(drv_index);
                 if (io->get_drive_entry(drv)) {
                     system_apps_dir[0] = drive_to_char16(drv);
                     shared_data_dir[0] = drive_to_char16(drv);
@@ -512,7 +514,9 @@ namespace eka2l1 {
         io_system *io = sys->get_io_system();
 
         // Ignore drive z.
-        for (drive_number drv = drive_y; drv >= drive_a; drv--) {
+        // Stepping one below drive_a would leave the enum's value range.
+        for (int drv_index = drive_y; drv_index >= drive_a; drv_index--) {
+            const drive_number drv = static_cast<drive_number>(drv_index);
             if (io->get_drive_entry(drv)) {
                 temp_data_dir[0] = drive_to_char16(drv);
 

--- a/src/emu/services/src/msv/entry.cpp
+++ b/src/emu/services/src/msv/entry.cpp
@@ -44,7 +44,9 @@ namespace eka2l1::epoc::msv {
         , msg_dir_(msg_folder) {
         drive_number drv_target = drive_z;
 
-        for (drive_number drv = drive_z; drv >= drive_a; drv--) {
+        // Stepping one below drive_a would leave the enum's value range.
+        for (int drv_index = drive_z; drv_index >= drive_a; drv_index--) {
+            const drive_number drv = static_cast<drive_number>(drv_index);
             auto drv_entry = io->get_drive_entry(drv);
 
             if (drv_entry && (drv_entry->media_type == drive_media::rom)) {

--- a/src/emu/services/src/msv/msv.cpp
+++ b/src/emu/services/src/msv/msv.cpp
@@ -75,7 +75,9 @@ namespace eka2l1 {
 
         drive_number drv_target = drive_z;
 
-        for (drive_number drv = drive_z; drv >= drive_a; drv--) {
+        // Stepping one below drive_a would leave the enum's value range.
+        for (int drv_index = drive_z; drv_index >= drive_a; drv_index--) {
+            const drive_number drv = static_cast<drive_number>(drv_index);
             auto drv_entry = io->get_drive_entry(drv);
 
             if (drv_entry && (drv_entry->media_type == drive_media::rom)) {

--- a/src/emu/services/src/ui/icon/icon.cpp
+++ b/src/emu/services/src/ui/icon/icon.cpp
@@ -111,7 +111,9 @@ namespace eka2l1 {
         // No drive/dir component? Search the well-known resource folders on every drive.
         if ((path.find(u':') == std::u16string::npos) && (path.find(u'\\') == std::u16string::npos)) {
             static const char16_t *kPrefixes[] = { u"\\resource\\apps\\", u"\\resource\\" };
-            for (drive_number drv = drive_z; drv >= drive_a; drv = static_cast<drive_number>(drv - 1)) {
+            // Stepping one below drive_a would leave the enum's value range.
+            for (int drv_index = drive_z; drv_index >= drive_a; drv_index--) {
+                const drive_number drv = static_cast<drive_number>(drv_index);
                 auto entry = io->get_drive_entry(drv);
                 if (!entry) {
                     continue;

--- a/src/emu/services/src/ui/icon/init.cpp
+++ b/src/emu/services/src/ui/icon/init.cpp
@@ -39,7 +39,9 @@ namespace eka2l1 {
         std::u16string path;
 
         // Find the ROM drive
-        for (drive_number drv = drive_z; drv >= drive_a; drv = static_cast<drive_number>(drv - 1)) {
+        // Stepping one below drive_a would leave the enum's value range.
+        for (int drv_index = drive_z; drv_index >= drive_a; drv_index--) {
+            const drive_number drv = static_cast<drive_number>(drv_index);
             auto result = io->get_drive_entry(drv);
             if (result && result->media_type == drive_media::rom) {
                 path += drive_to_char16(drv);

--- a/src/emu/services/src/ui/skin/utils.cpp
+++ b/src/emu/services/src/ui/skin/utils.cpp
@@ -141,7 +141,9 @@ namespace eka2l1::epoc {
         std::u16string formal_path = u"\\resource\\skins\\";
         formal_path += pid_to_string(skin_pid);
 
-        for (drive_number drv = drive_z; drv >= drive_a; drv--) {
+        // Stepping one below drive_a would leave the enum's value range.
+        for (int drv_index = drive_z; drv_index >= drive_a; drv_index--) {
+            const drive_number drv = static_cast<drive_number>(drv_index);
             if (io->get_drive_entry(drv)) {
                 std::u16string skin_folder_path(1, drive_to_char16(drv));
                 skin_folder_path += u":";

--- a/src/emu/services/src/ui/view/view.cpp
+++ b/src/emu/services/src/ui/view/view.cpp
@@ -56,7 +56,9 @@ namespace eka2l1 {
         std::u16string priority_filename = u"resource\\apps\\PrioritySet.rsc";
         symfile f = nullptr;
 
-        for (drive_number drive = drive_z; drive >= drive_a; drive = static_cast<drive_number>(static_cast<int>(drive) - 1)) {
+        // Stepping one below drive_a would leave the enum's value range.
+        for (int drive_index = drive_z; drive_index >= drive_a; drive_index--) {
+            const drive_number drive = static_cast<drive_number>(drive_index);
             if (io->get_drive_entry(drive)) {
                 f = io->open_file(std::u16string(drive_to_char16(drive), 1) + priority_filename, READ_MODE | BIN_MODE);
 


### PR DESCRIPTION
CI builds and runs the unit tests, and #604 added a second host-only suite in the differential test. What it does not do is run either of them under a sanitiser — and memory errors are what this codebase actually gets wrong. Two examples from the last few months, both found by running something under ASan by hand, once: an inflate bit-reader that read past its buffer and pulled random heap into a patch DLL's decompressed image, and a chunk destructor that walked a page table array whose size member had never been initialised. Neither reproduced reliably without a sanitiser; both were obvious with one.

This adds a job that builds `ekatests` with clang and `-fsanitize=address,undefined` in its own build tree and runs `ctest` with `halt_on_error=1`, so an undefined-behaviour report fails the job rather than scrolling past in the log. It joins the `CI` aggregation job, so branch protection picks it up with no configuration change.

Leak detection is deliberately off (`ASAN_OPTIONS=detect_leaks=0`). The suite ends with objects the emulator never frees on purpose, and separating those from real leaks is a different piece of work than catching memory errors and undefined behaviour.

## What the job reported

Five defects, all on master, all fixed here so the job is green from the start rather than starting life red:

- **`page_array` frees a `new[]` table with plain `delete`.** The segment table is allocated with `new pages_segment*[n]` and released with `delete`, which is undefined and a hard error under ASan. Worth noting how this one surfaced: it is invisible on macOS, where the `alloc-dealloc-mismatch` check is off by default, and only appeared when the job first got far enough to run the suite on Linux. It reproduces locally once the check is switched on, and the fix is `delete[]`.
- **`bitmap_allocator::force_fill` shifts by a negative amount.** Once the remaining bit count drops below zero, `mask >> end_bit` shifts a 32-bit value by 4294967266. The loop exits immediately afterwards and the bogus mask is never read, so nothing misbehaves today — but the shift is undefined, and the next person to restructure that loop inherits it.
- **`chunkyseri` offsets a null pointer to measure a serialisation.** Measure mode is handed a null buffer and walks it to count bytes; `nullptr + 4` is undefined. Measure mode counts into a size member now, and the constructor no longer forms `end` from a null base.
- **Thirteen loops leave the value range of `drive_number`.** Every descending drive walk (`for (drive_number drv = drive_z; drv >= drive_a; drv--)`) steps one below `drive_a` to terminate, and −1 is not a value the enum can hold. The counter is an `int` now and the drive number is formed inside the loop body.

Two build-side details the job also turned up, both fixed here: the vendored `xz` refuses `-fsanitize=` unless `XZ_SANDBOX=no` is passed (its Landlock sandbox and the sanitisers cannot both be on), and `pystr.h` uses `std::remove_if` and `std::find` without including `<algorithm>`, which every existing configuration happened to get transitively.

## Verification

Locally, on the tree this PR produces: `ekatests` is clean under `-fsanitize=address,undefined` — 135 cases, 2580 assertions, no sanitiser output, including with `alloc_dealloc_mismatch=1` forced on.

The job's acceptance test is that it goes red on a bad tree, so each fix was reverted on its own and the suite re-run with the same options the job uses:

| Fix reverted | What the sanitiser reports |
|---|---|
| `delete[]` on the segment table | `pagearray.cpp:111: alloc-dealloc-mismatch (operator new [] vs operator delete)` |
| The `force_fill` shift guard | `allocator.cpp:175: shift exponent 4294967266 is too large for 32-bit type` |
| Measure-mode byte counting in `chunkyseri` | `chunkyseri.cpp:30: applying non-zero offset 4 to null pointer` |
| One descending drive loop (`packages::install_sis_stubs`) | `types.h:130: load of value 4294967295, which is not a valid value for type 'drive_number'` |

Each of those is a failing `ctest` run, which is what the job checks.

## Not in this PR

The differential test could run under the same flags, but `scripts/cpu_difftest.sh` configures its own build tree and would need to pass sanitiser flags through; that is worth doing separately. Neither does this job run the sanitisers on macOS or Windows, where the suite is only built normally.