### PR TITLE
efsrv: Keep file sharing state under one form of the path

### DIFF
--- a/src/emu/services/include/services/fs/fs.h
+++ b/src/emu/services/include/services/fs/fs.h
@@ -323,7 +323,7 @@ namespace eka2l1 {
         void get_default_system_path(service::ipc_context *ctx);
 
         enum {
-            FLAG_INITED = 0
+            FLAG_INITED = 1 << 0
         };
 
         std::uint32_t flags;

--- a/src/emu/services/src/fs/files.cpp
+++ b/src/emu/services/src/fs/files.cpp
@@ -59,6 +59,13 @@ namespace eka2l1 {
         return common::compare_ignore_case(normalized, own) == 0;
     }
 
+    // The sharing state is keyed by path, so the key has to be one single form of it:
+    // a file opened as "c:/dir/f" and again as "c:\dir\f" is the same file.
+    static std::u16string canonical_file_attrib_path(std::u16string path) {
+        return eka2l1::transform_separators<char16_t>(
+            std::move(path), true, eka2l1::get_separator_16);
+    }
+
     bool file_attrib::claim_exclusive(const kernel::uid pr_uid) {
         if (owner == pr_uid) {
             flags |= static_cast<std::uint32_t>(fs_file_attrib_flag::exclusive);
@@ -110,7 +117,7 @@ namespace eka2l1 {
     void fs_node::deref() {
         if (vfs_node->type == io_component_type::file) {        
             file *vfs_file = reinterpret_cast<file *>(vfs_node.get());
-            const std::u16string filename = vfs_file->file_name();
+            const std::u16string filename = canonical_file_attrib_path(vfs_file->file_name());
 
             auto ite = serv->attribs.find(filename);
             if (ite != serv->attribs.end()) {
@@ -436,6 +443,7 @@ namespace eka2l1 {
         }
 
         file *vfs_file = reinterpret_cast<file *>(node->vfs_node.get());
+        const std::u16string old_path = vfs_file->file_name();
         auto new_path = ctx->get_argument_value<std::u16string>(0);
 
         if (!new_path) {
@@ -449,7 +457,7 @@ namespace eka2l1 {
             return;
         }
 
-        bool res = ctx->sys->get_io_system()->rename(vfs_file->file_name(), new_path_abs);
+        bool res = ctx->sys->get_io_system()->rename(old_path, new_path_abs);
 
         if (!res) {
             ctx->complete(epoc::error_general);
@@ -463,9 +471,30 @@ namespace eka2l1 {
         vfs_file->close();
 
         symfile new_vfs_file = ctx->sys->get_io_system()->open_file(new_path_abs, last_mode);
+
+        if (!new_vfs_file) {
+            // Renamed on disk, but the new path would not open. Say so, rather than
+            // leaving the subsession holding a null file it dereferences next.
+            LOG_ERROR(SERVICE_EFSRV, "Can't reopen {} after rename", common::ucs2_to_utf8(new_path_abs));
+            ctx->complete(epoc::error_general);
+            return;
+        }
+
         new_vfs_file->seek(last_pos, file_seek_mode::beg);
 
         node->vfs_node = std::move(new_vfs_file);
+
+        auto &attribs = server<fs_server>()->attribs;
+        auto attrib_node = attribs.extract(canonical_file_attrib_path(old_path));
+        if (!attrib_node.empty()) {
+            attrib_node.key() = canonical_file_attrib_path(new_path_abs);
+            auto insert_result = attribs.insert(std::move(attrib_node));
+            if (!insert_result.inserted) {
+                LOG_ERROR(SERVICE_EFSRV,
+                    "File sharing state already exists after renaming {} to {}",
+                    common::ucs2_to_utf8(old_path), common::ucs2_to_utf8(new_path_abs));
+            }
+        }
 
         ctx->complete(epoc::error_none);
     }
@@ -641,6 +670,13 @@ namespace eka2l1 {
         }
 
         symfile temp_file = server<fs_server>()->get_temp_file(full_path);
+
+        if (!temp_file) {
+            LOG_ERROR(SERVICE_EFSRV, "Can't create a temp file in {}", common::ucs2_to_utf8(full_path));
+            ctx->complete(epoc::error_general);
+            return;
+        }
+
         full_path = temp_file->file_name();
 
         temp_file->close();
@@ -659,7 +695,9 @@ namespace eka2l1 {
         ctx->write_data_to_descriptor_argument<int>(3, handle);
 
         // Arg2 take the temp path
-        ctx->write_arg(2, full_path);
+        const utf16_str guest_path = eka2l1::transform_separators<char16_t>(
+            full_path, true, eka2l1::get_separator_16);
+        ctx->write_arg(2, guest_path);
         ctx->complete(epoc::error_none);
     }
 
@@ -680,7 +718,8 @@ namespace eka2l1 {
 
         file *f = reinterpret_cast<file *>(node->vfs_node.get());
 
-        auto &node_attrib = server<fs_server>()->attribs[f->file_name()];
+        auto &node_attrib = server<fs_server>()->attribs[
+            canonical_file_attrib_path(f->file_name())];
         node_attrib.increment_use(node->process);
 
         ctx->write_data_to_descriptor_argument<epoc::handle>(3, dup_handle);
@@ -944,7 +983,8 @@ namespace eka2l1 {
 
         // Check the attribute first
         fs_node *new_node = server<fs_server>()->make_new<fs_node>();
-        auto &node_attrib = server<fs_server>()->attribs[name];
+        auto &node_attrib = server<fs_server>()->attribs[
+            canonical_file_attrib_path(name)];
 
         if (node_attrib.is_exlusive()) {
             // Check if we can open it


### PR DESCRIPTION
The file server keys a file's sharing state — who has it open, and whether exclusively — by the path it was opened with. Nothing settled on a single form of that path, so the same file opened as `c:/dir/f` and as `c:\dir\f` gets two independent entries, and an exclusive open stops keeping the second one out. All three places that touch the map (open, duplicate, release) now go through one canonical form.

**Renaming lost the state entirely.** The entry stayed under the old path, where nothing would look for it again, and the new path started clean — so a file that was open exclusively could be opened again by anybody after a rename.

**Two failures in the same area were reported as success.** A rename whose new path would not open left the subsession holding a null file for whatever it did next to dereference; a temp file that could not be created did the same. Both report an error now. `Fs::TempFile` also handed back a host-shaped path, which the guest cannot use as a file name.

**`FLAG_INITED` was defined as `0`.** `flags |= FLAG_INITED` therefore set nothing and every test of it read false, so `fs_server::init()` ran in full — creating the predictable directory tree — on every connect *and* every session lookup, instead of once.

Full suite green.