### PR TITLE
vfs, common: never hand a null host FILE to the C library

### DIFF
--- a/src/emu/common/include/common/buffer.h
+++ b/src/emu/common/include/common/buffer.h
@@ -302,10 +302,18 @@ namespace eka2l1 {
             }
 
             std::uint64_t read(void *buf, const std::uint64_t read_size) override {
+                if (!fi_) {
+                    return 0;
+                }
+
                 return fread(buf, 1, read_size, fi_);
             }
 
             void seek(const std::int64_t amount, common::seek_where wh) override {
+                if (!fi_) {
+                    return;
+                }
+
                 int flags = 0;
                 switch (wh) {
                 case common::seek_where::beg: {
@@ -332,10 +340,18 @@ namespace eka2l1 {
             }
 
             std::uint64_t tell() override {
+                if (!fi_) {
+                    return 0;
+                }
+
                 return ftell(fi_);
             }
 
             std::uint64_t size() override {
+                if (!fi_) {
+                    return 0;
+                }
+
                 const std::uint64_t cur_pos = tell();
                 seek(0, common::end);
                 const std::uint64_t s = tell();

--- a/src/emu/vfs/src/vfs.cpp
+++ b/src/emu/vfs/src/vfs.cpp
@@ -309,6 +309,15 @@ namespace eka2l1 {
     if (closed)    \
         LOG_WARN(VFS, "File {} closed but operation still continues", common::ucs2_to_utf8(input_name));
 
+// An open that failed (or a resize that could not get its handle back) leaves
+// this file without a host FILE. Fail the operation instead of handing a null
+// handle to the C library, which faults inside it.
+#define NO_HANDLE_RETURN(val)                                                                 \
+    if (!file) {                                                                              \
+        LOG_ERROR(VFS, "File {} has no host handle open", common::ucs2_to_utf8(input_name));   \
+        return val;                                                                           \
+    }
+
         physical_file(const utf16_str &vfs_path, const utf16_str &real_path, const int mode)
             : file(nullptr) {
             init(vfs_path, real_path, mode);
@@ -322,6 +331,13 @@ namespace eka2l1 {
             return file && !feof(file);
         }
 
+        // Whether the host actually handed us a file. Unlike valid() this does
+        // not care about the stream position, so it can be asked right after
+        // construction.
+        bool is_open() const {
+            return file != nullptr;
+        }
+
         int file_mode() const override {
             return fmode;
         }
@@ -329,9 +345,15 @@ namespace eka2l1 {
         void init(const utf16_str &vfs_path, const utf16_str &real_path, const int mode) {
             // Disable directory check here
             closed = false;
-            file = common::open_c_file(common::ucs2_to_utf8(real_path).c_str(), translate_mode(mode));
 
+            // Fill the descriptive members in first, so a failed open still
+            // leaves a fully initialised object behind (an uninitialised fmode
+            // would make the mode checks below read garbage).
+            input_name = vfs_path;
             physical_path = real_path;
+            fmode = mode;
+
+            file = common::open_c_file(common::ucs2_to_utf8(real_path).c_str(), translate_mode(mode));
 
             // LOG_TRACE(VFS, "Open with mode: {}", cmode);
 
@@ -339,9 +361,6 @@ namespace eka2l1 {
                 LOG_ERROR(VFS, "Can't open file: {}", common::ucs2_to_utf8(real_path));
                 return;
             }
-
-            input_name = vfs_path;
-            fmode = mode;
         }
 
         void shutdown() {
@@ -352,18 +371,21 @@ namespace eka2l1 {
 
         size_t write_file(const void *data, uint32_t size, uint32_t count) override {
             WARN_CLOSE
+            NO_HANDLE_RETURN(0)
 
             return fwrite(data, size, count, file) * size;
         }
 
         size_t read_file(void *data, uint32_t size, uint32_t count) override {
             WARN_CLOSE
+            NO_HANDLE_RETURN(0)
 
             return fread(data, size, count, file) * size;
         }
 
         std::uint64_t size() const override {
             WARN_CLOSE
+            NO_HANDLE_RETURN(0)
 
             auto crr_pos = ftell(file);
             fseek(file, 0, SEEK_END);
@@ -377,7 +399,11 @@ namespace eka2l1 {
         bool close() override {
             WARN_CLOSE
 
-            fclose(file);
+            if (file) {
+                fclose(file);
+                file = nullptr;
+            }
+
             closed = true;
 
             return true;
@@ -385,12 +411,14 @@ namespace eka2l1 {
 
         uint64_t tell() override {
             WARN_CLOSE
+            NO_HANDLE_RETURN(0)
 
             return ftell(file);
         }
 
         std::uint64_t seek(std::int64_t seek_off, file_seek_mode where) override {
             WARN_CLOSE
+            NO_HANDLE_RETURN(0xFFFFFFFFFFFFFFFF)
 
             if (where == file_seek_mode::address) {
                 return 0xFFFFFFFFFFFFFFFF;
@@ -420,6 +448,7 @@ namespace eka2l1 {
 
         bool flush() override {
             WARN_CLOSE
+            NO_HANDLE_RETURN(false)
 
             if (!(fmode & WRITE_MODE)) {
                 // Undefined behaviour on all platforms.
@@ -436,9 +465,12 @@ namespace eka2l1 {
                 return false;
             }
 
+            NO_HANDLE_RETURN(false)
+
             // Temporary close the file to let resize function works.
             const std::uint64_t saved_pos = tell();
             fclose(file);
+            file = nullptr;
 
             int err_code = common::resize(common::ucs2_to_utf8(physical_path), new_size);
 
@@ -448,6 +480,15 @@ namespace eka2l1 {
 #else
             file = fopen(common::ucs2_to_utf8(physical_path).c_str(), translate_mode(fmode, true));
 #endif
+
+            if (!file) {
+                // The reopen can fail for reasons outside our control (the host
+                // is out of descriptors, the file disappeared under us, ...).
+                // Stay handle-less: every other operation now fails cleanly
+                // instead of faulting on a null FILE inside the C library.
+                LOG_ERROR(VFS, "Can't reopen file {} after resize", common::ucs2_to_utf8(physical_path));
+                return false;
+            }
 
             fseek(file, static_cast<long>(saved_pos), SEEK_SET);
 
@@ -944,7 +985,16 @@ namespace eka2l1 {
                 return nullptr;
             }
 
-            return std::make_unique<physical_file>(path, *real_path, mode);
+            auto opened = std::make_unique<physical_file>(path, *real_path, mode);
+
+            if (!opened->is_open()) {
+                // The host refused to give us a handle. Report the file as not
+                // openable, so the caller answers the guest with an error
+                // instead of getting a file object with nothing behind it.
+                return nullptr;
+            }
+
+            return opened;
         }
 
         std::int64_t watch_directory(const std::u16string &path, common::directory_watcher_callback callback,
@@ -1085,7 +1135,7 @@ namespace eka2l1 {
             auto ff = physical_file_system::open_file(new_path, mode);
 
             // Dont change order!
-            if (!entry || ((mode & PREFER_PHYSICAL) && (ff->size() != entry->size))) {
+            if (!entry || (ff && (mode & PREFER_PHYSICAL) && (ff->size() != entry->size))) {
                 return ff;
             }
 

--- a/src/tests/common/CMakeLists.txt
+++ b/src/tests/common/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(COMMON_TEST_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/algorithm.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/allocator.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bytes.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/chunkyseri.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/crypt.cpp

--- a/src/tests/common/buffer.cpp
+++ b/src/tests/common/buffer.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch.hpp>
+#include <common/buffer.h>
+
+using namespace eka2l1;
+
+TEST_CASE("ro_std_file_stream_over_missing_file", "buffer") {
+    common::ro_std_file_stream stream("this-file-does-not-exist", true);
+    char scratch[8] = {};
+
+    REQUIRE_FALSE(stream.valid());
+    REQUIRE(stream.read(scratch, sizeof(scratch)) == 0);
+    REQUIRE(stream.size() == 0);
+    REQUIRE(stream.tell() == 0);
+
+    stream.seek(4, common::seek_where::beg);
+    REQUIRE(stream.tell() == 0);
+}

--- a/src/tests/epoc/vfs.cpp
+++ b/src/tests/epoc/vfs.cpp
@@ -37,3 +37,16 @@ TEST_CASE("get_physical", "vfs") {
 
     REQUIRE(eka2l1::common::compare_ignore_case(*actual_path_b, std::u16string(u"drive_b") + static_cast<char16_t>(eka2l1::get_separator()) + u"despacito3leak") == 0);
 }
+
+TEST_CASE("open_file_the_host_refuses", "vfs") {
+    eka2l1::io_system io;
+    io_scope_guard guard(io);
+
+    io.mount_physical_path(drive_number::drive_a, drive_media::physical, io_attrib_internal,
+        u".");
+
+    // The parent directory does not exist, so the host refuses the handle.
+    // RFile::Replace answers KErrPathNotFound there; the file server never hands
+    // back a file object with nothing behind it.
+    REQUIRE(io.open_file(u"A:\\NoSuchFolder\\NotHere.txt", WRITE_MODE | BIN_MODE) == nullptr);
+}


### PR DESCRIPTION
`physical_file` keeps whatever `open_c_file` returned and every operation calls
straight into the C library with it. Two paths can leave that pointer null: a
create/replace whose parent directory the host does not have, and a `resize()`
whose reopen fails after the temporary close. Reading, seeking or flushing such a
file faults inside the C library rather than answering the guest with an error.

Operations now refuse a file without a handle, `close()` clears the pointer it
frees, a failed reopen after `resize()` is reported instead of leaving the file
believing it still has a handle, and `open_file` answers with no file at all when
the host refused one -- which is what its existing "the file is not there" and
"the drive is write-protected" paths already do.

The descriptive members are filled in before the open, so a file that failed to
open is still fully initialised; `fmode` in particular was left uninitialised and
the mode checks read it.

`ro_std_file_stream` has the same shape and the same problem: it exposes
`valid()`, but `read`, `seek`, `tell` and `size` did not consult it.
---

**Verification**: `ctest` green on this branch (plain Release, ASan, and ASan+UBSan). The whole batch was also merged into one tree and run through the iOS Release simulator regression suite: 12/12 on the default suite (Final Battle, Calculator, N95 Calculator) plus 5/5 on the touch suite (Angry Birds on a Symbian^3 device), with the emulator log clean of panics, access violations and graphics halts, and every regression screenshot distinct.