### PR TITLE
services: Publish the critical disk-space thresholds at boot

### DIFF
--- a/src/emu/services/src/init.cpp
+++ b/src/emu/services/src/init.cpp
@@ -192,6 +192,14 @@ namespace eka2l1::epoc {
         // From Domain Server request
         DEFINE_INT_PROP(sys, 0x1020e406, 0x250, 0);
 
+        // Without these SysUtil's critical-disk-space check finds no threshold at all
+        // and leaves, so a caller that checks free space before writing -- Camera
+        // saving a photo, for one -- never gets to the write.
+        DEFINE_INT_PROP(sys, epoc::DISK_LEVEL_CATEGORY, epoc::RAM_DISK_CRITICAL_THRESHOLD_KEY,
+            epoc::RAM_DISK_CRITICAL_THRESHOLD);
+        DEFINE_INT_PROP(sys, epoc::DISK_LEVEL_CATEGORY, epoc::OTHER_DISK_CRITICAL_THRESHOLD_KEY,
+            epoc::OTHER_DISK_CRITICAL_THRESHOLD);
+
         DEFINE_BIN_PROP(sys, epoc::SYS_CATEGORY, epoc::LOCALE_LANG_KEY, sizeof(epoc::locale_language), lang);
         DEFINE_BIN_PROP(sys, epoc::SYS_CATEGORY, epoc::LOCALE_DATA_KEY, sizeof(epoc::locale), locale);
         DEFINE_BIN_PROP(sys, epoc::SYS_CATEGORY, epoc::LOCALE_LOCALE_SETTINGS_KEY, sizeof(epoc::locale_locale_settings), locale_settings);

--- a/src/emu/utils/include/utils/system.h
+++ b/src/emu/utils/include/utils/system.h
@@ -41,6 +41,16 @@ namespace eka2l1::epoc {
     // never backs up or restores, so it stays in EBURNormal | ENoBackup.
     const std::int32_t BACKUP_RESTORE_NORMAL_STATE = 0x00000001;
 
+    // KPSUidDiskLevel and its two keys, which the system state manager publishes at
+    // boot. SysUtil looks for a critical free-space threshold in patched sysutil data,
+    // then in these properties, then in central repository, and leaves if none answers.
+    // The values are Symbian's own patch defaults from sysutil.iby.
+    const std::uint32_t DISK_LEVEL_CATEGORY = 0x10205065;
+    const std::uint32_t RAM_DISK_CRITICAL_THRESHOLD_KEY = 0x00000001;
+    const std::uint32_t OTHER_DISK_CRITICAL_THRESHOLD_KEY = 0x00000002;
+    const std::int32_t RAM_DISK_CRITICAL_THRESHOLD = 65536;
+    const std::int32_t OTHER_DISK_CRITICAL_THRESHOLD = 262144;
+
     enum system_agent_state {
         system_agent_state_off = 0,
         system_agent_state_on = 1


### PR DESCRIPTION
`SysUtil::DiskSpaceBelowCriticalLevelL` looks for its threshold in three places, in order: patched `sysutil.dll` data, the `KPSUidDiskLevel` properties, and central repository. In the emulator the patch data is absent, the properties were never defined, and the repository lookup leaves — so the check fails outright, and a caller that asks whether it may write *before* writing never gets to the write. That is what leaves the Camera stuck at "Saving image".

On a device the system state manager publishes both properties at boot (`ssminitcriticallevels.cpp` in `sysstatemgmt`). This defines them the same way.

Everything here is Symbian's own, checked against the source rather than guessed:

- `KPSUidDiskLevel` = `0x10205065`, with `KRamDiskCriticalThreshold` = 1 and `KOtherDiskCriticalThreshold` = 2 (`commonservices/sysutil/inc/sysutilinternalpskeys.h`).
- The values 65536 and 262144 are the patch defaults from `commonservices/sysutil/group/sysutil.iby`, which is where `KSysUtilRamDiskCriticalThreshold` and `KSysUtilOtherDiskCriticalThreshold` get theirs.

Full suite green.