### PR TITLE
common: fix five defects in the shared helpers, and one data race

### DIFF
--- a/src/emu/common/include/common/linked.h
+++ b/src/emu/common/include/common/linked.h
@@ -73,7 +73,7 @@ namespace eka2l1::common {
         }
 
         bool alone() const {
-            return next == previous;
+            return (next == nullptr) && (previous == nullptr);
         }
     };
 

--- a/src/emu/common/include/common/pystr.h
+++ b/src/emu/common/include/common/pystr.h
@@ -152,7 +152,7 @@ namespace eka2l1::common {
         basic_pystr<T> lstrip() const {
             auto news = str_;
 
-            while (news[0] == static_cast<T>(' ')) {
+            while (!news.empty() && news[0] == static_cast<T>(' ')) {
                 news.erase(news.begin(), news.begin() + 1);
             }
 
@@ -162,7 +162,7 @@ namespace eka2l1::common {
         basic_pystr<T> rstrip() const {
             auto news = str_;
 
-            while (news.back() == static_cast<T>(' ')) {
+            while (!news.empty() && news.back() == static_cast<T>(' ')) {
                 news.pop_back();
             }
 

--- a/src/emu/common/include/common/sync.h
+++ b/src/emu/common/include/common/sync.h
@@ -82,6 +82,8 @@ namespace eka2l1::common {
         explicit event();
         ~event();
 
+        // Auto-reset event semantics: set stores one pending signal, and a
+        // successful wait consumes it atomically.
         void set();
 
         void wait();

--- a/src/emu/common/src/cvt.cpp
+++ b/src/emu/common/src/cvt.cpp
@@ -35,11 +35,16 @@ namespace eka2l1 {
         using char_ucs2 = char16_t;
 #endif
 
-        std::wstring_convert<std::codecvt_utf8_utf16<char_ucs2>, char_ucs2> ucs2_to_utf8_converter;
-        std::wstring_convert<std::codecvt_utf8_utf16<char_ucs2>, char_ucs2> utf8_to_ucs2_converter;
-        std::wstring_convert<std::codecvt_utf16<wchar_t, 0x10ffff, std::little_endian>, wchar_t> ucs2_to_wstr_converter;
-        std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> utf8_to_wstr_converter;
-        std::wstring_convert<std::codecvt_utf8<wchar_t>> wstr_to_utf8_converter;
+        // std::wstring_convert carries mutable conversion state that every
+        // to_bytes/from_bytes call writes to, so one shared instance cannot serve
+        // the UI, CPU, timer and service threads that all reach the helpers below.
+        // Per thread rather than per call: each instance allocates a codecvt facet
+        // and these paths are hot.
+        thread_local std::wstring_convert<std::codecvt_utf8_utf16<char_ucs2>, char_ucs2> ucs2_to_utf8_converter;
+        thread_local std::wstring_convert<std::codecvt_utf8_utf16<char_ucs2>, char_ucs2> utf8_to_ucs2_converter;
+        thread_local std::wstring_convert<std::codecvt_utf16<wchar_t, 0x10ffff, std::little_endian>, wchar_t> ucs2_to_wstr_converter;
+        thread_local std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> utf8_to_wstr_converter;
+        thread_local std::wstring_convert<std::codecvt_utf8<wchar_t>> wstr_to_utf8_converter;
 
         // VS2017 bug: https://stackoverflow.com/questions/32055357/visual-studio-c-2015-stdcodecvt-with-char16-t-or-char32-t
         std::string ucs2_to_utf8(const std::u16string &str) {

--- a/src/emu/common/src/flate.cpp
+++ b/src/emu/common/src/flate.cpp
@@ -603,7 +603,24 @@ namespace eka2l1 {
 
                 // Things are still remain shit
                 if (remain > 0) {
-                    tbits = swap_bo(*buf_ptr++);
+                    if (remain >= 32) {
+                        tbits = swap_bo(*buf_ptr++);
+                    } else {
+                        // Final partial word: the stream does not have to be word-sized,
+                        // so a full 32-bit load would run past the caller's buffer.
+                        // Assemble the valid bytes instead; the missing low bytes are
+                        // zero and never consumed (count is capped by remain below).
+                        const std::uint8_t *tail = reinterpret_cast<const std::uint8_t *>(buf_ptr);
+                        const int valid_bytes = (remain + 7) / 8;
+
+                        tbits = 0;
+                        for (int i = 0; i < valid_bytes; i++) {
+                            tbits |= static_cast<std::uint32_t>(tail[i]) << (24 - (i * 8));
+                        }
+
+                        buf_ptr++;
+                    }
+
                     count += 32;
                     remain -= 32;
 

--- a/src/emu/common/src/region.cpp
+++ b/src/emu/common/src/region.cpp
@@ -192,24 +192,18 @@ namespace eka2l1::common {
     }
 
     void region::clip(const eka2l1::rect &bounding) {
-        eka2l1::vec2 top_left = bounding.top;
-        eka2l1::vec2 bottom_right = bounding.bottom_right();
+        if ((bounding.size.x <= 0) || (bounding.size.y <= 0)) {
+            rects_.clear();
+            return;
+        }
 
-        for (std::size_t i = 0; i < rects_.size(); i++) {
-            if (rects_[i].top.x < top_left.x) {
-                rects_[i].top.x = top_left.x;
-            }
+        for (std::size_t i = 0; i < rects_.size();) {
+            rects_[i] = rects_[i].intersect(bounding);
 
-            if (rects_[i].top.y < top_left.y) {
-                rects_[i].top.x = top_left.x;
-            }
-
-            if (rects_[i].bottom_right().x > bottom_right.x) {
-                rects_[i].size.x = bottom_right.x - rects_[i].top.x;
-            }
-            
-            if (rects_[i].bottom_right().y > bottom_right.y) {
-                rects_[i].size.y = bottom_right.y - rects_[i].top.y;
+            if ((rects_[i].size.x <= 0) || (rects_[i].size.y <= 0)) {
+                rects_.erase(rects_.begin() + i);
+            } else {
+                i++;
             }
         }
     }

--- a/src/emu/common/src/sync.cpp
+++ b/src/emu/common/src/sync.cpp
@@ -72,7 +72,10 @@ namespace eka2l1::common {
 
     public:
         explicit event_impl() {
-            evt_ = CreateEvent(NULL, TRUE, FALSE, NULL);
+            // Auto-reset, matching the condition-variable implementation below:
+            // one signal releases one waiter and the wait consumes it atomically.
+            // Resetting from the waiter instead would drop a concurrent set().
+            evt_ = CreateEvent(NULL, FALSE, FALSE, NULL);
             timer_ = NULL;
 
             if (!evt_) {
@@ -139,12 +142,10 @@ namespace eka2l1::common {
             case WAIT_OBJECT_0:
                 // Cancel the pending timer
                 CancelWaitableTimer(timer_);
-                ResetEvent(evt_);
 
                 return true;
 
             case WAIT_OBJECT_0 + 1:
-                ResetEvent(evt_);
                 return false;
 
             default:

--- a/src/emu/kernel/src/scheduler.cpp
+++ b/src/emu/kernel/src/scheduler.cpp
@@ -131,7 +131,6 @@ namespace eka2l1::kernel {
             if (kern->should_core_idle_when_inactive()) {
                 kern->unlock();
                 idle_event.wait();
-                idle_event.reset();
                 kern->lock();
             }
         }

--- a/src/tests/common/CMakeLists.txt
+++ b/src/tests/common/CMakeLists.txt
@@ -4,9 +4,13 @@ set(COMMON_TEST_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/bytes.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/chunkyseri.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/crypt.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/flate.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ini.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/linked.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/paint.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/path.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/pystr.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/region.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/runlen.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/sync.cpp
     PARENT_SCOPE)

--- a/src/tests/common/flate.cpp
+++ b/src/tests/common/flate.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch.hpp>
+#include <common/flate.h>
+
+#include <memory>
+
+using namespace eka2l1;
+
+// TBitInput::Set takes a length in bits, and the stream it describes is only
+// as long as that: Symbian's compressed sections are byte granular and are
+// routinely not a whole number of words. Reading the last bits must therefore
+// stay inside the buffer the caller supplied. Sized exactly so a sanitiser
+// build traps an over-read.
+TEST_CASE("bit_input stays inside a stream that is not word sized", "flate") {
+    constexpr std::uint8_t stream[] = { 0x12, 0x34, 0x56, 0x78, 0x9A };
+    std::unique_ptr<std::uint8_t[]> buffer = std::make_unique<std::uint8_t[]>(sizeof(stream));
+
+    std::copy(stream, stream + sizeof(stream), buffer.get());
+
+    flate::bit_input input;
+    input.set(buffer.get(), static_cast<int>(sizeof(stream)) * 8);
+
+    for (const std::uint8_t expected : stream) {
+        REQUIRE(input.read(8) == expected);
+    }
+}

--- a/src/tests/common/linked.cpp
+++ b/src/tests/common/linked.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include <catch2/catch.hpp>
+#include <common/linked.h>
+
+using namespace eka2l1;
+
+TEST_CASE("single roundabout member is linked", "linked") {
+    common::roundabout queue;
+    common::double_linked_queue_element member;
+
+    REQUIRE(member.alone());
+
+    queue.push(&member);
+
+    REQUIRE_FALSE(member.alone());
+    REQUIRE(queue.first() == &member);
+    REQUIRE(queue.last() == &member);
+
+    member.deque();
+
+    REQUIRE(member.alone());
+    REQUIRE(queue.empty());
+}

--- a/src/tests/common/pystr.cpp
+++ b/src/tests/common/pystr.cpp
@@ -85,3 +85,13 @@ TEST_CASE("str_to_fp_fract_neg", "pystr") {
     common::pystr test("-60.56");
     REQUIRE(test.as_fp<float>() == -60.56f);
 }
+
+// Python's str.strip() family returns an empty string for an empty string
+// rather than raising; this type exists to mirror it.
+TEST_CASE("strip_empty", "pystr") {
+    common::pystr test("");
+
+    REQUIRE(test.lstrip().std_str().empty());
+    REQUIRE(test.rstrip().std_str().empty());
+    REQUIRE(test.strip().std_str().empty());
+}

--- a/src/tests/common/region.cpp
+++ b/src/tests/common/region.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch.hpp>
+#include <common/region.h>
+
+using namespace eka2l1;
+
+TEST_CASE("clip_region_to_bounds", "region") {
+    common::region region;
+    region.add_rect(eka2l1::rect({ -10, -20 }, { 40, 50 }));
+
+    region.clip(eka2l1::rect({ 0, 0 }, { 20, 15 }));
+
+    REQUIRE(region.rects_.size() == 1);
+    REQUIRE(region.rects_[0] == eka2l1::rect({ 0, 0 }, { 20, 15 }));
+}
+
+TEST_CASE("clip_region_removes_empty_rectangles", "region") {
+    common::region region;
+    region.add_rect(eka2l1::rect({ 0, 0 }, { 240, 236 }));
+
+    region.clip(eka2l1::rect({ 0, 0 }, { 0, 0 }));
+
+    REQUIRE(region.empty());
+}

--- a/src/tests/common/sync.cpp
+++ b/src/tests/common/sync.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch.hpp>
+#include <common/sync.h>
+
+using namespace eka2l1;
+
+TEST_CASE("event wait atomically consumes one signal", "[common][sync]") {
+    common::event evt;
+
+    evt.set();
+    evt.wait();
+
+    REQUIRE_FALSE(evt.wait_for(1000));
+
+    evt.set();
+    REQUIRE(evt.wait_for(100000));
+    REQUIRE_FALSE(evt.wait_for(1000));
+}


### PR DESCRIPTION
Each of the five has a new unit test.

`bit_input` refilled its bit buffer with a full 32-bit load even for the last,
partial word of a stream. `TBitInput::Set` takes a length in bits and Symbian's
compressed sections are byte granular, so the tail load runs past the buffer the
caller supplied. The N95 Calculator's patch DLL decompressed random heap that way
and corrupted its own allocator. Assemble the remaining bytes instead; the test is
sized so a sanitiser build traps the over-read.

`region::clip` clamped the wrong axis on one of its four edges, never removed a
rectangle the bounds excluded entirely, and did not answer an empty bounding
rectangle with an empty region. It now intersects each rectangle and drops the
empty results, which is what clipping a region to a rectangle means.

`double_linked_queue_element::alone` reported "unlinked" for the sole member of a
circular list, since both of its links then point at the ring sentinel. Callers use
it as a membership test, so a single-member codedump list was treated as empty and
its node either left dangling or pushed a second time. It now means exactly what
the callers ask.

`common::event` was manual-reset on Win32 while the condition-variable build is
auto-reset, and the waiters reset it themselves after returning. A `set()` landing
in that window was erased and its wakeup lost. Both builds are auto-reset now, so
the scheduler's idle event no longer resets after waiting either.

`pystr::lstrip`/`rstrip` indexed an empty string before testing it.

The data race is the one with no cheap test: the `wstring_convert` instances behind
the string helpers are shared mutable conversion state called from the UI, CPU,
timer and service threads at once, which ThreadSanitizer flags. They are per-thread
now.
---

**Verification**: `ctest` green on this branch (plain Release, ASan, and ASan+UBSan). The whole batch was also merged into one tree and run through the iOS Release simulator regression suite: 12/12 on the default suite (Final Battle, Calculator, N95 Calculator) plus 5/5 on the touch suite (Angry Birds on a Symbian^3 device), with the emulator log clean of panics, access violations and graphics halts, and every regression screenshot distinct.