### PR TITLE
applist: Keep one registration per app, not one per scan

### DIFF
--- a/src/emu/services/src/applist/applist.cpp
+++ b/src/emu/services/src/applist/applist.cpp
@@ -87,6 +87,56 @@ namespace eka2l1 {
 
     static const char16_t *APA_APP_RUNNER = u"apprun.exe";
 
+    // Which of two registrations for the same app uid to keep. An installed copy
+    // supersedes the one in ROM, the way it does on a device; otherwise the drive the
+    // scan reaches first wins, so the answer does not depend on scan order.
+    static bool should_replace_duplicate_registry(const apa_app_registry &replacement, const apa_app_registry &existing) {
+        if (replacement.mandatory_info.uid != existing.mandatory_info.uid) {
+            return false;
+        }
+
+        if ((existing.land_drive == drive_z) != (replacement.land_drive == drive_z)) {
+            return existing.land_drive == drive_z;
+        }
+
+        return replacement.land_drive < existing.land_drive;
+    }
+
+    // load_registry() checks for a registration of the same path before it starts
+    // reading, but the read happens outside the lock, so two workers can both get past
+    // that check. Repeat it here, where the entry actually goes in, and settle app uids
+    // claimed by more than one registration file while we hold the lock.
+    static bool commit_registry(std::vector<apa_app_registry> &regs, apa_app_registry &&reg) {
+        auto same_path = std::find_if(regs.begin(), regs.end(), [&reg](const apa_app_registry &existing) {
+            return (common::compare_ignore_case(existing.rsc_path, reg.rsc_path) == 0);
+        });
+
+        if (same_path != regs.end()) {
+            if (same_path->last_rsc_modified == reg.last_rsc_modified) {
+                return false;
+            }
+
+            regs.erase(same_path);
+        }
+
+        if (reg.mandatory_info.uid != 0) {
+            auto same_uid = std::find_if(regs.begin(), regs.end(), [&reg](const apa_app_registry &existing) {
+                return existing.mandatory_info.uid == reg.mandatory_info.uid;
+            });
+
+            if (same_uid != regs.end()) {
+                if (!should_replace_duplicate_registry(reg, *same_uid)) {
+                    return false;
+                }
+
+                regs.erase(same_uid);
+            }
+        }
+
+        regs.push_back(std::move(reg));
+        return true;
+    }
+
     applist_server::applist_server(system *sys)
         : service::typical_server(sys, get_app_list_server_name_by_epocver(sys->get_symbian_version_use()))
         , drive_change_handle_(0)
@@ -195,9 +245,7 @@ namespace eka2l1 {
         }
 
         const std::lock_guard<std::mutex> guard(list_access_mut_);
-        regs.push_back(std::move(reg));
-
-        return true;
+        return commit_registry(regs, std::move(reg));
     }
 
     bool applist_server::load_registry(eka2l1::io_system *io, const std::u16string &path, drive_number land_drive,
@@ -333,8 +381,7 @@ namespace eka2l1 {
         }
 
         const std::lock_guard<std::mutex> guard(list_access_mut_);
-        regs.push_back(std::move(reg));
-        return true;
+        return commit_registry(regs, std::move(reg));
     }
 
     bool applist_server::delete_registry(const std::u16string &rsc_path) {


### PR DESCRIPTION
Registrations go into the list unconditionally at the end of a load. Two ways that produces a list with the same app in it twice:

**The same registration file, twice.** `load_registry` checks whether a registration with that path is already listed — but that check runs at the *start*, and the parse that follows happens outside the list lock. Registrations are loaded on a thread pool (`submit_loop` over the scanned paths), so two workers handed the same path can both get past the check and both append.

**Two registration files claiming one app uid.** A copy installed to `C:` alongside the one in ROM is the ordinary case. Both entries sit in the list, and a lookup by app uid answers with whichever happens to come first.

Both paths that add a registration — the EKA1 one and the modern one — now go through a single place that repeats the path check while holding the lock, and settles a uid claimed twice: an installed copy supersedes the ROM one, the way it does on a device, and otherwise the lower drive letter wins so the outcome does not depend on the order the thread pool finishes in.

No unit test: the insertion path needs a running server, an io system and the thread pool, and the race it closes would not be reproducible in one anyway. The change is confined to the two call sites that append.

Full suite green.