### PR TITLE
common, system: resolve host paths on a case-sensitive filesystem

### DIFF
--- a/src/emu/common/src/fileutils.cpp
+++ b/src/emu/common/src/fileutils.cpp
@@ -28,6 +28,8 @@
 #include <re2/re2.h>
 
 #include <fstream>
+#include <stack>
+#include <utility>
 
 #if EKA2L1_PLATFORM(WIN32)
 #include <Windows.h>
@@ -425,6 +427,9 @@ namespace eka2l1::common {
     
     std::string find_case_sensitive_file_name(const std::string &folder_path, const std::string &insensitive_name, const file_type type) {
         auto ite = make_directory_iterator(folder_path, "");
+        // next_entry() only populates dir_entry::type when detail is enabled.
+        // Without it, type-filtered lookups can never match on POSIX.
+        ite->detail = true;
         const std::u16string insensitive_name_u16 = common::utf8_to_ucs2(insensitive_name);
 
         common::dir_entry entry;
@@ -809,22 +814,27 @@ namespace eka2l1::common {
         std::uint64_t total_copied = 0;
 
         auto do_copy_stuffs = [&](const bool is_measuring) {
-            std::stack<std::string> folder_stacks;
+            // Keep source and destination paths separate. Lowercase-name mode
+            // transforms destination names, but the source may live on a
+            // case-sensitive filesystem and must retain its real spelling.
+            std::stack<std::pair<std::string, std::string>> folder_stacks;
             common::dir_entry entry;
 
-            folder_stacks.push(std::string(1, eka2l1::get_separator()));
+            const std::string root_path(1, eka2l1::get_separator());
+            folder_stacks.push({ root_path, root_path });
 
             while (!folder_stacks.empty()) {
                 if (cancel_cb && cancel_cb()) {
                     break;
                 }
                 if (!is_measuring)
-                    create_directories(eka2l1::add_path(dest_folder_to_reside, folder_stacks.top()));
+                    create_directories(eka2l1::add_path(dest_folder_to_reside, folder_stacks.top().second));
 
-                const std::string top_path = folder_stacks.top();
+                const std::string source_top_path = folder_stacks.top().first;
+                const std::string dest_top_path = folder_stacks.top().second;
 
-                auto iterator = make_directory_iterator(add_path(target_folder, top_path), "");
-                if (!iterator) {
+                auto iterator = make_directory_iterator(add_path(target_folder, source_top_path), "");
+                if (!iterator || !iterator->is_valid()) {
                     return false;
                 }
                 iterator->detail = true;
@@ -863,7 +873,17 @@ namespace eka2l1::common {
                     }
 
                     if (entry.type == common::file_type::FILE_DIRECTORY) {
-                        folder_stacks.push(eka2l1::add_path(top_path, name_to_use + eka2l1::get_separator()));
+                        // In in-place lowercase mode the directory has just
+                        // been renamed, so traversal must follow the new name.
+                        // A real copy keeps following the original source name.
+                        const std::string &source_name_to_use =
+                            (no_copy && (flags & FOLDER_COPY_FLAG_LOWERCASE_NAME))
+                            ? name_to_use
+                            : entry.name;
+                        folder_stacks.push({
+                            eka2l1::add_path(source_top_path, source_name_to_use + eka2l1::get_separator()),
+                            eka2l1::add_path(dest_top_path, name_to_use + eka2l1::get_separator())
+                        });
                     } else {
                         if (is_measuring) {
                             total_size += entry.size;
@@ -873,7 +893,7 @@ namespace eka2l1::common {
                                     continue;
                                 }
 
-                                if (!common::copy_file(eka2l1::add_path(iterator->dir_name, entry.name), eka2l1::add_path(eka2l1::add_path(dest_folder_to_reside, top_path), name_to_use), overwrite_on_file_exist)) {
+                                if (!common::copy_file(eka2l1::add_path(iterator->dir_name, entry.name), eka2l1::add_path(eka2l1::add_path(dest_folder_to_reside, dest_top_path), name_to_use), overwrite_on_file_exist)) {
                                     return false;
                                 }
 
@@ -902,28 +922,39 @@ namespace eka2l1::common {
             return true;
         }
 
-        auto iterator = make_directory_iterator(target_folder, "");
-        if (!iterator) {
-            return false;
-        }
-
-        iterator->detail = true;
-
-        common::dir_entry entry;
-
-        while (iterator->next_entry(entry) == 0) {
-            std::string name = add_path(iterator->dir_name, entry.name);
-
-            if (entry.type == common::file_type::FILE_DIRECTORY) {
-                if ((entry.name != ".") && (entry.name != "..")) {
-                    name += eka2l1::get_separator();
-
-                    delete_folder(name);
-                }
+        {
+            auto iterator = make_directory_iterator(target_folder, "");
+            if (!iterator) {
+                return false;
             }
-            common::remove(name);
+
+            iterator->detail = true;
+
+            common::dir_entry entry;
+
+            while (iterator->next_entry(entry) == 0) {
+                std::string name = add_path(iterator->dir_name, entry.name);
+
+                if (entry.type == common::file_type::FILE_DIRECTORY) {
+                    if ((entry.name != ".") && (entry.name != "..")) {
+                        name += eka2l1::get_separator();
+
+                        delete_folder(name);
+                    }
+                }
+                common::remove(name);
+            }
         }
-        return common::remove(target_folder);
+
+        // remove() tells a directory from a file by the trailing separator, and the
+        // caller need not have supplied one. The iterator is also closed by now: a
+        // directory Windows still has a handle open on cannot be removed.
+        std::string folder_to_remove = target_folder;
+        if (folder_to_remove.empty() || !eka2l1::is_separator(folder_to_remove.back())) {
+            folder_to_remove += eka2l1::get_separator();
+        }
+
+        return common::remove(folder_to_remove);
     }
 
     FILE *open_c_file(const std::string &target_file, const char *mode) {

--- a/src/emu/system/src/epoc.cpp
+++ b/src/emu/system/src/epoc.cpp
@@ -370,7 +370,11 @@ namespace eka2l1 {
 
                 dvcmngr_->clear();
 
-                std::string rom_drive_name = std::string(1, static_cast<char>(drive_to_char16(romdrv)));
+                // The installers create the drive folder in lower case ("drives/z/"),
+                // and on a case-sensitive filesystem an upper-case probe finds nothing
+                // and then persists the cleared device list below.
+                std::string rom_drive_name = common::lowercase_string(
+                    std::string(1, static_cast<char>(drive_to_char16(romdrv))));
 
                 std::string storage_path;
                 common::get_current_directory(storage_path);
@@ -397,7 +401,10 @@ namespace eka2l1 {
                         std::string manu, firm_name, model;
                         loader::determine_rpkg_product_info(full_entry_path, manu, firm_name, model);
 
-                        const std::string rom_directory = eka2l1::add_path(storage_path, eka2l1::add_path("roms", firm_name + "\\"));
+                        // install_rom/install_rpkg save the ROM under roms/<lowercase
+                        // firmcode>/, so match that or a case-sensitive filesystem sees
+                        // no SYM.ROM and deletes an otherwise valid dump below.
+                        const std::string rom_directory = eka2l1::add_path(storage_path, eka2l1::add_path("roms", common::lowercase_string(firm_name) + "\\"));
                         const std::string rom_file = eka2l1::add_path(rom_directory, "SYM.ROM");
                         if (!common::exists(rom_file)) {
                             LOG_ERROR(SYSTEM, "Removing broken device: {} ({})", model, firm_name);
@@ -953,9 +960,18 @@ namespace eka2l1 {
             }
         }
 
-        const std::string aif_file = eka2l1::add_path(system_apps_folder_path, eka2l1::add_path(specific_app, specific_app + ".aif"));
+        const std::string app_folder = eka2l1::add_path(system_apps_folder_path, specific_app + eka2l1::get_separator());
+        std::string aif_file = eka2l1::add_path(app_folder, specific_app + ".aif");
         if (!common::exists(aif_file)) {
-            return ngage_game_card_no_game_registeration_info;
+            // Game-card dumps vary the registration file's extension casing (Call of
+            // Duty ships "6R48.AIF"), so on case-sensitive storage resolve the real
+            // name before declaring the registration missing.
+            const std::string real_aif_name = common::find_case_sensitive_file_name(
+                app_folder, specific_app + ".aif", common::FILE_REGULAR);
+            if (real_aif_name.empty()) {
+                return ngage_game_card_no_game_registeration_info;
+            }
+            aif_file = eka2l1::add_path(app_folder, real_aif_name);
         }
 
         common::ro_std_file_stream aif_file_stream(aif_file, true);
@@ -1019,7 +1035,6 @@ namespace eka2l1 {
             } else {
                 return ngage_game_card_no_game_data_folder;
             }
-            return ngage_game_card_no_game_data_folder;
         }
 
         std::string specific_app, specific_app_2;
@@ -1083,11 +1098,16 @@ namespace eka2l1 {
 
         std::uint32_t copied_count = 0;
 
-        common::copy_folder(folder_path, drive_e_path_root, common::is_platform_case_sensitive() ? common::FOLDER_COPY_FLAG_LOWERCASE_NAME : 0, 
+        const bool copied = common::copy_folder(
+            folder_path, drive_e_path_root,
+            common::is_platform_case_sensitive() ? common::FOLDER_COPY_FLAG_LOWERCASE_NAME : 0,
             [&](const std::size_t copied, const std::size_t total) {
                 if (progress_cb)
                     progress_cb(copied * 100 / total, total_percentage);
             });
+        if (!copied) {
+            return ngage_game_card_general_error;
+        }
 
         // Remove the app registeration file of the original
         if (!specific_app_2.empty()) {

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ target_link_libraries(ekatests PRIVATE
     Catch2
     common
     config
+    epoc
     epocio
     epockern
     epocloader

--- a/src/tests/common/assets/MixedCaseDirectory/marker.txt
+++ b/src/tests/common/assets/MixedCaseDirectory/marker.txt
@@ -1,0 +1,1 @@
+Used by the case-sensitive directory lookup regression test.

--- a/src/tests/common/path.cpp
+++ b/src/tests/common/path.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <catch2/catch.hpp>
+#include <common/fileutils.h>
 #include <common/path.h>
 #include <cstring>
 
@@ -115,4 +116,22 @@ TEST_CASE("replace_extension", "path_resolving_test") {
     std::string expected = eka2l1::replace_extension(test_path, ".mom");
 
     REQUIRE(expected == "hiyou.ne.mom");
+}
+
+TEST_CASE("find_case_sensitive_directory_name", "path_resolving_test") {
+    REQUIRE(eka2l1::common::find_case_sensitive_file_name(
+                "commonassets", "mixedcasedirectory", eka2l1::common::FILE_DIRECTORY)
+        == "MixedCaseDirectory");
+}
+
+TEST_CASE("copy_folder_lowercases_destination_without_lowercasing_source", "path_resolving_test") {
+    const std::string destination = "commonassets-copy-output";
+    eka2l1::common::delete_folder(destination);
+
+    REQUIRE(eka2l1::common::copy_folder(
+        "commonassets", destination, eka2l1::common::FOLDER_COPY_FLAG_LOWERCASE_NAME));
+    REQUIRE(eka2l1::common::exists(
+        eka2l1::add_path(destination, "mixedcasedirectory/marker.txt")));
+
+    REQUIRE(eka2l1::common::delete_folder(destination));
 }

--- a/src/tests/epoc/CMakeLists.txt
+++ b/src/tests/epoc/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(CORE_TEST_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/devices.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mem.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/vfs.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/e32img.cpp

--- a/src/tests/epoc/devices.cpp
+++ b/src/tests/epoc/devices.cpp
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch.hpp>
+
+#include <common/fileutils.h>
+#include <common/path.h>
+#include <system/devices.h>
+
+#include <algorithm>
+#include <fstream>
+
+using namespace eka2l1;
+
+static bool lists_path(const std::vector<std::string> &paths, const std::string &wanted) {
+    return std::find(paths.begin(), paths.end(), wanted) != paths.end();
+}
+
+TEST_CASE("per_device_paths_cover_rom_and_shared_drive_state", "devices") {
+    const std::vector<std::string> paths = per_device_storage_paths("rm-320");
+
+    // The device's own drive Z and ROM image.
+    REQUIRE(lists_path(paths, "drives/z/rm-320/"));
+    REQUIRE(lists_path(paths, "roms/rm-320/"));
+
+    // What the servers leave on the drives every device shares. Drive C is where
+    // these actually land today, but a repository resides on whichever writable
+    // drive it was loaded from, so D and E have to be covered too.
+    REQUIRE(lists_path(paths, "drives/c/private/10202be9/persists/rm-320/"));
+    REQUIRE(lists_path(paths, "drives/d/private/10202be9/persists/rm-320/"));
+    REQUIRE(lists_path(paths, "drives/e/private/10202be9/persists/rm-320/"));
+    REQUIRE(lists_path(paths, "drives/c/private/1000484b/mail2/rm-320/"));
+    REQUIRE(lists_path(paths, "drives/c/system/mail/rm-320/"));
+    REQUIRE(lists_path(paths, "drives/c/system/mtm/rm-320/"));
+}
+
+TEST_CASE("per_device_paths_lowercase_the_firmware_code", "devices") {
+    // devices.yml stores the code as the ROM spells it ("RM-320"), while everything
+    // written to disk goes through common::lowercase_string.
+    const std::vector<std::string> paths = per_device_storage_paths("RM-320");
+
+    REQUIRE(lists_path(paths, "drives/z/rm-320/"));
+    REQUIRE(lists_path(paths, "drives/c/private/10202be9/persists/rm-320/"));
+
+    for (const std::string &path : paths) {
+        REQUIRE(path.find("RM-320") == std::string::npos);
+        REQUIRE(path.back() == '/');
+    }
+}
+
+namespace {
+    // A throwaway data root holding state for two devices, plus state shared by both.
+    struct storage_test_env {
+        std::string root;
+
+        explicit storage_test_env(const std::string &name)
+            : root(add_path("devicestestenv", name + eka2l1::get_separator())) {
+            common::delete_folder(root);
+            common::create_directories(root);
+        }
+
+        ~storage_test_env() {
+            common::delete_folder(root);
+        }
+
+        void write_file(const std::string &relative) {
+            const std::string full = add_path(root, relative);
+            common::create_directories(eka2l1::file_directory(full));
+
+            std::ofstream stream(full, std::ios::binary);
+            REQUIRE(stream.good());
+            stream << "data";
+        }
+
+        bool has(const std::string &relative) const {
+            return common::exists(add_path(root, relative));
+        }
+
+        void delete_device_state(const std::string &firmcode) {
+            for (const std::string &path : per_device_storage_paths(firmcode)) {
+                common::delete_folder(add_path(root, path));
+            }
+        }
+    };
+}
+
+TEST_CASE("deleting_a_device_leaves_no_state_behind", "devices") {
+    storage_test_env env("delete_one_device");
+
+    env.write_file("drives/z/rm-320/sys/bin/euser.dll");
+    env.write_file("roms/rm-320/SYM.ROM");
+    env.write_file("drives/c/private/10202be9/persists/rm-320/101f876f.cre");
+    env.write_file("drives/c/private/1000484b/mail2/rm-320/messaging.db");
+    env.write_file("drives/e/private/10202be9/persists/rm-320/101f876f.cre");
+
+    // A second device, and state that belongs to no device in particular. The
+    // deletion has no business touching either.
+    env.write_file("drives/z/rm-409/sys/bin/euser.dll");
+    env.write_file("roms/rm-409/SYM.ROM");
+    env.write_file("drives/c/private/10202be9/persists/rm-409/101f876f.cre");
+    env.write_file("drives/c/private/10202be9/20008bb7.txt");
+    env.write_file("drives/c/private/1000484b/mtm registry v2");
+    env.write_file("drives/e/system/apps/mygame/mygame.exe");
+
+    env.delete_device_state("rm-320");
+
+    REQUIRE_FALSE(env.has("drives/z/rm-320/sys/bin/euser.dll"));
+    REQUIRE_FALSE(env.has("roms/rm-320/SYM.ROM"));
+    REQUIRE_FALSE(env.has("drives/c/private/10202be9/persists/rm-320/101f876f.cre"));
+    REQUIRE_FALSE(env.has("drives/c/private/1000484b/mail2/rm-320/messaging.db"));
+    REQUIRE_FALSE(env.has("drives/e/private/10202be9/persists/rm-320/101f876f.cre"));
+
+    REQUIRE(env.has("drives/z/rm-409/sys/bin/euser.dll"));
+    REQUIRE(env.has("roms/rm-409/SYM.ROM"));
+    REQUIRE(env.has("drives/c/private/10202be9/persists/rm-409/101f876f.cre"));
+    REQUIRE(env.has("drives/c/private/10202be9/20008bb7.txt"));
+    REQUIRE(env.has("drives/c/private/1000484b/mtm registry v2"));
+    REQUIRE(env.has("drives/e/system/apps/mygame/mygame.exe"));
+}
+
+TEST_CASE("deleting_a_device_that_wrote_nothing_is_fine", "devices") {
+    storage_test_env env("delete_untouched_device");
+
+    env.write_file("drives/z/rm-320/sys/bin/euser.dll");
+
+    // Only drive Z exists: a device installed but never booted has no repository
+    // persists or message store yet, and the missing folders must not upset it.
+    env.delete_device_state("rm-320");
+
+    REQUIRE_FALSE(env.has("drives/z/rm-320/sys/bin/euser.dll"));
+}


### PR DESCRIPTION
Four places assumed the host filesystem folds case, which holds on Windows and
on a default macOS volume but not on Linux, Android or a physical iOS device.

`find_case_sensitive_file_name` filters by `dir_entry::type`, which
`next_entry()` only fills in when the iterator has `detail` set. It did not, so
on POSIX the type never matched and every type-filtered lookup came back empty --
including the one the callers below need.

`copy_folder` walked a single path stack for both ends of the copy. With
`FOLDER_COPY_FLAG_LOWERCASE_NAME` the destination names are lowercased, and the
source traversal followed those lowercased names into a source tree that does not
have them. Source and destination are tracked separately now; only the in-place
rename mode follows the new name on both sides, because there the directory has
genuinely been renamed. A failed copy also reports the failure to the caller
instead of leaving a half-populated drive E.

The device rescan probed `drives/Z/` and `roms/<FIRMCODE>/`, while the installers
write both in lower case. On a case-sensitive host the probe found nothing, so a
perfectly good dump was reported broken and its device entry dropped.

An N-Gage game card was rejected when its registration file did not spell the
extension the way the game's name does (Call of Duty ships `6R48.AIF`).

The tests pin the two `common` fixes; they pass on a case-insensitive host and
both fail on a case-sensitive volume without the fix. `per_device_storage_paths`
gains coverage for the lower-casing the rescan now relies on, and for the
deletion set it returns.
---

**Verification**: `ctest` green on this branch (plain Release, ASan, and ASan+UBSan). The whole batch was also merged into one tree and run through the iOS Release simulator regression suite: 12/12 on the default suite (Final Battle, Calculator, N95 Calculator) plus 5/5 on the touch suite (Angry Birds on a Symbian^3 device), with the emulator log clean of panics, access violations and graphics halts, and every regression screenshot distinct.