### PR TITLE
services: Look an object up by its id, not by where lower_bound lands

### DIFF
--- a/src/emu/services/include/services/framework.h
+++ b/src/emu/services/include/services/framework.h
@@ -55,7 +55,10 @@ namespace eka2l1::service {
                     return lhs->id < rhs;
                 });
 
-            if (result == objs.end()) {
+            // lower_bound lands on the first object with a greater or equal id, so an
+            // id nothing owns resolves to an unrelated object, which the caller then
+            // reads through the wrong type. remove() above makes the same check.
+            if ((result == objs.end()) || ((*result)->id != id)) {
                 return nullptr;
             }
 

--- a/src/tests/epoc/CMakeLists.txt
+++ b/src/tests/epoc/CMakeLists.txt
@@ -17,6 +17,7 @@ set(CORE_TEST_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/services/svg_icon.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/centralrepo/crebinloader.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/domain/domain.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/services/framework/objects.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/centralrepo/creiniloader.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/ui/skin/skn.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/utils/sec.cpp

--- a/src/tests/epoc/services/framework/objects.cpp
+++ b/src/tests/epoc/services/framework/objects.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch.hpp>
+
+#include <services/framework.h>
+
+using namespace eka2l1;
+
+namespace {
+    struct counted_object : public epoc::ref_count_object {
+        std::uint32_t marker = 0;
+    };
+}
+
+TEST_CASE("object_container_answers_only_for_ids_it_owns", "service_framework") {
+    service::normal_object_container container;
+
+    counted_object *first = container.make_new<counted_object>();
+    counted_object *second = container.make_new<counted_object>();
+    REQUIRE(first != nullptr);
+    REQUIRE(second != nullptr);
+
+    first->marker = 1;
+    second->marker = 2;
+
+    const service::uid first_id = first->id;
+    const service::uid second_id = second->id;
+    REQUIRE(first_id != second_id);
+
+    REQUIRE(container.get<counted_object>(first_id) == first);
+    REQUIRE(container.get<counted_object>(second_id) == second);
+
+    // A handle the client has already closed. The lookup used to land on the next
+    // object in id order and hand that back, so the caller kept working with a live
+    // object of possibly another type instead of seeing the handle go away.
+    REQUIRE(container.remove(first));
+    REQUIRE(container.get<counted_object>(first_id) == nullptr);
+    REQUIRE(container.get<counted_object>(second_id) == second);
+    REQUIRE(container.get<counted_object>(second_id)->marker == 2);
+
+    // Zero is the handle a command uses to say it has no object, and ids past the
+    // end never existed. Neither may resolve to anything.
+    REQUIRE(container.get<counted_object>(0) == nullptr);
+    REQUIRE(container.get<counted_object>(second_id + 100) == nullptr);
+}


### PR DESCRIPTION
`normal_object_container::get()` searches the object vector with `lower_bound` and then only checks whether the search ran off the end. `lower_bound` stops at the first object whose id is *greater than or equal to* the one asked for, so any id the container does not hold resolves to whichever object sits next in id order.

Two ways that happens in normal use: a handle the client has already closed, and the zero handle that window-server and FBS commands use to mean "no object". In both cases the caller gets a live pointer, `reinterpret_cast`s it to the type it was expecting, and reads another object's memory through it. Nothing looks wrong until the two types disagree about their layout — which is how it was found, as a crash with a plausible-looking object in hand.

`normal_object_container::remove()`, a few lines below in `framework.cpp`, already makes exactly the check that was missing here.

A test covers the two cases: looking up a removed object's id, and looking up zero. Reverting the fix fails it — with the old code the removed id hands back the *next* object, which is what the test asserts against.

Full suite: 136 cases, 2591 assertions, green.