### PR TITLE
services: Complete a request nothing implements, do not drop it

### DIFF
--- a/src/emu/services/include/services/fs/fs.h
+++ b/src/emu/services/include/services/fs/fs.h
@@ -213,6 +213,7 @@ namespace eka2l1 {
 
         std::vector<notify_entry> notify_entries;
         epoc::notify_info dismount_notify_;
+        epoc::notify_info disk_space_notify_;
 
         void notify(const utf16_str &entry, const notify_type type);
         bool should_notify_failures;

--- a/src/emu/services/src/context.cpp
+++ b/src/emu/services/src/context.cpp
@@ -25,6 +25,7 @@
 
 #include <services/context.h>
 #include <utils/des.h>
+#include <utils/err.h>
 #include <utils/sec.h>
 
 #include <config/config.h>
@@ -357,7 +358,20 @@ namespace eka2l1 {
                     return;
                 }
 
-                LOG_WARN(SERVICE_TRACK, "Unimplemented IPC call: 0x{:x} for server: {}", func, obj_name);
+                // Error level on purpose: the default log preset pins Service.Track at
+                // error, so a warning here is invisible in exactly the situation it
+                // exists for -- a guest wedged on an opcode nobody implemented.
+                LOG_ERROR(SERVICE_TRACK, "Unimplemented IPC call: 0x{:x} for server: {}", func, obj_name);
+
+                // A real server always completes the message. Dropping it wedges the
+                // client for good: a synchronous SendReceive never returns, and an
+                // asynchronous one keeps its active object armed forever.
+                ipc_context context;
+
+                context.sys = sys;
+                context.msg = process_msg;
+                context.complete(epoc::error_not_supported);
+
                 return;
             }
 

--- a/src/emu/services/src/fs/fs.cpp
+++ b/src/emu/services/src/fs/fs.cpp
@@ -327,8 +327,27 @@ namespace eka2l1 {
             ctx->complete(epoc::error_none);
             break;
 
+        // Free space never crosses the client's threshold here, since the emulator
+        // never reports one, so the request stays outstanding the way it would on a
+        // device with a quiet disk. Completing it instead makes a client that re-arms
+        // on completion spin. The cancel is the only thing that ends it.
+        case epoc::fs_msg_notify_disk_space:
+            disk_space_notify_.complete(epoc::error_cancel);
+            disk_space_notify_ = epoc::notify_info(ctx->msg->request_sts, ctx->msg->own_thr);
+            break;
+
+        case epoc::fs_msg_notify_disk_space_cancel:
+            disk_space_notify_.complete(epoc::error_cancel);
+            ctx->complete(epoc::error_none);
+            break;
+
         default: {
             LOG_ERROR(SERVICE_EFSRV, "Unknown FSServer client opcode {}!", ctx->msg->function);
+
+            // Every other request is one a real file server answers straight away, so
+            // dropping it wedges the client: the harvester mounts its file-system
+            // plugins with Fs::MountPlugin and waits for the reply that never came.
+            ctx->complete(epoc::error_not_supported);
             break;
         }
 


### PR DESCRIPTION
A server that receives an opcode it has no handler for logs a warning and returns, leaving the message outstanding. That wedges the client for good: a synchronous `SendReceive` never returns, and an asynchronous one keeps its active object armed forever. The guest hangs on a request the emulator has already decided it will not answer, and the log line that would explain it is invisible — the default log preset pins `Service.Track` at error, so a warning there never prints.

Real servers always complete. This answers `KErrNotSupported` in the two places that dropped messages: the generic dispatcher, and the file server's own unknown-opcode path. The file server one is not hypothetical — the metadata harvester mounts its file-system plugins with `Fs::MountPlugin` and waits for a reply that never came.

`Fs::NotifyDiskSpace` is the one request that legitimately stays outstanding: free space never crosses the client's threshold here, and completing it makes a client that re-arms on completion spin. So it keeps a pending request on purpose, and its cancel now ends that request with `KErrCancel` instead of falling through to the unknown-opcode path — otherwise a client that cancels would wait forever on a status nothing ever sets.

Worth saying explicitly: `KErrNotSupported` is not free either. A client that retries on it spins instead of hanging, which is louder but not better. The alternative is worse in every case, since a dropped message can only ever hang.

Full suite green (135 cases, 2580 assertions).