### PR TITLE
accessory: Serve RAccessoryMode and the modern opcode set

### DIFF
--- a/src/emu/services/include/services/accessory/accessory.h
+++ b/src/emu/services/include/services/accessory/accessory.h
@@ -38,12 +38,14 @@ namespace eka2l1 {
 
     public:
         explicit accessory_subsession(accessory_server *svr);
+        virtual ~accessory_subsession() = default;
         virtual bool fetch(service::ipc_context *ctx) = 0;
     };
 
     struct accessory_single_connection_subsession : public accessory_subsession {
     protected:
         epoc::notify_info accessory_connected_nof_;
+        epoc::notify_info connection_status_nof_;
 
     public:
         explicit accessory_single_connection_subsession(accessory_server *svr);
@@ -52,6 +54,19 @@ namespace eka2l1 {
         void notify_new_accessory_connected(service::ipc_context *ctx);
         void cancel_notify_new_accessory_connected(service::ipc_context *ctx);
         void get_accessory_connection_status(service::ipc_context *ctx);
+    };
+
+    // RAccessoryMode. Nothing plugs into the emulator, so the mode is always
+    // hand-portable and a mode-changed notification never fires.
+    struct accessory_mode_subsession : public accessory_subsession {
+    protected:
+        epoc::notify_info mode_changed_nof_;
+
+    public:
+        explicit accessory_mode_subsession(accessory_server *svr);
+
+        bool fetch(service::ipc_context *ctx) override;
+        void get_accessory_mode(service::ipc_context *ctx);
     };
 
     using accessory_subsession_instance = std::unique_ptr<accessory_subsession>;
@@ -65,5 +80,6 @@ namespace eka2l1 {
 
         void fetch(service::ipc_context *ctx) override;
         void create_accessory_single_connection_subsession(service::ipc_context *ctx);
+        void create_accessory_mode_subsession(service::ipc_context *ctx);
     };
 }

--- a/src/emu/services/include/services/accessory/common.h
+++ b/src/emu/services/include/services/accessory/common.h
@@ -26,12 +26,36 @@ namespace eka2l1::epoc::acc {
     static constexpr std::uint32_t GENERIC_ID_ARRAY_COUNT = 10;
     static constexpr std::uint32_t MODEL_ID_MAX_LENGTH = 32;
 
+    // TAccMode. Only the value ever reported here is named.
+    enum accessory_mode_type {
+        accessory_mode_hand_portable = 0
+    };
+
     // There are massive changes to the enum in further Symbian future. But s60v3 keeps it simple
     enum opcode_s60v3 {
         opcode_s60v3_create_accessory_connection_subsession = 7,
         opcode_s60v3_get_accessory_connection_status = 9,
         opcode_s60v3_notify_new_accessory_connected = 11,
         opcode_s60v3_cancel_notify_new_accessory_connected = 12
+    };
+
+    // TAccSrvMsgs, from the accessory server's AccClientServerMessages.h.
+    enum opcode_modern {
+        opcode_modern_create_accessory_mode_subsession = 0,
+        opcode_modern_close_accessory_mode_subsession = 1,
+        opcode_modern_get_accessory_mode = 2,
+        opcode_modern_get_accessory_mode_async = 3,
+        opcode_modern_notify_accessory_mode_changed = 4,
+        opcode_modern_cancel_notify_accessory_mode_changed = 5,
+        opcode_modern_cancel_get_accessory_mode = 6,
+        opcode_modern_get_accessory_connection_status_async = 7,
+        opcode_modern_cancel_get_accessory_connection_status = 8,
+        opcode_modern_create_accessory_single_connection_subsession = 9,
+        opcode_modern_create_accessory_connection_subsession = 23,
+        opcode_modern_close_accessory_connection_subsession = 24,
+        opcode_modern_get_accessory_connection_status = 25,
+        opcode_modern_notify_accessory_connection_status_changed = 26,
+        opcode_modern_cancel_notify_accessory_connection_status_changed = 27
     };
 
 #pragma pack(push, 1)
@@ -53,6 +77,12 @@ namespace eka2l1::epoc::acc {
         generic_id ids_[GENERIC_ID_ARRAY_COUNT];
 
         explicit generic_id_array();
+    };
+
+    // TAccPolAccessoryMode: the mode, and whether audio comes out of the accessory.
+    struct accessory_mode {
+        std::uint32_t mode_;
+        std::uint32_t audio_output_status_;
     };
 #pragma pack(pop)
 }

--- a/src/emu/services/src/accessory/accessory.cpp
+++ b/src/emu/services/src/accessory/accessory.cpp
@@ -81,8 +81,85 @@ namespace eka2l1 {
 
             default:
                 LOG_ERROR(SERVICE_ACCESSORY, "Unimplemented opcode for Accessory single connection subsession 0x{:X}", ctx->msg->function);
+                ctx->complete(epoc::error_not_supported);
                 break;
             }
+        } else {
+            switch (ctx->msg->function) {
+            case epoc::acc::opcode_modern_get_accessory_connection_status:
+            case epoc::acc::opcode_modern_get_accessory_connection_status_async:
+                get_accessory_connection_status(ctx);
+                break;
+
+            case epoc::acc::opcode_modern_close_accessory_connection_subsession:
+                ctx->complete(epoc::error_none);
+                return true;
+
+            case epoc::acc::opcode_modern_notify_accessory_connection_status_changed:
+                connection_status_nof_ = epoc::notify_info(ctx->msg->request_sts, ctx->msg->own_thr);
+                break;
+
+            case epoc::acc::opcode_modern_cancel_get_accessory_connection_status:
+                ctx->complete(epoc::error_none);
+                break;
+
+            case epoc::acc::opcode_modern_cancel_notify_accessory_connection_status_changed:
+                connection_status_nof_.complete(epoc::error_cancel);
+                ctx->complete(epoc::error_none);
+                break;
+
+            default:
+                LOG_ERROR(SERVICE_ACCESSORY, "Unimplemented opcode for Accessory connection subsession 0x{:X}", ctx->msg->function);
+                ctx->complete(epoc::error_not_supported);
+                break;
+            }
+        }
+
+        return false;
+    }
+
+    accessory_mode_subsession::accessory_mode_subsession(accessory_server *svr)
+        : accessory_subsession(svr) {
+    }
+
+    void accessory_mode_subsession::get_accessory_mode(service::ipc_context *ctx) {
+        epoc::acc::accessory_mode mode;
+        mode.mode_ = epoc::acc::accessory_mode_hand_portable;
+        mode.audio_output_status_ = 0;
+
+        ctx->write_data_to_descriptor_argument<epoc::acc::accessory_mode>(0, mode);
+        ctx->complete(epoc::error_none);
+    }
+
+    bool accessory_mode_subsession::fetch(service::ipc_context *ctx) {
+        switch (ctx->msg->function) {
+        case epoc::acc::opcode_modern_get_accessory_mode:
+        case epoc::acc::opcode_modern_get_accessory_mode_async:
+            get_accessory_mode(ctx);
+            break;
+
+        case epoc::acc::opcode_modern_notify_accessory_mode_changed:
+            // Nothing ever plugs in or out, so this request stays pending for good.
+            mode_changed_nof_ = epoc::notify_info(ctx->msg->request_sts, ctx->msg->own_thr);
+            break;
+
+        case epoc::acc::opcode_modern_cancel_notify_accessory_mode_changed:
+            mode_changed_nof_.complete(epoc::error_cancel);
+            ctx->complete(epoc::error_none);
+            break;
+
+        case epoc::acc::opcode_modern_cancel_get_accessory_mode:
+            ctx->complete(epoc::error_none);
+            break;
+
+        case epoc::acc::opcode_modern_close_accessory_mode_subsession:
+            ctx->complete(epoc::error_none);
+            return true;
+
+        default:
+            LOG_ERROR(SERVICE_ACCESSORY, "Unimplemented opcode for Accessory mode subsession 0x{:X}", ctx->msg->function);
+            ctx->complete(epoc::error_not_supported);
+            break;
         }
 
         return false;
@@ -101,6 +178,14 @@ namespace eka2l1 {
         ctx->complete(epoc::error_none);
     }
 
+    void accessory_session::create_accessory_mode_subsession(service::ipc_context *ctx) {
+        accessory_subsession_instance inst = std::make_unique<accessory_mode_subsession>(server<accessory_server>());
+        const std::uint32_t id = static_cast<std::uint32_t>(subsessions_.add(inst));
+
+        ctx->write_data_to_descriptor_argument<std::uint32_t>(3, id);
+        ctx->complete(epoc::error_none);
+    }
+
     void accessory_session::fetch(service::ipc_context *ctx) {
         kernel_system *kern = server<accessory_server>()->get_kernel_object_owner();
 
@@ -108,6 +193,20 @@ namespace eka2l1 {
             switch (ctx->msg->function) {
             case epoc::acc::opcode_s60v3_create_accessory_connection_subsession:
                 create_accessory_single_connection_subsession(ctx);
+                return;
+
+            default:
+                break;
+            }
+        } else {
+            switch (ctx->msg->function) {
+            case epoc::acc::opcode_modern_create_accessory_connection_subsession:
+            case epoc::acc::opcode_modern_create_accessory_single_connection_subsession:
+                create_accessory_single_connection_subsession(ctx);
+                return;
+
+            case epoc::acc::opcode_modern_create_accessory_mode_subsession:
+                create_accessory_mode_subsession(ctx);
                 return;
 
             default:
@@ -127,6 +226,9 @@ namespace eka2l1 {
             }
         }
 
+        // These are synchronous calls, so an answer is not optional: an unanswered
+        // one blocks the client thread for good.
         LOG_ERROR(SERVICE_ACCESSORY, "Unimplemented opcode for accessory session 0x{:X}", ctx->msg->function);
+        ctx->complete(epoc::error_not_supported);
     }
 }

--- a/src/emu/services/src/accessory/common.cpp
+++ b/src/emu/services/src/accessory/common.cpp
@@ -21,7 +21,8 @@
 #include <utils/err.h>
 
 namespace eka2l1::epoc::acc {
-    generic_id_array::generic_id_array() {
+    generic_id_array::generic_id_array()
+        : ids_{} {
         // Set all unavailables
         for (std::uint32_t i = 0; i < GENERIC_ID_ARRAY_COUNT; i++) {
             ids_[i].header_.dbid_ = epoc::error_not_found;


### PR DESCRIPTION
The X7's Camera exits at startup. It opens an `RAccessoryMode` subsession before anything else, and the accessory server only knew the S60v3 opcodes — so the create call (opcode 0 in the modern set) fell through to a log line and was never answered. A synchronous call that is never answered hangs the client thread for good.

This adds the modern opcode set and the `RAccessoryMode` subsession behind it: get the mode synchronously or asynchronously, subscribe to mode changes, and cancel any of those. Nothing plugs into the emulator, so the mode is always hand-portable and a mode-changed notification never fires — which is a true statement to make to a client, unlike no answer at all. The single-connection subsession gets its modern opcodes too, and every unhandled request in this server now completes with `KErrNotSupported` instead of being dropped.

Both the opcode numbers and the `TAccPolAccessoryMode` layout are Symbian's own, checked against the source: `TAccSrvMsgs` in `accessoryservices/accessoryserver/inc/Common/AccClientServerMessages.h` (the enum counts from zero, which puts `CreateSubSessionAccessoryConnection` at 23 and `GetAccessoryConnectionStatus` at 25), and `TAccPolAccessoryMode` in `devicesrv_plat/accessory_policy_utility_api`, whose `EAccModeHandPortable` is the first `TAccMode`.

One more defect, found while reading the file: `generic_id_array`'s constructor filled in each entry's header fields but left the rest of the array uninitialised, so whatever was on the stack went out to the guest. It is zeroed now.

Full suite green.