### PR TITLE
applist: Recognise data the way AppArc's clients expect

### DIFF
--- a/src/emu/services/include/services/applist/applist.h
+++ b/src/emu/services/include/services/applist/applist.h
@@ -299,7 +299,6 @@ namespace eka2l1 {
         void get_app_icon_sizes(service::ipc_context &ctx);
         void get_native_executable_name_if_non_native(service::ipc_context &ctx);
         void app_info_provided_by_reg_file(service::ipc_context &ctx);
-        std::string recognize_data_impl(common::ro_stream &stream);
 
         void launch_app(service::ipc_context &ctx);
         void is_program(service::ipc_context &ctx);
@@ -308,6 +307,7 @@ namespace eka2l1 {
         void get_app_for_document_by_file_handle(service::ipc_context &ctx);
         void get_app_for_document_impl(service::ipc_context &ctx, const std::u16string &path);
         void get_app_executable_name_given_app_uid(service::ipc_context &ctx);
+        void recognize_data(service::ipc_context &ctx);
         void recognize_data_by_file_handle(service::ipc_context &ctx);
         void get_supported_data_types_phase1(service::ipc_context &ctx);
         void get_supported_data_types_phase2(service::ipc_context &ctx);
@@ -322,6 +322,10 @@ namespace eka2l1 {
     public:
         explicit applist_server(system *sys);
         ~applist_server() override;
+
+        // Recognition depends on the data and the name, not on server state, so this
+        // is a static and can be exercised on its own.
+        static data_recog_result recognize_data_impl(common::ro_stream &stream, const std::u16string &name);
 
         /**
          * \brief Forget a registeration without waiting for the next rescan.

--- a/src/emu/services/include/services/applist/common.h
+++ b/src/emu/services/include/services/applist/common.h
@@ -106,11 +106,22 @@ namespace eka2l1 {
     };
 #pragma pack(pop)
 
-    struct data_recog_result {
-        recog_data_type type_;
-        std::uint32_t confidence_rating_;
+    // TRecognitionConfidence, from AppArc's apmrec.h. The values matter: a client
+    // compares them, and EPossible is zero rather than the middle of the scale.
+    enum data_recognition_confidence : std::int32_t {
+        data_recognition_confidence_certain = 0x7FFFFFFF,
+        data_recognition_confidence_probable = 100,
+        data_recognition_confidence_possible = 0,
+        data_recognition_confidence_unlikely = -100,
+        data_recognition_confidence_not_recognized = (-0x7FFFFFFF - 1)
     };
 
+    struct data_recog_result {
+        recog_data_type type_;
+        std::int32_t confidence_rating_;
+    };
+
+    static_assert(sizeof(data_recog_result) == 272);
     static_assert(sizeof(apa_capability) == 64);
 
     static constexpr const char16_t *MAPPED_EXECUTABLE_HEAD_STRING = u"MappedExecutable";

--- a/src/emu/services/src/applist/applist.cpp
+++ b/src/emu/services/src/applist/applist.cpp
@@ -46,12 +46,16 @@
 #include <config/config.h>
 
 namespace eka2l1 {
-    static const std::array<std::u16string, 6> RECOG_MIME_TYPES = {
+    static const std::array<std::u16string, 10> RECOG_MIME_TYPES = {
         u"image/png",
         u"image/jpeg",
         u"image/bmp",
+        u"audio/wav",
         u"audio/mpeg",
         u"video/mp4",
+        u"text/html",
+        u"text/xml",
+        u"application/x-shockwave-flash",
         u"application/octet-stream"
     };
 
@@ -932,30 +936,94 @@ namespace eka2l1 {
         get_app_for_document_impl(ctx, path.value());
     }
 
-    std::string applist_server::recognize_data_impl(common::ro_stream &stream) {
+    data_recog_result applist_server::recognize_data_impl(common::ro_stream &stream, const std::u16string &name) {
+        data_recog_result result{};
+        const std::u16string extension = eka2l1::path_extension(name);
+
+        // Match the S60 web recognizer. It identifies XHTML as text/html; it
+        // does not advertise a separate application/xhtml+xml data type.
+        if ((common::compare_ignore_case(extension, u".html") == 0)
+            || (common::compare_ignore_case(extension, u".htm") == 0)
+            || (common::compare_ignore_case(extension, u".shtml") == 0)
+            || (common::compare_ignore_case(extension, u".shtm") == 0)
+            || (common::compare_ignore_case(extension, u".xhtml") == 0)) {
+            result.type_.type_name_.assign(nullptr, "text/html");
+            result.confidence_rating_ = data_recognition_confidence_probable;
+            return result;
+        }
+
+        if (common::compare_ignore_case(extension, u".xml") == 0) {
+            result.type_.type_name_.assign(nullptr, "text/xml");
+            result.confidence_rating_ = data_recognition_confidence_probable;
+            return result;
+        }
+
         std::uint8_t magic4[4] = { 0, 0, 0, 0 };
 
         stream.seek(0, common::seek_where::beg);
         stream.read(magic4, 4);
 
+        if ((common::compare_ignore_case(extension, u".swf") == 0)
+            || (((magic4[0] == 'F') || (magic4[0] == 'C') || (magic4[0] == 'Z'))
+                && (magic4[1] == 'W') && (magic4[2] == 'S'))) {
+            result.type_.type_name_.assign(nullptr, "application/x-shockwave-flash");
+            result.confidence_rating_ = data_recognition_confidence_probable;
+            return result;
+        }
+
         // MP3
         if ((magic4[0] == 0xFF) && ((magic4[1] == 0xFB) || (magic4[1] == 0xF3) || (magic4[1] == 0xF2))) {
-            return "audio/mpeg";
+            result.type_.type_name_.assign(nullptr, "audio/mpeg");
+            result.confidence_rating_ = data_recognition_confidence_probable;
+            return result;
         }
 
         // MP3 ver2
         if ((magic4[0] == 0x49) && (magic4[1] == 0x44) && (magic4[2] == 0x33)) {
-            return "audio/mpeg";
+            result.type_.type_name_.assign(nullptr, "audio/mpeg");
+            result.confidence_rating_ = data_recognition_confidence_probable;
+            return result;
         }
 
         std::uint8_t magic8[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
         stream.read(magic8, 8);
 
-        if (memcmp(magic8, "ftypmp42", 8) == 0) {
-            return "video/mp4";
+        // RIFF size occupies bytes 4-7, followed by the WAVE form type.
+        if ((memcmp(magic4, "RIFF", 4) == 0) && (memcmp(magic8 + 4, "WAVE", 4) == 0)) {
+            result.type_.type_name_.assign(nullptr, "audio/wav");
+            result.confidence_rating_ = data_recognition_confidence_certain;
+            return result;
         }
 
-        return "application/octet-stream";
+        if (memcmp(magic8, "ftypmp42", 8) == 0) {
+            result.type_.type_name_.assign(nullptr, "video/mp4");
+            result.confidence_rating_ = data_recognition_confidence_probable;
+            return result;
+        }
+
+        // Probable, not possible: EPossible is numerically zero, which a client reads
+        // as "nothing recognised this" and answers by taking another path entirely.
+        result.type_.type_name_.assign(nullptr, "application/octet-stream");
+        result.confidence_rating_ = data_recognition_confidence_probable;
+        return result;
+    }
+
+    void applist_server::recognize_data(service::ipc_context &ctx) {
+        std::uint8_t *data = ctx.get_descriptor_argument_ptr(2);
+        const std::size_t data_size = ctx.get_argument_data_size(2);
+        const std::optional<std::u16string> name = ctx.get_argument_value<std::u16string>(1);
+
+        if (!data && data_size != 0) {
+            ctx.complete(epoc::error_argument);
+            return;
+        }
+
+        std::uint8_t empty_data = 0;
+        common::ro_buf_stream stream(data ? data : &empty_data, data_size);
+        const data_recog_result result = recognize_data_impl(stream, name.value_or(std::u16string()));
+
+        ctx.write_data_to_descriptor_argument<data_recog_result>(0, result);
+        ctx.complete(epoc::error_none);
     }
 
     void applist_server::recognize_data_by_file_handle(service::ipc_context &ctx) {
@@ -971,17 +1039,14 @@ namespace eka2l1 {
         const std::uint64_t current_pos = source_file->tell();
         ro_file_stream stream_read(source_file);
 
-        const std::string mime_res = recognize_data_impl(stream_read);
+        const data_recog_result result = recognize_data_impl(stream_read, source_file->file_name());
         source_file->seek(current_pos, file_seek_mode::beg);
 
-        if (mime_res.empty()) {
+        if (result.type_.type_name_.get_length() == 0) {
             LOG_WARN(SERVICE_APPLIST, "File MIME data is not recognizable (filename: {})!", common::ucs2_to_utf8(source_file->file_name()));
             ctx.complete(epoc::error_not_supported);
+            return;
         }
-
-        data_recog_result result;
-        result.confidence_rating_ = 10;             // TODO: Fill with actual value
-        result.type_.type_name_.assign(nullptr, mime_res);
 
         ctx.write_data_to_descriptor_argument<data_recog_result>(0, result);
         ctx.complete(epoc::error_none);
@@ -1233,6 +1298,10 @@ namespace eka2l1 {
 
             case applist_request_app_for_document_passed_by_file_handle:
                 server<applist_server>()->get_app_for_document_by_file_handle(*ctx);
+                break;
+
+            case applist_request_recognize_data:
+                server<applist_server>()->recognize_data(*ctx);
                 break;
 
             case applist_request_recognize_data_passed_by_file_handle:

--- a/src/tests/epoc/CMakeLists.txt
+++ b/src/tests/epoc/CMakeLists.txt
@@ -11,6 +11,7 @@ set(CORE_TEST_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/svgb.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/package/manager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/applist/registeration.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/services/applist/recognize.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/fbs/bitmap.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/fbs/fontmatch.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/fbs/linkedfont.cpp

--- a/src/tests/epoc/services/applist/recognize.cpp
+++ b/src/tests/epoc/services/applist/recognize.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch.hpp>
+
+#include <common/buffer.h>
+#include <services/applist/applist.h>
+
+#include <string>
+#include <vector>
+
+using namespace eka2l1;
+
+namespace {
+    data_recog_result recognize(std::vector<std::uint8_t> data, const std::u16string &name) {
+        common::ro_buf_stream stream(data.empty() ? nullptr : data.data(), data.size());
+        return applist_server::recognize_data_impl(stream, name);
+    }
+
+    std::string type_of(data_recog_result result) {
+        return result.type_.type_name_.to_std_string(nullptr);
+    }
+
+    std::vector<std::uint8_t> bytes(const std::string &content) {
+        return std::vector<std::uint8_t>(content.begin(), content.end());
+    }
+}
+
+TEST_CASE("recognizer_reports_apparc_confidence_values", "applist") {
+    // TRecognitionConfidence (apmrec.h). A client compares these numerically, and
+    // EPossible is zero rather than the middle of the scale, so the fallback below
+    // has to sit above it or it reads as "nothing recognised this".
+    REQUIRE(data_recognition_confidence_certain == 0x7FFFFFFF);
+    REQUIRE(data_recognition_confidence_probable == 100);
+    REQUIRE(data_recognition_confidence_possible == 0);
+    REQUIRE(data_recognition_confidence_unlikely == -100);
+
+    data_recog_result unknown = recognize(bytes("nothing in particular"), u"c:\\data\\thing.bin");
+    REQUIRE(type_of(unknown) == "application/octet-stream");
+    REQUIRE(unknown.confidence_rating_ > data_recognition_confidence_possible);
+}
+
+TEST_CASE("recognizer_reads_the_name_for_web_content", "applist") {
+    // S60's web recognizer reports XHTML as text/html; it has no separate
+    // application/xhtml+xml type. The Store's local front page is an .xhtml file
+    // whose bytes say nothing, so the name is the only thing to go on.
+    const std::vector<std::uint8_t> page = bytes("<!DOCTYPE html><html></html>");
+
+    for (const std::u16string &name : { std::u16string(u"e:\\showroom\\front.xhtml"),
+             std::u16string(u"e:\\showroom\\front.html"), std::u16string(u"e:\\a.HTM"),
+             std::u16string(u"e:\\a.shtml") }) {
+        data_recog_result result = recognize(page, name);
+        REQUIRE(type_of(result) == "text/html");
+        REQUIRE(result.confidence_rating_ == data_recognition_confidence_probable);
+    }
+
+    data_recog_result xml = recognize(page, u"e:\\feed.xml");
+    REQUIRE(type_of(xml) == "text/xml");
+}
+
+TEST_CASE("recognizer_reads_the_magic_for_media", "applist") {
+    // RIFF, a size, then the WAVE form type at bytes 8 to 11.
+    std::vector<std::uint8_t> wave = { 'R', 'I', 'F', 'F', 0x24, 0x08, 0, 0, 'W', 'A', 'V', 'E' };
+    data_recog_result wav = recognize(wave, u"c:\\sound.dat");
+    REQUIRE(type_of(wav) == "audio/wav");
+    REQUIRE(wav.confidence_rating_ == data_recognition_confidence_certain);
+
+    // An ID3 tag, and a bare MPEG frame header.
+    REQUIRE(type_of(recognize({ 'I', 'D', '3', 0x03, 0, 0, 0, 0, 0, 0, 0, 0 }, u"c:\\a.dat")) == "audio/mpeg");
+    REQUIRE(type_of(recognize({ 0xFF, 0xFB, 0x90, 0x00, 0, 0, 0, 0, 0, 0, 0, 0 }, u"c:\\a.dat")) == "audio/mpeg");
+
+    // The three Flash signatures: uncompressed, zlib and LZMA.
+    for (const char first : { 'F', 'C', 'Z' }) {
+        std::vector<std::uint8_t> flash = { static_cast<std::uint8_t>(first), 'W', 'S', 0x0A, 0, 0, 0, 0, 0, 0, 0, 0 };
+        REQUIRE(type_of(recognize(flash, u"c:\\movie.dat")) == "application/x-shockwave-flash");
+    }
+
+    // ftyp sits at byte 4, so the brand runs from 4 to 11.
+    REQUIRE(type_of(recognize({ 0, 0, 0, 0x18, 'f', 't', 'y', 'p', 'm', 'p', '4', '2' }, u"c:\\clip.dat")) == "video/mp4");
+}


### PR DESCRIPTION
The N-Gage Launcher's Store tab freezes with an empty page and stops answering keys. It calls `RApaLsSession::RecognizeData`, and the buffer form of that request — opcode `0xA`, `applist_request_recognize_data` — had no handler at all; only the file-handle form did. The session logged `Unimplemented applist opcode 0xA` and never completed the message, so the guest sat in `SendReceive` forever.

Implementing it exposed the next problem: the Store then reported *Out of internal memory (Error -4)*. Its local front page is `frontpage_lg-1.xhtml`, whose 637 bytes begin with `<!DOCTYPE` and match no magic number, so the recognizer answered `application/octet-stream` — which sent the page down a content handler that could not read it. The guest's `KErrNoMemory` was a guest-side error, not host memory exhaustion.

The S60 web recognizer answers those by name: `.html`, `.htm`, `.shtml`, `.shtm` and `.xhtml` are all `text/html` (S60 deliberately does not report XHTML as `application/xhtml+xml`), and `.xml` is `text/xml`. Both IPC forms now pass the file name into the recognizer, and the two web types join the array the server advertises as supported.

**The confidence value was a literal 10**, with a TODO next to it, and 10 is not a member of `TRecognitionConfidence` at all. AppArc's values (`apmrec.h`) are `ECertain = KMaxTInt`, `EProbable = 100`, `EPossible = 0`, `EUnlikely = -100`, `ENotRecognized = KMinTInt`, and clients compare them numerically. `EPossible` being zero is why the `application/octet-stream` fallback must report `EProbable`: at zero a client reads it as nothing having recognised the data and takes another path entirely. The field is signed now, since two of the five values are negative.

Flash and WAV recognition come along because the same page needs them: `FWS`/`CWS`/`ZWS` for the three Shockwave container flavours, and `RIFF` with a `WAVE` form type — the one case certain enough to report `ECertain`.

Tests cover the confidence contract, the name-driven web types and each magic number. The recognizer is a static member now, since it depends on the data and the name rather than on server state, which is what makes it testable at all. Reverting the fallback to `EPossible` fails the first test.

Full suite green (138 cases, 2603 assertions).