### PR TITLE
msv: Write the capability words from Symbian 8.0, not 8.1a

### DIFF
--- a/src/emu/services/include/services/sms/common.h
+++ b/src/emu/services/include/services/sms/common.h
@@ -185,6 +185,7 @@ namespace eka2l1::epoc::sms {
         sms_pdu_type pdu_type_;
         sms_address service_center_address_;
 
+        virtual ~sms_pdu() = default;
         virtual void absorb(common::chunkyseri &seri) = 0;
     };
 

--- a/src/emu/services/src/msv/msv.cpp
+++ b/src/emu/services/src/msv/msv.cpp
@@ -903,7 +903,8 @@ namespace eka2l1 {
                 epoc::absorb_des_string(comp->filename_, seri, true);
             }
 
-            if (kern->is_eka1() && (kern->get_epoc_version() >= epocver::epoc81a)) {
+            // EKA1's packed record grew these three 32-bit fields in Symbian 8.0.
+            if (kern->is_eka1() && (kern->get_epoc_version() >= epocver::epoc80)) {
                 std::uint32_t cap_send_32 = group->cap_send_;
                 std::uint32_t cap_body_32 = group->cap_body_;
                 std::uint32_t cap_avail_32 = group->cap_avail_;


### PR DESCRIPTION
On a 6680, sdancer leaves with `KErrNotFound` while constructing its SMS client MTM, then exits cleanly before its active scheduler ever starts.

The EKA1 MTM registry writer only emitted the three capability words from `epoc81a` onward, but the 8.0 `msgs.dll` reads fixed-size records and already advances past them. Every record after the first was therefore shifted by twelve bytes, which hid the SMS MTM from the client that went looking for it — the failure is silent, because a missing MTM is indistinguishable from one that was never registered.

Writing the words from `epoc80` onward keeps the shorter Symbian 6/7 layout for the versions that really do lack the fields.

A second, unrelated one-liner in the same messaging stack rides along: `sms_pdu` is a base class whose subclasses are held and deleted through a base pointer, without a virtual destructor. That is undefined behaviour, and it is one line to fix.

Full suite green.