### PR TITLE
services: Fail an IPC argument the client did not supply

### DIFF
--- a/src/emu/services/src/context.cpp
+++ b/src/emu/services/src/context.cpp
@@ -25,6 +25,7 @@
 
 #include <services/context.h>
 #include <utils/des.h>
+#include <utils/err.h>
 #include <utils/sec.h>
 
 #include <config/config.h>
@@ -174,6 +175,10 @@ namespace eka2l1 {
             if (sys->get_kernel_system()->is_eka1() || ((int)arg_type & ((int)ipc_arg_type::flag_des | (int)ipc_arg_type::flag_16b))) {
                 eka2l1::epoc::desc16 *des = ptr<epoc::desc16>(msg->args.args[idx]).get(msg->own_thr->owning_process());
 
+                if (!des) {
+                    return false;
+                }
+
                 des->assign(msg->own_thr->owning_process(), data);
 
                 return true;
@@ -198,6 +203,17 @@ namespace eka2l1 {
                 if (!is_eka1 && ((int)arg_type & (int)ipc_arg_type::flag_16b)) {
                     eka2l1::epoc::desc16 *des = ptr<epoc::desc16>(msg->args.args[idx]).get(own_pr);
 
+                    // An argument the client left null, or pointed outside its own address
+                    // space, resolves to nothing. The rest of this file already answers that
+                    // with a failure rather than a dereference; these paths did not.
+                    if (!des) {
+                        if (err_code) {
+                            *err_code = epoc::error_bad_descriptor;
+                        }
+
+                        return false;
+                    }
+
                     // We can't handle odd length
                     assert(len % 2 == 0);
 
@@ -214,6 +230,14 @@ namespace eka2l1 {
                     des->assign(own_pr, data, write_size * 2);
                 } else {
                     eka2l1::epoc::des8 *des = ptr<epoc::des8>(msg->args.args[idx]).get(own_pr);
+
+                    if (!des) {
+                        if (err_code) {
+                            *err_code = epoc::error_bad_descriptor;
+                        }
+
+                        return false;
+                    }
 
                     std::uint32_t write_size = len;
                     const std::uint32_t des_to_write_size = des->get_max_length(own_pr);
@@ -271,6 +295,10 @@ namespace eka2l1 {
             kernel::process *own_pr = msg->own_thr->owning_process();
             epoc::des8 *descriptor = ptr<epoc::des8>(msg->args.args[idx]).get(own_pr);
 
+            if (!descriptor) {
+                return 0;
+            }
+
             if (!is_eka1 && (static_cast<int>(arg_type) & static_cast<int>(ipc_arg_type::flag_16b))) {
                 return descriptor->get_max_length(own_pr) * 2;
             }
@@ -297,6 +325,10 @@ namespace eka2l1 {
             kernel::process *own_pr = msg->own_thr->owning_process();
             epoc::des8 *descriptor = ptr<epoc::des8>(msg->args.args[idx]).get(own_pr);
 
+            if (!descriptor) {
+                return 0;
+            }
+
             if (!is_eka1 && (static_cast<int>(arg_type) & static_cast<int>(ipc_arg_type::flag_16b))) {
                 return descriptor->get_length() * 2;
             }
@@ -310,6 +342,10 @@ namespace eka2l1 {
             if (sys->get_kernel_system()->is_eka1() || ((int)arg_type & (int)ipc_arg_type::flag_des)) {
                 kernel::process *own_pr = msg->own_thr->owning_process();
                 eka2l1::epoc::des8 *des = ptr<epoc::des8>(msg->args.args[idx]).get(own_pr);
+
+                if (!des) {
+                    return false;
+                }
 
                 des->set_length(own_pr, len);
                 return true;


### PR DESCRIPTION
Six paths in `ipc_context` resolved a descriptor argument straight into a dereference.

A client is free to pass a null pointer in an argument slot, or one outside its own address space; `ptr<T>::get()` resolves both to nothing, and the emulator then reads or writes through null and takes the host process down with it — not the guest thread, the emulator. That is how the camera server's `MessageGetDesLength` killed the whole emulator when a guest asked about a slot it had never filled in.

The two paths in this same file that already handle it — reading a 16-bit descriptor argument, and taking a raw pointer to one — are the model this follows: answer with a failure and let the caller decide. Writes report `KErrBadDescriptor`, the two length queries answer zero, and the two setters return false.

No behaviour changes for a well-formed request: every guard is on a pointer that would otherwise have been dereferenced.

Full suite green (135 cases, 2580 assertions).