### PR TITLE
alarm: Answer all three alarm id list requests

### DIFF
--- a/src/emu/services/include/services/alarm/alarm.h
+++ b/src/emu/services/include/services/alarm/alarm.h
@@ -24,7 +24,9 @@
 
 namespace eka2l1 {
     enum alarm_opcode {
+        alarm_get_alarm_id_list_for_category = 9,
         alarm_get_alarm_id_list_by_state = 11,
+        alarm_get_alarm_id_list = 12,
         alarm_notify_change = 19,
         alarm_notify_change_cancel = 20,
         alarm_fetch_transfer_buffer = 21
@@ -57,7 +59,7 @@ namespace eka2l1 {
         explicit alarm_session(service::typical_server *serv, const kernel::uid ss_id, epoc::version client_version);
 
         void fetch(service::ipc_context *ctx) override;
-        void get_alarm_id_list_by_state(service::ipc_context *ctx);
+        void stream_alarm_id_list(service::ipc_context *ctx);
         void fetch_transfer_buffer(service::ipc_context *ctx);
         void notify_change(service::ipc_context *ctx);
         void notify_change_cancel(service::ipc_context *ctx);

--- a/src/emu/services/src/alarm/alarm.cpp
+++ b/src/emu/services/src/alarm/alarm.cpp
@@ -51,8 +51,13 @@ namespace eka2l1 {
 
     void alarm_session::fetch(service::ipc_context *ctx) {
         switch (ctx->msg->function) {
+        // All three list requests stream the id array into the transfer buffer and hand
+        // its size back in slot 1. Their filter argument only narrows a queue that is
+        // always empty here, so one implementation answers all of them.
+        case alarm_get_alarm_id_list_for_category:
         case alarm_get_alarm_id_list_by_state:
-            get_alarm_id_list_by_state(ctx);
+        case alarm_get_alarm_id_list:
+            stream_alarm_id_list(ctx);
             break;
 
         case alarm_fetch_transfer_buffer:
@@ -73,9 +78,7 @@ namespace eka2l1 {
         }
     }
 
-    void alarm_session::get_alarm_id_list_by_state(service::ipc_context *ctx) {
-        auto state = ctx->get_argument_value<std::uint32_t>(0);
-
+    void alarm_session::stream_alarm_id_list(service::ipc_context *ctx) {
         common::chunkyseri seri(nullptr, 0, common::chunkyseri_mode::SERI_MODE_MEASURE);
         populate_alarm_ids(seri, alarm_ids);
 


### PR DESCRIPTION
The 5320's Clock never finishes starting. It asks the alarm server for the alarm ids in a category — `EASShdOpCodeGetAlarmIdListForCategory`, opcode 9 — and nothing answered, so the synchronous call never returned and the application sat there.

The by-state variant (11) was already implemented; the whole-list one (12) had the same gap as 9. All three do the same thing: stream the id array into the transfer buffer and report its size in slot 1. Their filter argument only narrows a queue that is always empty here, so one implementation serves all three, and the by-state handler loses the argument it read and never used.

Opcode numbers are Symbian's own, from `ASShdOpCodes.h` in `commonappservices/alarmserver` — `EASShdOpCodeFirst = KCapabilityNone = 0`, so `GetAlarmIdListForCategory` is 9, `GetAlarmIdListByState` 11 and `GetAlarmIdList` 12, which is what the file already assumed for 11, 19, 20 and 21.

Full suite green.