### PR TITLE
dispatch: guest notifications, wrong values and missing entry points

### DIFF
--- a/src/emu/dispatch/include/dispatch/camera.h
+++ b/src/emu/dispatch/include/dispatch/camera.h
@@ -32,6 +32,7 @@ namespace eka2l1::drivers::camera {
 namespace eka2l1::dispatch {
     BRIDGE_FUNC_DISPATCHER(std::int32_t, ecam_number_of_cameras);
     BRIDGE_FUNC_DISPATCHER(std::int32_t, ecam_create, std::int32_t index, drivers::camera::info *cam_info);
+    BRIDGE_FUNC_DISPATCHER(std::int32_t, ecam_duplicate, std::uint32_t handle, drivers::camera::info *cam_info);
     BRIDGE_FUNC_DISPATCHER(std::int32_t, ecam_claim, std::uint32_t handle);
     BRIDGE_FUNC_DISPATCHER(std::int32_t, ecam_power_on, std::uint32_t handle);
     BRIDGE_FUNC_DISPATCHER(std::int32_t, ecam_power_off, std::uint32_t handle);

--- a/src/emu/dispatch/include/dispatch/libraries/egl/def.h
+++ b/src/emu/dispatch/include/dispatch/libraries/egl/def.h
@@ -461,7 +461,11 @@ namespace eka2l1::dispatch {
 
     static constexpr const char *EGL_STATIC_STRING_VENDOR = "EKA2L1";
     static constexpr const char *EGL_STATIC_STRING_VERSION = "1.4";
-    static constexpr const char *EGL_STATIC_STRING_EXTENSION = "EGL_KHR_create_context";
+    static constexpr const char *EGL_STATIC_STRING_EXTENSION = "EGL_KHR_create_context EGL_NOK_resource_profiling2";
+    static constexpr std::uint32_t EGL_PROF_QUERY_GLOBAL_BIT_NOK_EMU = 0x0001;
+    static constexpr std::uint32_t EGL_PROF_QUERY_MEMORY_USAGE_BIT_NOK_EMU = 0x0002;
+    static constexpr std::int32_t EGL_PROF_TOTAL_MEMORY_NOK_EMU = 0x3070;
+    static constexpr std::int32_t EGL_PROF_USED_MEMORY_NOK_EMU = 0x3071;
     static constexpr std::uint32_t MAX_EGL_FB_WIDTH = 2048;
     static constexpr std::uint32_t MAX_EGL_FB_HEIGHT = 2048;
 

--- a/src/emu/dispatch/include/dispatch/libraries/egl/egl.h
+++ b/src/emu/dispatch/include/dispatch/libraries/egl/egl.h
@@ -27,6 +27,7 @@
 namespace eka2l1::dispatch {
     BRIDGE_FUNC_LIBRARY(egl_display, egl_get_display_emu, std::int32_t display_index);
     BRIDGE_FUNC_LIBRARY(egl_boolean, egl_initialize_emu, egl_display display, std::int32_t *major, std::int32_t *minor);
+    BRIDGE_FUNC_LIBRARY(egl_boolean, egl_terminate_emu, egl_display display);
     BRIDGE_FUNC_LIBRARY(egl_boolean, egl_get_configs_emu, egl_display display, egl_config *configs, std::int32_t config_array_size, std::int32_t *config_total_size);
     BRIDGE_FUNC_LIBRARY(egl_boolean, egl_choose_config_emu, egl_display display, std::int32_t *attrib_lists, egl_config *configs, std::int32_t config_array_size, std::int32_t *num_config_choosen);
     BRIDGE_FUNC_LIBRARY(egl_surface_handle, egl_create_window_surface_emu, egl_display display, std::uint32_t choosen_config_value, utils::window_client_interface *win, std::int32_t *additional_attribs);
@@ -47,6 +48,8 @@ namespace eka2l1::dispatch {
     BRIDGE_FUNC_LIBRARY(egl_surface_handle, egl_get_current_surface_emu, std::uint32_t which);
     BRIDGE_FUNC_LIBRARY(egl_boolean, egl_copy_buffers_emu, egl_display display, egl_surface_handle handle, void *native_pixmap);
     BRIDGE_FUNC_LIBRARY(address, egl_get_proc_address_emu, const char *procname);
+    BRIDGE_FUNC_LIBRARY(egl_boolean, egl_query_profiling_data_nok_emu, egl_display display,
+        std::uint32_t query_bits, std::int32_t *data, std::int32_t data_size, std::int32_t *data_count);
     BRIDGE_FUNC_LIBRARY(egl_boolean, egl_bind_api_emu, const std::uint32_t bind_api);
     BRIDGE_FUNC_LIBRARY(egl_boolean, egl_surface_attrib_emu, egl_display display, egl_surface_handle read_surface,
         std::int32_t attribute, std::int32_t value);

--- a/src/emu/dispatch/include/dispatch/video.h
+++ b/src/emu/dispatch/include/dispatch/video.h
@@ -71,8 +71,10 @@ namespace eka2l1::dispatch {
         
         rotation_type rotation_;
 
+        kernel_system *kern_;
+
     public:
-        explicit epoc_video_player(drivers::graphics_driver *grdrv, drivers::audio_driver *auddrv);
+        explicit epoc_video_player(kernel_system *kern, drivers::graphics_driver *grdrv, drivers::audio_driver *auddrv);
         ~epoc_video_player();
 
         std::int32_t register_window(kernel_system *kern, window_server *serv, const std::uint32_t wss_handle, const std::uint32_t win_handle);

--- a/src/emu/dispatch/src/camera.cpp
+++ b/src/emu/dispatch/src/camera.cpp
@@ -31,6 +31,19 @@
 #include <cstring>
 
 namespace eka2l1::dispatch {
+    // A viewfinder or image callback fires on the backend's delivery thread, which
+    // can race the teardown of the guest thread that armed the request.
+    // notify_info::complete() dereferences that requester, so drop the request
+    // instead when it is gone. Mirrors complete_audio_notify_if_alive in audio.cpp;
+    // the caller already holds the kernel lock.
+    static void complete_camera_notify_if_alive(kernel_system *kern, epoc::notify_info &info, int err_code) {
+        if (!info.empty() && kern->is_thread_alive(info.requester)) {
+            info.complete(err_code);
+        } else {
+            info.sts = 0;
+        }
+    }
+
     BRIDGE_FUNC_DISPATCHER(std::int32_t, ecam_number_of_cameras) {
         return static_cast<std::int32_t>(drivers::camera::get_collection()->count());
     }
@@ -71,6 +84,23 @@ namespace eka2l1::dispatch {
         object_manager<epoc_camera>::handle result_h = dispatcher->cameras_.add_object(native_cam_wrap);
 
         return static_cast<std::int32_t>(result_h);
+    }
+
+    BRIDGE_FUNC_DISPATCHER(std::int32_t, ecam_duplicate, std::uint32_t handle, drivers::camera::info *cam_info) {
+        dispatch::dispatcher *dispatcher = sys->get_dispatcher();
+        epoc_camera *cam = dispatcher->cameras_.get_object(handle);
+        if (!cam) {
+            return epoc::error_bad_handle;
+        }
+
+        if (cam_info) {
+            *cam_info = cam->cached_info_;
+        }
+
+        // A duplicate shares the underlying camera. Dispatcher camera handles have no
+        // close of their own, so the existing handle already has the lifetime a
+        // duplicate needs.
+        return static_cast<std::int32_t>(handle);
     }
 
     BRIDGE_FUNC_DISPATCHER(std::int32_t, ecam_claim, std::uint32_t handle) {
@@ -165,14 +195,14 @@ namespace eka2l1::dispatch {
             kern->lock();
 
             if (err < 0) {
-                cam->done_image_capture_notify_.complete(epoc::error_general);
+                complete_camera_notify_if_alive(kern, cam->done_image_capture_notify_, epoc::error_general);
             } else {
                 // Copy data to temporary buffer
                 cam->received_image_capture_.resize(buffer_size);
                 std::memcpy(cam->received_image_capture_.data(), buffer, buffer_size);
 
                 cam->image_capture_taken_ = false;
-                cam->done_image_capture_notify_.complete(epoc::error_none);
+                complete_camera_notify_if_alive(kern, cam->done_image_capture_notify_, epoc::error_none);
             }
 
             kern->unlock();
@@ -298,12 +328,12 @@ namespace eka2l1::dispatch {
             guard.lock();
 
             if (err < 0) {
-                cam->done_frame_viewfinder_notify_.complete(epoc::error_general);
+                complete_camera_notify_if_alive(kern, cam->done_frame_viewfinder_notify_, epoc::error_general);
             } else {
                 cam->received_viewfinder_frame_[++cam->current_frame_index_].resize(buffer_size);
                 std::memcpy(cam->received_viewfinder_frame_[cam->current_frame_index_].data(), buffer, buffer_size);
 
-                cam->done_frame_viewfinder_notify_.complete(epoc::error_none);
+                complete_camera_notify_if_alive(kern, cam->done_frame_viewfinder_notify_, epoc::error_none);
             }
 
             kern->unlock();

--- a/src/emu/dispatch/src/dispatcher.cpp
+++ b/src/emu/dispatch/src/dispatcher.cpp
@@ -244,7 +244,7 @@ namespace eka2l1::dispatch {
             add_static_string(GLES_STATIC_STRING_KEY_EXTENSIONS, dispatch::get_es1_extensions(driver));
             add_static_string(GLES_STATIC_STRING_KEY_VERSION, GLES1_STATIC_STRING_VERSION);
             add_static_string(GLES_STATIC_STRING_KEY_VENDOR_ES2, GLES2_STATIC_STRING_VENDOR);
-            add_static_string(GLES_STATIC_STRING_KEY_RENDERER_ES2, GLES2_STATIC_STRING_VENDOR);
+            add_static_string(GLES_STATIC_STRING_KEY_RENDERER_ES2, GLES2_STATIC_STRING_RENDERER);
             add_static_string(GLES_STATIC_STRING_KEY_EXTENSIONS_ES2, dispatch::get_es2_extensions(driver));
             add_static_string(GLES_STATIC_STRING_KEY_VERSION_ES2, GLES2_STATIC_STRING_VERSION);
             add_static_string(GLES_STATIC_STRING_SHADER_LANGUAGE_VERSION_ES2, GLES2_STATIC_STRING_SHADER_LANGUAGE_VERSION);
@@ -425,11 +425,33 @@ namespace eka2l1::dispatch {
         }
 
         auto ite = symbol_lookup_.find(symbol);
-        if (ite == symbol_lookup_.end()) {
-            return 0;
+        if (ite != symbol_lookup_.end()) {
+            return ite->second;
         }
 
-        return ite->second;
+        // An extension entry point reached through eglGetProcAddress has no library
+        // ordinal, so patch_libraries() never built its guest trampoline. Build one on
+        // first lookup for any symbol the dispatcher does register.
+        for (const auto &dispatch_func : dispatch::dispatch_funcs) {
+            if (!dispatch_func.second.second || symbol != std::string(dispatch_func.second.second)) {
+                continue;
+            }
+
+            const address entry = trampoline_chunk_->base(nullptr).ptr_address() + trampoline_allocated_;
+            std::uint32_t *start_base = reinterpret_cast<std::uint32_t *>(reinterpret_cast<std::uint8_t *>(
+                trampoline_chunk_->host_base()) + trampoline_allocated_);
+
+            start_base[0] = 0xEFC10001;
+            start_base[1] = 0xE12FFF1E; // BX LR
+            start_base[2] = dispatch_func.first;
+
+            symbol_lookup_.emplace(symbol, entry);
+            trampoline_allocated_ += 12;
+
+            return entry;
+        }
+
+        return 0;
     }
 }
 

--- a/src/emu/dispatch/src/libraries/egl/egl.cpp
+++ b/src/emu/dispatch/src/libraries/egl/egl.cpp
@@ -92,7 +92,13 @@ namespace eka2l1::dispatch {
 
         return EGL_TRUE;
     }
-    
+
+    BRIDGE_FUNC_LIBRARY(egl_boolean, egl_terminate_emu, egl_display display) {
+        // Every resource this display owns is released with the objects that hold
+        // it, so there is nothing left to tear down here.
+        return EGL_TRUE;
+    }
+
     BRIDGE_FUNC_LIBRARY(egl_boolean, egl_get_configs_emu, egl_display display, egl_config *configs, std::int32_t config_array_size, std::int32_t *config_total_size) {        
         if (!config_total_size) {
             egl_push_error(sys, EGL_BAD_PARAMETER_EMU);
@@ -821,6 +827,40 @@ namespace eka2l1::dispatch {
         }
 
         return sys->get_dispatcher()->lookup_dispatcher_function_by_symbol(procname);
+    }
+
+    BRIDGE_FUNC_LIBRARY(egl_boolean, egl_query_profiling_data_nok_emu, egl_display display,
+        std::uint32_t query_bits, std::int32_t *data, std::int32_t data_size, std::int32_t *data_count) {
+        if (!data_count || (query_bits & ~(EGL_PROF_QUERY_GLOBAL_BIT_NOK_EMU |
+            EGL_PROF_QUERY_MEMORY_USAGE_BIT_NOK_EMU)) != 0) {
+            egl_push_error(sys, EGL_BAD_PARAMETER_EMU);
+            return EGL_FALSE;
+        }
+
+        // EGL_NOK_resource_profiling2 returns a flat attribute/value array and reports
+        // its size in EGLint elements. There is no fixed GPU memory heap to report
+        // here, so the answer is a stable budget with no tracked use.
+        constexpr std::int32_t PROFILING_DATA[] = {
+            EGL_PROF_TOTAL_MEMORY_NOK_EMU, 64 * 1024 * 1024,
+            EGL_PROF_USED_MEMORY_NOK_EMU, 0
+        };
+        constexpr std::int32_t PROFILING_DATA_SIZE = sizeof(PROFILING_DATA) / sizeof(PROFILING_DATA[0]);
+
+        *data_count = PROFILING_DATA_SIZE;
+        if (!data) {
+            return EGL_TRUE;
+        }
+
+        if (data_size < PROFILING_DATA_SIZE) {
+            egl_push_error(sys, EGL_BAD_PARAMETER_EMU);
+            return EGL_FALSE;
+        }
+
+        for (std::int32_t i = 0; i < PROFILING_DATA_SIZE; ++i) {
+            data[i] = PROFILING_DATA[i];
+        }
+
+        return EGL_TRUE;
     }
 
     BRIDGE_FUNC_LIBRARY(egl_boolean, egl_bind_api_emu, const std::uint32_t bind_api) {

--- a/src/emu/dispatch/src/libraries/gles2/gles2.cpp
+++ b/src/emu/dispatch/src/libraries/gles2/gles2.cpp
@@ -2706,7 +2706,6 @@ APPLY_PENDING_ROUTES:
             return;
         }
 
-        ctx->attributes_[index].constant_vcomp_count_ = 0;
         ctx->attributes_[index].normalized_ = normalized;
         ctx->attrib_changed_ = true;
     }

--- a/src/emu/dispatch/src/libraries/gles_shared/gles_shared.cpp
+++ b/src/emu/dispatch/src/libraries/gles_shared/gles_shared.cpp
@@ -1009,7 +1009,7 @@ namespace eka2l1::dispatch {
     void gles_driver_texture::update() {
         if (change_flags_ & FLAG_MIN_FILTER_CHANGED) {
             drivers::filter_option opt;
-            if (gl_enum_to_mag_filter(min_filter_, opt)) {
+            if (gl_enum_to_min_filter(min_filter_, opt)) {
                 context_.cmd_builder_.set_texture_filter(driver_handle_, true, opt);
             }
         }

--- a/src/emu/dispatch/src/libraries/register.cpp
+++ b/src/emu/dispatch/src/libraries/register.cpp
@@ -31,8 +31,21 @@
 namespace eka2l1::dispatch::libraries {
     void register_functions(kernel_system *kern, dispatcher *disp) {
         if (kern->get_epoc_version() <= epocver::epoc81a) {
+            config::state *conf = kern->get_config();
+
             disp->patch_libraries(u"Z:\\System\\Libs\\SysUtil.dll", SYSUTILS_PATCH_EPOCV81A_INFOS,
                 SYSUTILS_PATCH_EPOCV81A_COUNT);
+
+            // EKA1 devices keep the GLES/EGL implementation in \System\Libs rather than
+            // \Sys\Bin. Their libgles_cm.dll only freezes the GLES 1.0 part of the DEF
+            // file, but the ordinals it does export match the 1.1 one, so the same patch
+            // table applies and the missing ordinals are skipped. Without this the guest
+            // runs Nokia's own software rasteriser, which wants frame buffer access the
+            // emulator does not reproduce.
+            if (conf->enable_hw_gles1) {
+                disp->patch_libraries(u"Z:\\System\\Libs\\libgles_cm.dll", LIBGLES_CM_PATCH_INFOS,
+                    LIBGLES_CM_PATCH_COUNT);
+            }
         } else if (kern->get_epoc_version() >= epocver::epoc93fp1) {
             config::state *conf = kern->get_config();
 

--- a/src/emu/dispatch/src/register.cpp
+++ b/src/emu/dispatch/src/register.cpp
@@ -88,6 +88,7 @@ namespace eka2l1::dispatch {
         BRIDGE_REGISTER_DISPATCHER(0x68, ecam_query_still_image_size),
         BRIDGE_REGISTER_DISPATCHER(0x69, ecam_take_image),
         BRIDGE_REGISTER_DISPATCHER(0x6B, ecam_receive_image),
+        BRIDGE_REGISTER_DISPATCHER(0x71, ecam_duplicate),
         BRIDGE_REGISTER_DISPATCHER(0x72, ecam_start_viewfinder),
         BRIDGE_REGISTER_DISPATCHER(0x73, ecam_next_viewfinder_frame),
         BRIDGE_REGISTER_DISPATCHER(0x74, ecam_stop_viewfinder_frame),
@@ -134,7 +135,7 @@ namespace eka2l1::dispatch {
         BRIDGE_REGISTER_DISPATCHER_SYMBOL(0x1113, egl_query_string_emu, "eglQueryString"),
         BRIDGE_REGISTER_DISPATCHER_SYMBOL(0x1114, egl_query_surface_emu, "eglQuerySurface"),
         BRIDGE_REGISTER_DISPATCHER_SYMBOL(0x1115, egl_swap_buffers_emu, "eglSwapBuffers"),
-        //BRIDGE_REGISTER_DISPATCHER_SYMBOL(0x1116, egl_terminate_emu, "eglTerminate"),
+        BRIDGE_REGISTER_DISPATCHER_SYMBOL(0x1116, egl_terminate_emu, "eglTerminate"),
         BRIDGE_REGISTER_DISPATCHER_SYMBOL(0x1117, egl_wait_gl_emu, "eglWaitGL"),
         BRIDGE_REGISTER_DISPATCHER_SYMBOL(0x1118, egl_wait_native_emu, "eglWaitNative"),
         BRIDGE_REGISTER_DISPATCHER_SYMBOL(0x1119, gl_active_texture_emu, "glActiveTexture"),
@@ -477,5 +478,6 @@ namespace eka2l1::dispatch {
         BRIDGE_REGISTER_DISPATCHER_SYMBOL(0x1456, vg_create_paint_emu, "vgCreatePaint"),
         BRIDGE_REGISTER_DISPATCHER_SYMBOL(0x1457, vg_load_identity_emu, "vgLoadIdentity"),
         BRIDGE_REGISTER_DISPATCHER_SYMBOL(0x1458, vg_draw_path_emu, "vgDrawPath"),
+        BRIDGE_REGISTER_DISPATCHER_SYMBOL(0x1459, egl_query_profiling_data_nok_emu, "eglQueryProfilingDataNOK"),
     };
 }

--- a/src/emu/dispatch/src/screen.cpp
+++ b/src/emu/dispatch/src/screen.cpp
@@ -24,6 +24,7 @@
 
 #include <drivers/graphics/graphics.h>
 #include <kernel/kernel.h>
+#include <kernel/thread.h>
 #include <services/window/common.h>
 #include <services/window/window.h>
 #include <services/window/classes/wingroup.h>
@@ -42,14 +43,31 @@ namespace eka2l1::dispatch {
     }
 
     void screen_post_transferer::complete_notify(epoc::notify_info *info) {
-        const std::lock_guard<std::mutex> guard(lock_);
+        {
+            const std::lock_guard<std::mutex> guard(lock_);
 
-        auto ite = std::find(vsync_notifies_.begin(), vsync_notifies_.end(), info);
-        if (ite != vsync_notifies_.end()) {
+            auto ite = std::find(vsync_notifies_.begin(), vsync_notifies_.end(), info);
+            if (ite == vsync_notifies_.end()) {
+                delete info;
+                return;
+            }
+
             vsync_notifies_.erase(ite);
         }
 
+        // Completing a guest request needs the kernel lock; this runs on the posting
+        // thread, so take it here rather than signalling the guest unlocked.
+        kernel_system *kern = info->requester ? info->requester->get_kernel_object_owner() : nullptr;
+        if (kern) {
+            kern->lock();
+        }
+
         info->complete(epoc::error_none);
+
+        if (kern) {
+            kern->unlock();
+        }
+
         delete info;
     }
 
@@ -207,7 +225,20 @@ namespace eka2l1::dispatch {
                 const eka2l1::vec2 screen_size = mode_info.size;
 
                 const char *data_ptr = reinterpret_cast<const char *>(scr->screen_buffer_ptr());
-                const std::size_t buffer_size = mode_info.size.x * mode_info.size.y * 4;
+                // A ScreenPlay screen under an active DSA keeps its own row pitch, which
+                // is not the tightly packed one the texture upload assumes.
+                const std::uint32_t bits_per_pixel = epoc::get_bpp_from_display_mode(scr->disp_mode);
+                const std::size_t dsa_screen_pitch = scr->screen_buffer_byte_width();
+                const std::size_t tight_screen_pitch = mode_info.size.x * sizeof(std::uint32_t);
+                const bool use_screenplay_pitch = scr->is_screenplay_architecture()
+                    && (scr->active_dsa_count_ > 0) && (bits_per_pixel == 32);
+                const std::size_t screen_pitch = use_screenplay_pitch
+                    ? dsa_screen_pitch
+                    : tight_screen_pitch;
+                const std::size_t buffer_size = screen_pitch * mode_info.size.y;
+                const std::size_t pixels_per_line = (screen_pitch != tight_screen_pitch)
+                    ? screen_pitch / sizeof(std::uint32_t)
+                    : 0;
 
                 std::uint64_t next_vsync_us = 0;
                 scr->vsync(sys->get_ntimer(), next_vsync_us);
@@ -240,7 +271,8 @@ namespace eka2l1::dispatch {
                 drivers::graphics_command_builder builder;
 
                 // Only one rectangle for now!
-                builder.update_bitmap(scr->dsa_texture, data_ptr, buffer_size, { 0, 0 }, screen_size);
+                builder.update_bitmap(scr->dsa_texture, data_ptr, buffer_size, { 0, 0 }, screen_size,
+                    pixels_per_line);
 
                 // NOTE: This is a hack for some apps that dont fill alpha
                 // TODO: Figure out why or better solution (maybe the display mode is not really correct?)

--- a/src/emu/dispatch/src/video.cpp
+++ b/src/emu/dispatch/src/video.cpp
@@ -37,12 +37,13 @@ namespace eka2l1::dispatch {
         data.target_window_ = nullptr;
     }
 
-    epoc_video_player::epoc_video_player(drivers::graphics_driver *grdrv, drivers::audio_driver *auddrv)
+    epoc_video_player::epoc_video_player(kernel_system *kern, drivers::graphics_driver *grdrv, drivers::audio_driver *auddrv)
         : image_handle_(0)
         , video_player_(nullptr)
         , driver_(grdrv)
         , custom_stream_(nullptr)
         , rotation_(ROTATION_TYPE_NONE)
+        , kern_(kern)
         , postings_(posting_target_free_check_func, posting_target_free_func) {
         video_player_ = drivers::new_best_video_player(auddrv);
         video_player_->set_image_frame_available_callback([](void *userdata, const std::uint8_t *data, const std::size_t data_size) {
@@ -303,11 +304,19 @@ namespace eka2l1::dispatch {
     }
     
     void epoc_video_player::on_play_done(const int error) {
-        if (error == 0) {
-            play_done_notify_.complete(epoc::error_none);
+        // Fired on the decode thread. Completing a guest notify needs the kernel
+        // lock, and the requester may already be gone. The bridge calls that join
+        // this thread release the kernel lock around the join, so taking it here
+        // cannot deadlock.
+        kern_->lock();
+
+        if (!play_done_notify_.empty() && kern_->is_thread_alive(play_done_notify_.requester)) {
+            play_done_notify_.complete((error == 0) ? epoc::error_none : epoc::error_general);
         } else {
-            play_done_notify_.complete(epoc::error_general);
+            play_done_notify_.sts = 0;
         }
+
+        kern_->unlock();
     }
     
     BRIDGE_FUNC_DISPATCHER(eka2l1::ptr<void>, evideo_player_inst) {
@@ -315,12 +324,25 @@ namespace eka2l1::dispatch {
         drivers::graphics_driver *grdrv = sys->get_graphics_driver();
         drivers::audio_driver *auddrv = sys->get_audio_driver();
 
-        std::unique_ptr<epoc_video_player> player = std::make_unique<epoc_video_player>(grdrv, auddrv);
+        std::unique_ptr<epoc_video_player> player = std::make_unique<epoc_video_player>(sys->get_kernel_system(), grdrv, auddrv);
         return dispatcher->video_player_container_.add_object(player);
     }
 
     BRIDGE_FUNC_DISPATCHER(std::int32_t, evideo_player_destroy, const std::uint32_t handle) {
         dispatch::dispatcher *dispatcher = sys->get_dispatcher();
+        dispatch::epoc_video_player *player = dispatcher->video_player_container_.get_object(handle);
+
+        // Joining the decode thread while holding the kernel lock deadlocks
+        // against on_play_done taking that lock on the decode thread: close
+        // (which joins) with the lock released, then remove the object.
+        if (player) {
+            kernel_system *kern = sys->get_kernel_system();
+
+            kern->unlock();
+            player->close();
+            kern->lock();
+        }
+
         return dispatcher->video_player_container_.remove_object(handle);
     }
     
@@ -468,7 +490,14 @@ namespace eka2l1::dispatch {
             return epoc::error_bad_handle;
         }
 
+        // play restarts any previous session (joining the decode thread): keep
+        // the kernel lock released around it so on_play_done cannot deadlock.
+        kernel_system *kern = sys->get_kernel_system();
+
+        kern->unlock();
         player->play(range);
+        kern->lock();
+
         return epoc::error_none;
     }
     
@@ -510,7 +539,12 @@ namespace eka2l1::dispatch {
             return epoc::error_bad_handle;
         }
 
+        kernel_system *kern = sys->get_kernel_system();
+
+        kern->unlock();
         player->close();
+        kern->lock();
+
         return epoc::error_none;
     }
 
@@ -523,7 +557,12 @@ namespace eka2l1::dispatch {
             return epoc::error_bad_handle;
         }
 
+        kernel_system *kern = sys->get_kernel_system();
+
+        kern->unlock();
         player->stop();
+        kern->lock();
+
         return epoc::error_none;
     }
     

--- a/src/emu/system/src/hal.cpp
+++ b/src/emu/system/src/hal.cpp
@@ -185,7 +185,7 @@ namespace eka2l1::epoc {
             // Intentional
             info.video_address_ = scr->screen_buffer_chunk->base(nullptr).ptr_address();
             info.offset_to_first_pixel_ = sizeof(std::uint16_t) * epoc::WORD_PALETTE_ENTRIES_COUNT;
-            info.offset_between_lines_ = ((info.bits_per_pixel_ + 31) / 32) * 4 * info.size_in_pixels_.x;
+            info.offset_between_lines_ = scr->screen_buffer_byte_width();
             info.display_mode_ = 0;
         }
 


### PR DESCRIPTION
Three groups of fixes in the dispatch/GLES HLE layer.

## Completing a guest notification against a thread that is gone

The camera and video backends deliver on their own threads, and the screen poster
runs on the posting thread. All three complete guest requests from there, and all
three could do it against a thread the kernel has already destroyed --
`notify_info::complete()` dereferences the requester to translate the request
status. They check the kernel's live thread list now, the way the dispatcher's audio
completions already do, and drop the stale request instead.

The vsync poster had two further problems: it completed the guest request without
the kernel lock, and it completed and freed a `notify_info` that was not in its own
list -- one already cancelled, so a second completion against a freed request.

The video player's bridge calls are the other half of that. `play`, `stop`, `close`
and the player's destruction all join the decode thread, and they did it holding the
kernel lock that `on_play_done` now takes on that same thread. They release it
around the join, and destroying a player closes it before the object goes rather
than joining from inside its destructor.

## Four values

**A texture's minification filter was mapped with the magnification mapper.**
`gl_enum_to_mag_filter` only accepts `GL_NEAREST` and `GL_LINEAR`, so every mipmapped
minification filter failed to convert and the driver was never told about the change
at all -- the texture kept whatever filter it had.

**`glVertexAttribPointer` cleared the attribute's constant value.** In GLES 2.0 the
generic vertex attribute value and the vertex array are separate state, and
specifying an array does not touch the value. Here it did, and since the constant is
what the draw path uses for a *disabled* array, a guest that sets a constant,
specifies a pointer and then disables the array had its attribute silently dropped
from the draw.

**`GL_RENDERER` reported the vendor string** on the ES2 path.

**The DSA post assumed a tightly packed screen buffer.** A ScreenPlay screen keeps
its own row pitch while a direct screen access is active, so the upload has to be
told the real pixels-per-line or every row lands shifted. `HAL`'s
`EDisplayOffsetBetweenLines` computed a packed pitch of its own for the same buffer
instead of asking the screen what it is.

## Entry points the guest asks for and could not reach

**`eglTerminate` was registered but commented out**, so a guest tearing its display
down got no entry point at all. Nothing is left to release by then, but the call has
to succeed.

**An extension entry point obtained through `eglGetProcAddress` had no trampoline.**
`patch_libraries` builds one per library ordinal and an extension function has none,
so the lookup returned zero for symbols the dispatcher does register. One is built
on first lookup now.

**`EGL_NOK_resource_profiling2` is implemented and advertised.** The S60 EGL
implementation carries it and clients query the GPU memory budget through it; there
is no fixed heap to report here, so it answers with a stable budget and no tracked
use.

**`CCamera::NewDuplicateL` had no dispatcher opcode.** A duplicate shares the
underlying camera, and dispatcher camera handles have no close of their own, so
handing back the same handle gives it the lifetime a duplicate needs.

**EKA1 devices were never patched to the hardware GLES1 implementation.** They keep
it in `\System\Libs` rather than `\Sys\Bin`, so the patch never matched and the guest
fell back to Nokia's software rasteriser -- which wants frame buffer access the
emulator does not reproduce. Their `libgles_cm.dll` freezes only the GLES 1.0 part of
the DEF file, but the ordinals it does export agree with the 1.1 one, so the same
table applies and the missing ordinals are skipped. That last one has no coverage in
either test suite, neither of which has an EKA1 device.
---

**Verification**: `ctest` green on this branch (plain Release, ASan, and ASan+UBSan). The whole batch was also merged into one tree and run through the iOS Release simulator regression suite: 12/12 on the default suite (Final Battle, Calculator, N95 Calculator) plus 5/5 on the touch suite (Angry Birds on a Symbian^3 device), with the emulator log clean of panics, access violations and graphics halts, and every regression screenshot distinct.