### PR TITLE
etel: Answer the network requests the Clock application makes

### DIFF
--- a/src/emu/services/include/services/etel/common.h
+++ b/src/emu/services/include/services/etel/common.h
@@ -116,6 +116,7 @@ namespace eka2l1::epoc {
         etel_mobile_line_get_mobile_line_status = 20023,
         etel_mobile_line_notify_status_change = 20024,
         etel_mobile_phone_get_battery_info = 20030,
+        etel_mobile_phone_get_current_mode = 20037,
         etel_mobile_phone_get_identity_caps = 20043,
         etel_mobile_phone_get_indicator = 20046,
         etel_mobile_phone_get_indicator_caps = 20047,
@@ -131,12 +132,19 @@ namespace eka2l1::epoc {
         etel_mobile_phone_get_network_registration_status_cancel = 20554,
         etel_mobile_phone_notify_battery_info_change_cancel = 20567,
         etel_mobile_phone_notify_indicator_changes_cancel = 20584,
+        etel_mobile_phone_notify_network_registration_status_change_cancel = 20592,
+        etel_mobile_phone_notify_signal_strength_change_cancel = 20597,
         etel_mobile_phone_get_home_network = 22004,
+        etel_mobile_phone_get_nitz_info = 22008,
         etel_mobile_phone_get_phone_id = 22012,
         etel_mobile_phone_get_subscriber_id = 22017,
+        etel_mobile_phone_notify_nitz_info_change = 22022,
+        etel_mobile_phone_notify_nitz_info_change_cancel = 22522,
+        etel_mobile_phone_get_current_network_no_location = 24011,
         etel_mobile_phone_get_current_network = 26000,
         etel_mobile_phone_notify_current_network_change = 26001,
-        etel_mobile_phone_get_current_network_cancel = 26500
+        etel_mobile_phone_get_current_network_cancel = 26500,
+        etel_mobile_phone_notify_current_network_change_cancel = 26501
     };
 
     enum etel_network_type : std::uint32_t {

--- a/src/emu/services/include/services/etel/subsess.h
+++ b/src/emu/services/include/services/etel/subsess.h
@@ -63,6 +63,7 @@ namespace eka2l1 {
         epoc::notify_info network_registration_status_change_nof_;
         epoc::notify_info signal_strength_change_nof_;
         epoc::notify_info current_network_change_nof_;
+        epoc::notify_info nitz_info_change_nof_;
         epoc::notify_info indicator_change_nof_;
         epoc::notify_info battery_info_change_nof_;
 
@@ -75,6 +76,7 @@ namespace eka2l1 {
         void get_indicator_caps(service::ipc_context *ctx);
         void get_indicator(service::ipc_context *ctx);
         void get_network_caps(service::ipc_context *ctx);
+        void get_current_mode(service::ipc_context *ctx);
         void get_network_registration_status(eka2l1::service::ipc_context *ctx);
         void get_home_network(eka2l1::service::ipc_context *ctx);
         void get_phone_id(eka2l1::service::ipc_context *ctx);
@@ -84,9 +86,15 @@ namespace eka2l1 {
         void get_signal_strength(eka2l1::service::ipc_context *ctx);
         void get_battery_info(eka2l1::service::ipc_context *ctx);
         void notify_network_registration_status_change(eka2l1::service::ipc_context *ctx);
+        void notify_network_registration_status_change_cancel(eka2l1::service::ipc_context *ctx);
         void get_network_registration_status_cancel(eka2l1::service::ipc_context *ctx);
         void notify_signal_strength_change(eka2l1::service::ipc_context *ctx);
+        void notify_signal_strength_change_cancel(eka2l1::service::ipc_context *ctx);
         void notify_current_network_change(eka2l1::service::ipc_context *ctx);
+        void notify_current_network_change_cancel(eka2l1::service::ipc_context *ctx);
+        void get_nitz_info(eka2l1::service::ipc_context *ctx);
+        void notify_nitz_info_change(eka2l1::service::ipc_context *ctx);
+        void notify_nitz_info_change_cancel(eka2l1::service::ipc_context *ctx);
         void notify_indicator_change(eka2l1::service::ipc_context *ctx);
         void cancel_indicator_change(eka2l1::service::ipc_context *ctx);
         void get_current_network_cancel(eka2l1::service::ipc_context *ctx);

--- a/src/emu/services/src/etel/phone.cpp
+++ b/src/emu/services/src/etel/phone.cpp
@@ -120,11 +120,20 @@ namespace eka2l1 {
     void etel_phone_subsession::get_network_caps(service::ipc_context *ctx) {
         LOG_TRACE(SERVICE_ETEL, "Get network caps hardcoded");
 
-        const std::uint32_t network_caps = epoc::etel_mobile_phone_network_cap_get_current_network
+        const std::uint32_t network_caps = epoc::etel_mobile_phone_network_cap_get_current_mode
+            | epoc::etel_mobile_phone_network_cap_get_current_network
             | epoc::etel_mobile_phone_network_cap_get_home_network;
 
         ctx->write_data_to_descriptor_argument<std::uint32_t>(0, network_caps);
 
+        ctx->complete(epoc::error_none);
+    }
+
+    void etel_phone_subsession::get_current_mode(service::ipc_context *ctx) {
+        LOG_TRACE(SERVICE_ETEL, "Get current network mode hardcoded");
+
+        ctx->write_data_to_descriptor_argument<std::uint32_t>(0,
+            static_cast<std::uint32_t>(phone_->network_info_.mode_));
         ctx->complete(epoc::error_none);
     }
 
@@ -197,7 +206,6 @@ namespace eka2l1 {
     void etel_phone_subsession::get_current_network(eka2l1::service::ipc_context *ctx) {
         LOG_TRACE(SERVICE_ETEL, "Get current network hardcoded");
         std::optional<epoc::etel_phone_network_info> network_info = ctx->get_argument_data_from_descriptor<epoc::etel_phone_network_info>(0);
-        epoc::etel_phone_location_area *phone_location_area = reinterpret_cast<epoc::etel_phone_location_area *>(ctx->get_descriptor_argument_ptr(2));
 
         network_info->mode_ = phone_->network_info_.mode_;
         network_info->status_ = phone_->network_info_.status_;
@@ -230,12 +238,42 @@ namespace eka2l1 {
         network_registration_status_change_nof_ = epoc::notify_info(ctx->msg->request_sts, ctx->msg->own_thr);
     }
 
+    void etel_phone_subsession::notify_network_registration_status_change_cancel(eka2l1::service::ipc_context *ctx) {
+        network_registration_status_change_nof_.complete(epoc::error_cancel);
+        ctx->complete(epoc::error_none);
+    }
+
     void etel_phone_subsession::notify_signal_strength_change(eka2l1::service::ipc_context *ctx) {
         signal_strength_change_nof_ = epoc::notify_info(ctx->msg->request_sts, ctx->msg->own_thr);
     }
 
+    void etel_phone_subsession::notify_signal_strength_change_cancel(eka2l1::service::ipc_context *ctx) {
+        signal_strength_change_nof_.complete(epoc::error_cancel);
+        ctx->complete(epoc::error_none);
+    }
+
     void etel_phone_subsession::notify_current_network_change(eka2l1::service::ipc_context *ctx) {
         current_network_change_nof_ = epoc::notify_info(ctx->msg->request_sts, ctx->msg->own_thr);
+    }
+
+    void etel_phone_subsession::notify_current_network_change_cancel(eka2l1::service::ipc_context *ctx) {
+        current_network_change_nof_.complete(epoc::error_cancel);
+        ctx->complete(epoc::error_none);
+    }
+
+    void etel_phone_subsession::get_nitz_info(eka2l1::service::ipc_context *ctx) {
+        // Nothing here broadcasts a network time frame. A TSY reports that by failing
+        // the fetch, not by handing back an empty snapshot.
+        ctx->complete(epoc::error_not_found);
+    }
+
+    void etel_phone_subsession::notify_nitz_info_change(eka2l1::service::ipc_context *ctx) {
+        nitz_info_change_nof_ = epoc::notify_info(ctx->msg->request_sts, ctx->msg->own_thr);
+    }
+
+    void etel_phone_subsession::notify_nitz_info_change_cancel(eka2l1::service::ipc_context *ctx) {
+        nitz_info_change_nof_.complete(epoc::error_cancel);
+        ctx->complete(epoc::error_none);
     }
 
     void etel_phone_subsession::notify_indicator_change(eka2l1::service::ipc_context *ctx) {
@@ -380,6 +418,10 @@ namespace eka2l1 {
                 get_network_caps(ctx);
                 break;
 
+            case epoc::etel_mobile_phone_get_current_mode:
+                get_current_mode(ctx);
+                break;
+
             case epoc::etel_mobile_phone_get_network_registration_status:
                 get_network_registration_status(ctx);
                 break;
@@ -392,8 +434,16 @@ namespace eka2l1 {
                 notify_network_registration_status_change(ctx);
                 break;
 
+            case epoc::etel_mobile_phone_notify_network_registration_status_change_cancel:
+                notify_network_registration_status_change_cancel(ctx);
+                break;
+
             case epoc::etel_mobile_phone_notify_signal_strength_change:
                 notify_signal_strength_change(ctx);
+                break;
+
+            case epoc::etel_mobile_phone_notify_signal_strength_change_cancel:
+                notify_signal_strength_change_cancel(ctx);
                 break;
 
             case epoc::etel_mobile_phone_get_network_registration_status_cancel:
@@ -412,12 +462,31 @@ namespace eka2l1 {
                 get_phone_id(ctx);
                 break;
 
+            // The no-location variant is the same fetch without the location-area slot,
+            // which is never filled in here anyway.
             case epoc::etel_mobile_phone_get_current_network:
+            case epoc::etel_mobile_phone_get_current_network_no_location:
                 get_current_network(ctx);
+                break;
+
+            case epoc::etel_mobile_phone_get_nitz_info:
+                get_nitz_info(ctx);
+                break;
+
+            case epoc::etel_mobile_phone_notify_nitz_info_change:
+                notify_nitz_info_change(ctx);
+                break;
+
+            case epoc::etel_mobile_phone_notify_nitz_info_change_cancel:
+                notify_nitz_info_change_cancel(ctx);
                 break;
 
             case epoc::etel_mobile_phone_notify_current_network_change:
                 notify_current_network_change(ctx);
+                break;
+
+            case epoc::etel_mobile_phone_notify_current_network_change_cancel:
+                notify_current_network_change_cancel(ctx);
                 break;
 
             case epoc::etel_mobile_phone_get_current_network_cancel:


### PR DESCRIPTION
The 5320's Clock shows a black screen and never draws. Two of its components are waiting on the phone subsession: `ClkNitzMdls` asks for the network time frame (`EMobilePhoneGetNITZInfo`, 22008) and subscribes to changes (`EMobilePhoneNotifyNITZInfoChange`, 22022), and the clock itself asks for the current network without the location area (`EMobilePhoneGetCurrentNetworkNoLocation`, 24011). None of the three had a handler, so each hung its caller.

Also missing, and needed by the same clients:

- **The current network mode** (`EMobilePhoneGetCurrentMode`, 20037), together with the capability bit that tells a client it may ask.
- **Four cancel opcodes** — network registration status (20592), signal strength (20597), current network change (26501) and NITZ change (22522). A client that cancels a notification it armed otherwise waits forever for the cancel call itself to return.

The NITZ fetch answers `KErrNotFound`: nothing here broadcasts a network time frame, and failing the fetch is how a TSY says so — an empty snapshot would be read as a real one.

Every opcode number is Symbian's own, taken from `ETELMMCS.H` in `telephonyserver/etelmultimode`, which spells each value out in a trailing comment (20037, 20592, 20597, 22008, 22022, 22522, 24011, 26501). The capability bit matches `KCapsGetCurrentMode`.

One unrelated tidy-up rides along, in a line this PR touches: `get_current_network` resolved the location-area descriptor argument into a pointer that nothing read.

Full suite green.