### PR TITLE
loader: Answer Loader::LoadPhysicalDevice

### DIFF
--- a/src/emu/services/include/services/loader/loader.h
+++ b/src/emu/services/include/services/loader/loader.h
@@ -59,6 +59,8 @@ namespace eka2l1 {
 
         void load_logical_device(service::ipc_context &context);
 
+        void load_physical_device(service::ipc_context &context);
+
         void get_info_from_header(service::ipc_context &context);
 
         void delete_loader(service::ipc_context &context);

--- a/src/emu/services/src/loader/loader.cpp
+++ b/src/emu/services/src/loader/loader.cpp
@@ -359,6 +359,19 @@ namespace eka2l1 {
         context.complete(epoc::error_none);
     }
 
+    void loader_server::load_physical_device(service::ipc_context &context) {
+        std::optional<utf16_str> pdd_name = context.get_argument_value<utf16_str>(1);
+        if (!pdd_name.has_value()) {
+            context.complete(epoc::error_argument);
+            return;
+        }
+
+        // Same answer as the logical driver above: the device the client is about to
+        // open is an HLE service here, not a driver loaded into the emulated kernel.
+        LOG_TRACE(SERVICE_LOADER, "Trying to load PDD {}", common::ucs2_to_utf8(pdd_name.value()));
+        context.complete(epoc::error_none);
+    }
+
     void loader_server::load_locale(service::ipc_context &context) {
         context.complete(epoc::error_not_found);
     }
@@ -373,5 +386,6 @@ namespace eka2l1 {
         REGISTER_IPC(loader_server, check_library_hash, ECheckLibraryHash, "Loader::CheckLibraryHash");
         REGISTER_IPC(loader_server, load_locale, ELoadLocale, "Loader::LoadLocale");
         REGISTER_IPC(loader_server, load_logical_device, ELoadLogicalDevice, "Loader::LoadLogicalDevice");
+        REGISTER_IPC(loader_server, load_physical_device, ELoadPhysicalDevice, "Loader::LoadPhysicalDevice");
     }
 }


### PR DESCRIPTION
`Loader::LoadLogicalDevice` (opcode 3) has an answer; the physical device call sitting next to it in the same enum (4) had none. A client that loads a PDD before opening its channel therefore waits forever on a synchronous request.

The answer is the same one the logical driver already gets: the device behind it is an HLE service in the emulator rather than a driver loaded into the emulated kernel, so the load reports success and the client goes on to open its channel.

Full suite green.