### PR TITLE
sensor: Make a backend callback safe to run

### DIFF
--- a/src/emu/services/include/services/sensor/sensor.h
+++ b/src/emu/services/include/services/sensor/sensor.h
@@ -30,6 +30,8 @@
 #include <memory>
 
 namespace eka2l1 {
+    struct sensor_client_session_callback_state;
+
     class sensor_server : public service::typical_server {
     public:
         explicit sensor_server(eka2l1::system *sys);
@@ -38,13 +40,17 @@ namespace eka2l1 {
 
     struct sensor_client_session : public service::typical_session {
     private:
+        std::shared_ptr<sensor_client_session_callback_state> callback_state_;
         std::map<std::uint32_t, std::unique_ptr<drivers::sensor>> channels_;
         std::map<std::uint32_t, std::unique_ptr<service::ipc_context>> channel_data_msgs_;
         std::map<std::uint32_t, std::uint64_t> ask_recv_time_;
 
         drivers::sensor *get_sensor_channel(const std::uint32_t id);
+        void complete_channel_data_request_locked(kernel_system *kern, const std::uint32_t channel_id,
+            std::vector<std::uint8_t> &data, std::size_t packet_sent);
     public:
         explicit sensor_client_session(service::typical_server *serv, const kernel::uid ss_id, epoc::version client_version);
+        ~sensor_client_session() override;
 
         void fetch(service::ipc_context *ctx) override;
         void query_channels(eka2l1::service::ipc_context *ctx);
@@ -55,7 +61,5 @@ namespace eka2l1 {
         void channel_data(eka2l1::service::ipc_context *ctx);
         void get_property(eka2l1::service::ipc_context *ctx);
         void get_all_properties(eka2l1::service::ipc_context *ctx);
-
-        void complete_channel_data_request(const std::uint32_t channel_id, std::vector<std::uint8_t> &data, std::size_t packet_sent);
     };
 }

--- a/src/emu/services/src/sensor/sensor.cpp
+++ b/src/emu/services/src/sensor/sensor.cpp
@@ -27,6 +27,14 @@
 #include <atomic>
 
 namespace eka2l1 {
+    // A backend callback can outlive the request that armed it, and the session it
+    // would report to. The callback holds this instead of the session; session_ is
+    // only read or cleared while the kernel lock is held.
+    struct sensor_client_session_callback_state {
+        kernel_system *kern_;
+        sensor_client_session *session_;
+    };
+
     sensor_server::sensor_server(eka2l1::system *sys)
         : service::typical_server(sys, "!SensorServer") {
     }
@@ -38,7 +46,19 @@ namespace eka2l1 {
 
     sensor_client_session::sensor_client_session(service::typical_server *serv, const kernel::uid ss_id,
         epoc::version client_version)
-        : service::typical_session(serv, ss_id, client_version) {
+        : service::typical_session(serv, ss_id, client_version)
+        , callback_state_(std::make_shared<sensor_client_session_callback_state>(
+              sensor_client_session_callback_state{ serv->get_kernel_object_owner(), this })) {
+    }
+
+    sensor_client_session::~sensor_client_session() {
+        // Sessions are destroyed under the kernel lock, so a callback that is already
+        // waiting on it sees this before it can look at the session.
+        callback_state_->session_ = nullptr;
+
+        for (auto &channel : channels_) {
+            channel.second->cancel_data_listening();
+        }
     }
 
     void sensor_client_session::fetch(service::ipc_context *ctx) {
@@ -99,6 +119,16 @@ namespace eka2l1 {
         }
 
         drivers::sensor_driver *ssdriver = ctx->sys->get_sensor_driver();
+        if (!ssdriver) {
+            // A frontend that has no sensor backend leaves the driver unset. Report
+            // no channels rather than dereferencing it.
+            std::uint32_t channel_info_count = 0;
+            ctx->write_data_to_descriptor_argument(2, channel_info_count);
+            ctx->set_descriptor_argument_length(1, 0);
+            ctx->complete(epoc::error_none);
+            return;
+        }
+
         drivers::sensor_info search_info_driver;
 
         // TODO: I don't copy vendor and location in because.. don't feel like needed. In future cases, please do.
@@ -144,6 +174,12 @@ namespace eka2l1 {
         }
 
         drivers::sensor_driver *ssdriver = ctx->sys->get_sensor_driver();
+        if (!ssdriver) {
+            LOG_ERROR(SERVICE_SENSOR, "No sensor driver available, unable to open channel {}", channel_id);
+            ctx->complete(epoc::error_not_supported);
+
+            return;
+        }
 
         auto controller = ssdriver->new_sensor_controller(channel_id);
         if (!controller) {
@@ -169,6 +205,13 @@ namespace eka2l1 {
         auto find_result = channels_.find(channel_id);
         
         if (find_result != channels_.end()) {
+            auto data_msg = channel_data_msgs_.find(channel_id);
+            if (data_msg != channel_data_msgs_.end()) {
+                data_msg->second->complete(epoc::error_cancel);
+                channel_data_msgs_.erase(data_msg);
+            }
+            ask_recv_time_.erase(channel_id);
+
             channels_.erase(find_result);
             ctx->complete(epoc::error_none);
 
@@ -229,6 +272,7 @@ namespace eka2l1 {
             ite->second->complete(epoc::error_cancel);
             channel_data_msgs_.erase(ite);
         }
+        ask_recv_time_.erase(channel_id);
 
         ctx->complete(epoc::error_none);
     }
@@ -248,51 +292,95 @@ namespace eka2l1 {
             return;
         }
 
+        // Both output descriptors are mandatory here. Refusing a bad one now is much
+        // better than arming a backend callback that cannot report anywhere later.
+        if (!ctx->get_descriptor_argument_ptr(1) || !ctx->get_descriptor_argument_ptr(2)
+            || (ctx->get_argument_max_data_size(2) < sizeof(data_count_ret_val))) {
+            ctx->complete(epoc::error_bad_descriptor);
+            return;
+        }
+
         channel_data_msgs_[channel_id] = ctx->move_to_new();
         ask_recv_time_[channel_id] = common::get_current_utc_time_in_microseconds_since_epoch();
 
-        channel->receive_data([this, channel_id](std::vector<std::uint8_t> &data, std::size_t packet_sent) {
-            complete_channel_data_request(channel_id, data, packet_sent);
+        const std::shared_ptr<sensor_client_session_callback_state> callback_state = callback_state_;
+        channel->receive_data([callback_state, channel_id](std::vector<std::uint8_t> &data, std::size_t packet_sent) {
+            kernel_system *kern = callback_state->kern_;
+            kern->lock();
+
+            // Taking the kernel lock before touching the session or the IPC message
+            // serialises this completion against StopListening, CloseChannel and
+            // session teardown, all of which run on the emulated thread.
+            if (callback_state->session_) {
+                callback_state->session_->complete_channel_data_request_locked(kern, channel_id, data, packet_sent);
+            }
+
+            kern->unlock();
         });
     }
 
-    void sensor_client_session::complete_channel_data_request(const std::uint32_t channel_id, std::vector<std::uint8_t> &data, std::size_t packet_sent) {
+    void sensor_client_session::complete_channel_data_request_locked(kernel_system *kern,
+        const std::uint32_t channel_id, std::vector<std::uint8_t> &data, std::size_t packet_sent) {
         auto channel_msg_ite = channel_data_msgs_.find(channel_id);
         if (channel_msg_ite == channel_data_msgs_.end()) {
-            LOG_ERROR(SERVICE_SENSOR, "Channel data receive message is not available!");
             return;
         }
 
         std::unique_ptr<service::ipc_context> context = std::move(channel_msg_ite->second);
+        channel_data_msgs_.erase(channel_msg_ite);
+
         drivers::sensor *controller = get_sensor_channel(channel_id);
 
         if (!controller) {
-            LOG_ERROR(SERVICE_SENSOR, "Channel controller is not available!");
+            ask_recv_time_.erase(channel_id);
             return;
         }
 
-        channel_data_msgs_.erase(channel_msg_ite);
+        // The message holds a raw pointer to the requesting thread, which may have
+        // gone away while the backend was working. The kernel lock is held here.
+        if (!context || !context->msg || !kern->is_thread_alive(context->msg->own_thr)) {
+            ask_recv_time_.erase(channel_id);
+            return;
+        }
+
+        if (!context->get_descriptor_argument_ptr(1) || !context->get_descriptor_argument_ptr(2)) {
+            ask_recv_time_.erase(channel_id);
+            context->complete(epoc::error_bad_descriptor);
+            return;
+        }
 
         data_count_ret_val ret_val;
         ret_val.item_count_ = packet_sent;
         ret_val.lost_count_ = 0;
 
         const std::size_t max_write_bytes = context->get_argument_max_data_size(1);
+        const std::size_t count_write_bytes = context->get_argument_max_data_size(2);
+        if (count_write_bytes < sizeof(ret_val)) {
+            ask_recv_time_.erase(channel_id);
+            context->complete(epoc::error_overflow);
+            return;
+        }
+
         const std::size_t max_item_fill = max_write_bytes / controller->data_packet_size();
 
         if (max_item_fill < packet_sent) {
             ret_val.lost_count_ = packet_sent - max_item_fill;
         }
 
-        kernel_system *kern = context->msg->own_thr->get_kernel_object_owner();
-        kern->lock();
+        const bool count_written = context->write_data_to_descriptor_argument(2, ret_val);
+        const bool data_written = context->write_data_to_descriptor_argument(1, data.data(), common::min<std::uint32_t>(
+            static_cast<std::uint32_t>(max_write_bytes), static_cast<std::uint32_t>(data.size())));
 
-        context->write_data_to_descriptor_argument(2, ret_val);
-        context->write_data_to_descriptor_argument(1, data.data(), common::min<std::uint32_t>(
-                static_cast<std::uint32_t>(max_write_bytes), static_cast<std::uint32_t>(data.size())));
+        if (!count_written || !data_written) {
+            ask_recv_time_.erase(channel_id);
+            context->complete(epoc::error_bad_descriptor);
+            return;
+        }
 
         const std::uint64_t now = common::get_current_utc_time_in_microseconds_since_epoch();
-        const std::uint64_t passed = (now - ask_recv_time_[channel_id]);
+        const auto ask_time = ask_recv_time_.find(channel_id);
+        const std::uint64_t passed = (ask_time != ask_recv_time_.end()) ? (now - ask_time->second) : 0;
+        ask_recv_time_.erase(channel_id);
 
         static constexpr std::uint64_t TIME_GET_BACK_REQUEST = 60;
 
@@ -304,7 +392,6 @@ namespace eka2l1 {
         }
 
         context->complete(epoc::error_none);
-        kern->unlock();
     }
 
     static void copy_driver_sensor_property_to_client(drivers::sensor_property_data &source, sensor_property &dest) {


### PR DESCRIPTION
A guest arms a channel-data request, the sensor backend calls back on its own thread, and the completion path assumed everything it needed was still there. Three ways it is not:

- **The session may be gone.** The callback captured `this`, so a client that closed its session while a sample was in flight left the callback writing through a destroyed object. It holds a small shared state now, whose session pointer the destructor clears — under the kernel lock, which the callback also takes, so it sees one state or the other and never a half-torn-down session.
- **The requesting thread may be gone.** The stored IPC message keeps a raw pointer to it, so the completion checks the thread is still alive before dereferencing any guest descriptor.
- **The descriptors may not be usable.** Both output arguments are mandatory and the count slot has to be big enough for what goes into it, so a request that cannot be answered is refused when it arrives rather than after a backend callback has been armed for it.

Closing a channel or cancelling data listening now also completes a request that was still outstanding — previously the client kept waiting on a channel that no longer existed — and drops the timing entry that went with it, which the old code read back with `operator[]` and silently defaulted.

Separately, and much smaller: a frontend with no sensor backend leaves the driver unset. Querying channels dereferenced it after answering, and opening one dereferenced it outright. Querying now reports no channels and opening reports `KErrNotSupported`.

Full suite green.