### PR TITLE
kernel: object lifetimes, timers, image loading and the executive tables

### DIFF
--- a/src/emu/common/include/common/linked.h
+++ b/src/emu/common/include/common/linked.h
@@ -112,6 +112,14 @@ namespace eka2l1::common {
         bool empty() const {
             return (elem_.next == &elem_);
         }
+
+        // Re-initialise to an empty ring without dequeuing the current members.
+        // Only valid when every enqueued element is known to be dead already:
+        // their link nodes must not be touched.
+        void reset() {
+            elem_.next = &elem_;
+            elem_.previous = &elem_;
+        }
     };
 
     template <size_t NUM>

--- a/src/emu/kernel/include/kernel/codedump_collector.h
+++ b/src/emu/kernel/include/kernel/codedump_collector.h
@@ -60,5 +60,22 @@ namespace eka2l1::kernel {
         void force_clean() {
             clean_impl();
         }
+
+        /**
+         * @brief Forget every collected entry without freeing it.
+         *
+         * The intrusive link nodes live inside the codesegs / attached infos
+         * themselves, so once the kernel has wiped those objects out the
+         * lists dangle into freed memory. Called from kernel wipeout after
+         * the codeseg container is destroyed; a normal clean would walk (and
+         * write through) the dead nodes.
+         */
+        void wipe() {
+            attach_list_.reset();
+            in_decease_list_.reset();
+
+            collected_memory_ = 0;
+            in_list_count_ = 0;
+        }
     };
 }

--- a/src/emu/kernel/include/kernel/codeseg.h
+++ b/src/emu/kernel/include/kernel/codeseg.h
@@ -173,6 +173,8 @@ namespace eka2l1::kernel {
 
         void calculate_hash();
         void free_attached_data(attached_info &info);
+        void apply_relocations(std::uint8_t *code_base_ptr, std::uint8_t *data_base_ptr,
+            address code_run_addr, address data_run_addr, bool data_only);
 
     public:
         /*! \brief Create a new codeseg

--- a/src/emu/kernel/include/kernel/kernel.h
+++ b/src/emu/kernel/include/kernel/kernel.h
@@ -608,6 +608,13 @@ namespace eka2l1 {
             return threads_;
         }
 
+        // True while wipeout() is tearing the whole kernel down. Completion/scheduling
+        // work should be skipped then: the scheduler and threads are being destroyed, so
+        // signalling or rescheduling a thread would touch state that is already gone.
+        bool is_wiping() const {
+            return wiping_;
+        }
+
         // Whether the given raw thread pointer still refers to a live kernel thread.
         // A destroyed thread is erased from threads_, so a stale pointer will not match.
         // Used to guard completions (property subscriptions, audio callbacks, ...) against

--- a/src/emu/kernel/include/kernel/libmanager.h
+++ b/src/emu/kernel/include/kernel/libmanager.h
@@ -142,8 +142,6 @@ namespace eka2l1 {
 
             std::uint32_t additional_mode_;
 
-            drive_number get_drive_rom();
-
             void apply_pending_patches();
             void apply_trick_or_treat_algo();
             void jump_trampoline_through_svc();
@@ -154,6 +152,8 @@ namespace eka2l1 {
 
             explicit lib_manager(kernel_system *kern, io_system *ios, memory_system *mems);
             ~lib_manager();
+
+            drive_number get_drive_rom();
 
             address get_entry_point_call_routine_address() const;
             address get_thread_entry_routine_address() const;

--- a/src/emu/kernel/include/kernel/timer.h
+++ b/src/emu/kernel/include/kernel/timer.h
@@ -46,6 +46,12 @@ namespace eka2l1 {
 
             signal_info info;
             bool outstanding;
+            int activate_defer_count_ = 0;
+
+            // Whether the outstanding request may be completed now. Reschedules the
+            // event and answers false while the guest has issued the request but not
+            // yet made it active.
+            bool fire_or_defer();
 
         public:
             timer(kernel_system *kern, ntimer *timing, std::string name,
@@ -60,6 +66,10 @@ namespace eka2l1 {
 
             bool request_finish();
             bool cancel_request();
+
+            // Complete the outstanding request, unless it has to be deferred.
+            // Must be called with the kernel lock held.
+            void fire();
         };
     }
 }

--- a/src/emu/kernel/include/kernel/timing.h
+++ b/src/emu/kernel/include/kernel/timing.h
@@ -94,6 +94,15 @@ namespace eka2l1 {
 
         void reset();
 
+        /**
+         * @brief Stop the timer thread and drop all pending events.
+         *
+         * Event callbacks fire on the timer thread and reach deep into kernel and
+         * service state, so the thread must be joined before any of that state is
+         * torn down. Safe to call multiple times; reset() restarts the thread.
+         */
+        void stop();
+
         inline int64_t ms_to_cycles(int ms) {
             return CPU_HZ_ / 1000 * ms;
         }

--- a/src/emu/kernel/src/codedump_collector.cpp
+++ b/src/emu/kernel/src/codedump_collector.cpp
@@ -93,6 +93,12 @@ namespace eka2l1::kernel {
 
         collected_memory_ -= seg->get_used_memory_size();
         in_list_count_--;
+
+        // Return the reference taken in add(codeseg*). Kept as the last
+        // statement: if this was the final reference the codeseg is destroyed
+        // right here, so a caller that keeps using the segment afterwards
+        // (codeseg::attach() does) must hold its own reference first.
+        seg->decrease_access_count();
     }
 
     void codedump_collector::cleanup(std::uint64_t upcoming_memory_size) {

--- a/src/emu/kernel/src/codeseg.cpp
+++ b/src/emu/kernel/src/codeseg.cpp
@@ -102,6 +102,72 @@ namespace eka2l1::kernel {
         return true;
     }
 
+    void codeseg::apply_relocations(std::uint8_t *code_base_ptr, std::uint8_t *data_base_ptr,
+        const address code_run_addr, const address data_run_addr, const bool data_only) {
+        const std::uint32_t code_delta = code_run_addr - code_base;
+        const std::uint32_t data_delta = data_run_addr - data_base;
+
+        for (const std::uint64_t relocate_info : relocation_list) {
+            const loader::relocation_type rel_type = static_cast<loader::relocation_type>((relocate_info >> 32) & 0xFFFF);
+            const loader::relocate_section sect_type = static_cast<loader::relocate_section>((relocate_info >> 48) & 0xFFFF);
+
+            if (data_only && (sect_type != loader::relocate_section_data)) {
+                continue;
+            }
+
+            const std::uint32_t offset_to_relocate = static_cast<std::uint32_t>(relocate_info);
+            std::uint8_t *base_ptr = nullptr;
+
+            switch (sect_type) {
+            case loader::relocate_section_text:
+                base_ptr = code_base_ptr;
+                break;
+
+            case loader::relocate_section_data:
+                base_ptr = data_base_ptr;
+                break;
+
+            default:
+                continue;
+            }
+
+            address the_delta = 0;
+            switch (rel_type) {
+            case loader::relocation_type::data:
+                the_delta = data_delta;
+                break;
+
+            case loader::relocation_type::text:
+                the_delta = code_delta;
+                break;
+
+            case loader::relocation_type::inferred: {
+                const std::uint32_t val = *reinterpret_cast<std::uint32_t *>(&base_ptr[offset_to_relocate]);
+
+                if ((code_base <= val) && (val <= code_base + code_size)) {
+                    the_delta = code_delta;
+                } else if ((data_base <= val) && (val <= data_base + data_size + bss_size)) {
+                    the_delta = data_delta;
+                } else {
+                    LOG_ERROR(KERNEL, "Unable to infer the relocation type of offset 0x{:X}", val);
+                }
+
+                break;
+            }
+
+            case loader::relocation_type::reserved:
+                continue;
+
+            default:
+                LOG_ERROR(KERNEL, "Unknown code relocation type {}", static_cast<std::uint32_t>(rel_type));
+                break;
+            }
+
+            std::uint32_t *to_relocate_ptr = reinterpret_cast<std::uint32_t *>(&base_ptr[offset_to_relocate]);
+            *to_relocate_ptr += the_delta;
+        }
+    }
+
     bool codeseg::attach(kernel::process *new_foe, const bool forcefully) {
         if (!new_foe && !forcefully) {
             return false;
@@ -140,6 +206,12 @@ namespace eka2l1::kernel {
                         if (data_size != 0) {
                             std::uint8_t *data_base_ptr = reinterpret_cast<std::uint8_t *>(att->get()->data_chunk->host_base()) + add_offset;
                             std::copy(constant_data.get(), constant_data.get() + data_size, data_base_ptr); // .data
+
+                            // The saved image contains link-time addresses. Restoring it
+                            // after a detach must repeat data relocations just like the
+                            // initial attachment, while leaving the retained code alone.
+                            const address data_run_addr = att->get()->data_chunk->base(new_foe).ptr_address() + add_offset;
+                            apply_relocations(nullptr, data_base_ptr, get_code_run_addr(new_foe), data_run_addr, true);
                         }
                     }
 
@@ -254,6 +326,8 @@ namespace eka2l1::kernel {
 
         if (attaches.empty()) {
             if (!garbage_link.alone()) {
+                // Drops the collector's reference on this deceased codeseg. Safe only
+                // because we already hold our own (increase_access_count() above).
                 kern->get_codedump_collector().remove(this);
             }
         }
@@ -274,7 +348,13 @@ namespace eka2l1::kernel {
 
                         const address addr = dependency.dep_->lookup(new_foe, ord);
                         if (!addr) {
-                            LOG_ERROR(KERNEL, "Invalid ordinal {}, requested from {}", ord, dependency.dep_->name());
+                            // The import is left pointing at address zero, so the first call
+                            // through it runs off into unmapped memory. Name the importer and
+                            // where the veneer lives: that is what makes such a fault, which
+                            // surfaces far away as a wild PC, traceable back to here.
+                            LOG_ERROR(KERNEL, "Invalid ordinal {} (of {}), requested from {} by {}, patched at code+0x{:X}",
+                                ord, dependency.dep_->get_export_table_raw().size(), dependency.dep_->name(),
+                                name(), offset_to_apply);
                         }
 
                         *reinterpret_cast<std::uint32_t *>(&code_base_ptr[offset_to_apply]) = addr + adj;
@@ -283,71 +363,8 @@ namespace eka2l1::kernel {
             }
         }
 
-        if (need_patch_and_reloc) {
-            if (!relocation_list.empty()) {
-                const std::uint32_t code_delta = the_addr_of_code_run - code_base;
-                const std::uint32_t data_delta = the_addr_of_data_run - data_base;
-
-                // Relocate the image
-                for (const std::uint64_t relocate_info : relocation_list) {
-                    const loader::relocation_type rel_type = static_cast<loader::relocation_type>((relocate_info >> 32) & 0xFFFF);
-                    const std::uint32_t offset_to_relocate = static_cast<std::uint32_t>(relocate_info);
-
-                    loader::relocate_section sect_type = static_cast<loader::relocate_section>((relocate_info >> 48) & 0xFFFF);
-                    address the_delta = 0;
-
-                    std::uint8_t *base_ptr = nullptr;
-
-                    switch (sect_type) {
-                    case loader::relocate_section_text:
-                        base_ptr = code_base_ptr;
-                        break;
-
-                    case loader::relocate_section_data:
-                        base_ptr = data_base_ptr;
-                        break;
-
-                    default:
-                        break;
-                    }
-
-                    std::uint32_t *to_relocate_ptr = reinterpret_cast<std::uint32_t *>(&base_ptr[offset_to_relocate]);
-
-                    switch (rel_type) {
-                    case loader::relocation_type::data:
-                        the_delta = data_delta;
-                        break;
-
-                    case loader::relocation_type::text:
-                        the_delta = code_delta;
-                        break;
-
-                    case loader::relocation_type::inferred: {
-                        // This one is harder
-                        std::uint32_t val = *to_relocate_ptr;
-
-                        if ((code_base <= val) && (val <= code_base + code_size)) {
-                            the_delta = code_delta;
-                        } else if ((data_base <= val) && (val <= data_base + data_size + bss_size)) {
-                            the_delta = data_delta;
-                        } else {
-                            LOG_ERROR(KERNEL, "Unable to infer the relocation type of offset 0x{:X}", val);
-                        }
-
-                        break;
-                    }
-
-                    case loader::relocation_type::reserved:
-                        continue;
-
-                    default:
-                        LOG_ERROR(KERNEL, "Unknown code relocation type {}", static_cast<std::uint32_t>(rel_type));
-                        break;
-                    }
-
-                    *to_relocate_ptr = *to_relocate_ptr + the_delta;
-                }
-            }
+        if (need_patch_and_reloc && !relocation_list.empty()) {
+            apply_relocations(code_base_ptr, data_base_ptr, the_addr_of_code_run, the_addr_of_data_run, false);
         }
 
         if (new_foe)
@@ -384,6 +401,11 @@ namespace eka2l1::kernel {
         if (!code_chunk_shared && info.code_chunk) {
             kern->destroy(info.code_chunk);
         }
+
+        // An earlier non-fatal detach may have parked this attach info in the
+        // codedump collector; erasing it below while its garbage link is still
+        // enqueued leaves the collector walking freed memory on its next clean.
+        kern->get_codedump_collector().remove(info);
 
         info.closing_lib_link.deque();
         info.process_link.deque();
@@ -804,9 +826,13 @@ namespace eka2l1::kernel {
 
     void codeseg::calculate_hash() {
         XXH32_state_t *state = XXH32_createState();
+        std::uint8_t *mapped_code = nullptr;
+        if (is_rom()) {
+            get_code_run_addr(nullptr, &mapped_code);
+        }
 
         XXH32_reset(state, 0x5B001101);
-        XXH32_update(state, code_data.get(), code_size);
+        XXH32_update(state, is_rom() ? mapped_code : code_data.get(), code_size);
 
         hash_ = XXH32_digest(state);
         XXH32_freeState(state);

--- a/src/emu/kernel/src/ipc.cpp
+++ b/src/emu/kernel/src/ipc.cpp
@@ -18,8 +18,11 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <common/log.h>
+
 #include <kernel/ipc.h>
 #include <kernel/session.h>
+#include <kernel/thread.h>
 
 namespace eka2l1 {
     ipc_arg::ipc_arg(int arg0, const int aflag) {
@@ -85,10 +88,32 @@ namespace eka2l1 {
     }
 
     void ipc_msg::unref() {
+        // Guard against a double unref (e.g. a server completing a message
+        // whose client already released it). Wrapping the unsigned count
+        // would poison the slot forever and desync the owner thread's
+        // access accounting.
+        if (ref_count == 0) {
+            LOG_WARN(KERNEL, "Unreferencing an already-released IPC message (id {}, function 0x{:X})", id, function);
+            return;
+        }
+
         if (--ref_count == 0) {
             if (msg_session) {
                 session_msg_link.deque();
             }
+
+            // A message released while still sitting in a server's delivered
+            // queue (its session died before the server received it) must
+            // leave that queue too, or the server later pops the freed slot -
+            // possibly recycled by a new exchange by then - and completes it
+            // again against the wrong owner.
+            if (delivered_msg_link.next) {
+                delivered_msg_link.deque();
+            }
+
+            // Read this before dropping the access count: the drop may destroy
+            // a stopped owner on the spot, and own_thr must not be touched after.
+            const bool owner_stopped = own_thr && (own_thr->current_state() == kernel::thread_state::stop);
 
             if (own_thr) {
                 own_thr->decrease_access_count();
@@ -97,6 +122,19 @@ namespace eka2l1 {
             switch (type) {
             case ipc_message_type_disconnect:
                 type = ipc_message_type_wild;
+                break;
+
+            case ipc_message_type_sync:
+                // A live thread keeps its sync message for reuse, so the slot
+                // normally stays reserved. Only reclaim it when the owner died
+                // with this message still in flight (free_msg skipped it then).
+                // The drop above may have destroyed that owner, so drop the
+                // pointer along with the slot reservation.
+                if (owner_stopped) {
+                    type = ipc_message_type_wild;
+                    own_thr = nullptr;
+                }
+
                 break;
 
             case ipc_message_type_session:

--- a/src/emu/kernel/src/kernel.cpp
+++ b/src/emu/kernel/src/kernel.cpp
@@ -29,6 +29,7 @@
 
 #include <common/armemitter.h>
 #include <common/buffer.h>
+#include <common/common.h>
 #include <common/chunkyseri.h>
 #include <common/configure.h>
 #include <common/cvt.h>
@@ -136,16 +137,35 @@ namespace eka2l1 {
         OBJECT_CONTAINER_CLEANUP(undertakers_);
         OBJECT_CONTAINER_CLEANUP(prop_refs_);
         OBJECT_CONTAINER_CLEANUP(props_);
-        OBJECT_CONTAINER_CLEANUP(chunks_);
 
         for (std::size_t i = 0; i < msgs_.size(); i++) {
-            msgs_[i].reset();   
+            if (msgs_[i]) {
+                // Sessions and servers are gone by now, so a message leaked with a
+                // non-zero reference count must not run its unref side effects
+                // against them, nor against an owner thread a stale completion may
+                // have destroyed early. Neutralise it so ~ipc_msg tears it down
+                // without touching those pointers.
+                msgs_[i]->own_thr = nullptr;
+                msgs_[i]->msg_session = nullptr;
+                msgs_[i]->ref_count = 0;
+            }
+
+            msgs_[i].reset();
         }
 
         OBJECT_CONTAINER_CLEANUP_KEEP_OBJECTS(threads_);
         OBJECT_CONTAINER_CLEANUP_KEEP_OBJECTS(processes_);
+        // Chunks must outlive processes: killing a process destroys its memory
+        // model, whose destructor walks the still-attached chunks (the global and
+        // DLL-static ones opened into it) to detach its mappings.
+        OBJECT_CONTAINER_CLEANUP(chunks_);
         OBJECT_CONTAINER_CLEANUP(libraries_);
         OBJECT_CONTAINER_CLEANUP(codesegs_);
+
+        // The collector outlives a reboot, but its intrusive lists point into the
+        // codesegs and attached infos destroyed just above. Forget them, or the
+        // first clean after the reboot walks freed memory.
+        codedump_collector_.wipe();
         OBJECT_CONTAINER_CLEANUP(message_queues_)
         OBJECT_CONTAINER_CLEANUP(logical_channels_);
         OBJECT_CONTAINER_CLEANUP(logical_devices_);
@@ -788,22 +808,47 @@ namespace eka2l1 {
         return msgs_[handle - 1].get();
     }
 
+    static bool destroy_object_in_container(std::vector<kernel_obj_unq_ptr> &container, kernel_obj_ptr obj) {
+        auto locate = [&]() {
+            return std::lower_bound(container.begin(), container.end(), obj, [](const auto &lhs, const auto &rhs) {
+                return lhs->unique_id() < rhs->unique_id();
+            });
+        };
+
+        auto res = locate();
+
+        // lower_bound lands on the first object with a greater or equal uid, so an
+        // object that is not (or no longer) in this container resolves to an
+        // unrelated live one. Destroying and erasing that one leaves everybody still
+        // referencing it with a dangling pointer, paid for much later.
+        if ((res == container.end()) || (res->get() != obj)) {
+            return false;
+        }
+
+        obj->destroy();
+
+        // destroy() can destroy other objects of the same type: a codeseg drops the
+        // references it holds on its dependencies, a thread releases its owner. Each
+        // of those erases an element of this very vector, so the iterator taken above
+        // may now address a different - live - object. Locate the slot again.
+        res = locate();
+
+        if ((res != container.end()) && (res->get() == obj)) {
+            container.erase(res);
+        }
+
+        return true;
+    }
+
     bool kernel_system::destroy(kernel_obj_ptr obj) {
         if (!obj || wiping_) {
             return true;
         }
 
         switch (obj->get_object_type()) {
-#define OBJECT_SEARCH(obj_type, obj_map)                                                                         \
-    case kernel::object_type::obj_type: {                                                                        \
-        auto res = std::lower_bound(obj_map.begin(), obj_map.end(), obj, [&](const auto &lhs, const auto &rhs) { \
-            return lhs->unique_id() < rhs->unique_id();                                                          \
-        });                                                                                                      \
-        if (res == obj_map.end())                                                                                \
-            return false;                                                                                        \
-        (*res)->destroy();                                                                                       \
-        obj_map.erase(res);                                                                                      \
-        return true;                                                                                             \
+#define OBJECT_SEARCH(obj_type, obj_map)                  \
+    case kernel::object_type::obj_type: {                 \
+        return destroy_object_in_container(obj_map, obj); \
     }
 
             OBJECT_SEARCH(mutex, mutexes_)
@@ -1021,6 +1066,17 @@ namespace eka2l1 {
     }
 
     void kernel_system::free_msg(ipc_msg_ptr msg) {
+        // A message that is still referenced belongs to an in-flight exchange: a
+        // server has yet to complete it while the client thread dies with its sync
+        // message pending. Forcing the slot free lets create_msg recycle it, and the
+        // late completion then unrefs the new owner - which loses an access count it
+        // still needs, is destroyed while other messages point at it, and takes the
+        // kernel teardown down with a dangling own_thr. Let the final unref release
+        // the message instead.
+        if (msg->ref_count > 0) {
+            return;
+        }
+
         msg->type = ipc_message_type_wild;
         msg->ref_count = 0;
     }
@@ -1435,7 +1491,23 @@ namespace eka2l1 {
     }
 
     std::uint64_t kernel_system::universal_time() {
-        return base_time_ + timing_->microseconds();
+        const std::uint64_t raw = base_time_ + timing_->microseconds();
+
+        // On EKA1 the kernel only refreshes the system clock from the 64Hz tick
+        // interrupt, so User::UTCTime() and TTime::HomeTime() advance in whole tick
+        // periods. Code written for that granularity assumes two reads inside one
+        // tick return the same value: N-Gage Call of Duty computes
+        // frames * 100000 / (elapsed_us / 1000) during view startup, guards only on
+        // elapsed_us != 0, and divides by zero for any elapsed_us under a
+        // millisecond. EKA2L1 otherwise sources a continuous microsecond clock.
+        // EKA2 backs the clock with the fast counter and really is fine grained, so
+        // it is left alone.
+        if (is_eka1()) {
+            const std::uint64_t tick_us = common::microsecs_per_sec / epoc::TICK_TIMER_HZ;
+            return raw / tick_us * tick_us;
+        }
+
+        return raw;
     }
 
     std::uint64_t kernel_system::home_time() {

--- a/src/emu/kernel/src/libmanager.cpp
+++ b/src/emu/kernel/src/libmanager.cpp
@@ -848,7 +848,7 @@ namespace eka2l1::hle {
             std::pair<std::optional<loader::e32img>, std::optional<loader::romimg>>
                 result{ std::nullopt, std::nullopt };
 
-            if (io_->exist(lib_path)) {
+            if (io_->exist(path)) {
                 symfile f = io_->open_file(path, READ_MODE | BIN_MODE | additional_mode_);
                 if (!f) {
                     return result;
@@ -923,6 +923,26 @@ namespace eka2l1::hle {
             return std::pair<std::optional<loader::e32img>, std::optional<loader::romimg>>{};
         }
 
+        if (!eka2l1::has_root_name(lib_path, true)) {
+            // A path like \sys\bin\foo.exe names a directory but no drive. Symbian's
+            // loader searches every drive for it; opening it verbatim finds nothing.
+            for (drive_number drv = drive_a; drv <= drive_z; drv = static_cast<drive_number>(static_cast<int>(drv) + 1)) {
+                std::u16string candidate(1, drive_to_char16(drv));
+                candidate += u':';
+                candidate += lib_path;
+
+                auto result = open_and_get(candidate);
+                if (result.first != std::nullopt || result.second != std::nullopt) {
+                    if (full_path)
+                        *full_path = candidate;
+
+                    return result;
+                }
+            }
+
+            return std::pair<std::optional<loader::e32img>, std::optional<loader::romimg>>{};
+        }
+
         if (full_path) {
             *full_path = lib_path;
         }
@@ -952,7 +972,7 @@ namespace eka2l1::hle {
 
             eka2l1::ro_file_stream image_data_stream(f.get());
 
-            if (f->is_in_rom()) {
+            if (f->is_in_rom() && !loader::is_e32img(reinterpret_cast<common::ro_stream *>(&image_data_stream))) {
                 auto romimg = loader::parse_romimg(reinterpret_cast<common::ro_stream *>(&image_data_stream), mem_, kern_->get_epoc_version(), is_driver_lib);
                 if (!romimg) {
                     return nullptr;
@@ -972,6 +992,26 @@ namespace eka2l1::hle {
         };
 
         std::u16string lib_path = name;
+
+        // A Symbian absolute path can be rooted without naming a drive (for
+        // example, "\\sys\\bin\\foo.dll"). Resolve that form against each
+        // mounted drive instead of treating it as a complete VFS path.
+        if (eka2l1::has_root_dir(lib_path) && eka2l1::root_name(lib_path, true).empty()) {
+            for (drive_number drv = drive_a; drv <= drive_z; drv = static_cast<drive_number>(static_cast<int>(drv) + 1)) {
+                std::u16string candidate(1, drive_to_char16(drv));
+                candidate += u':';
+                candidate += lib_path;
+
+                if (io_->exist(candidate)) {
+                    if (codeseg_ptr result = load_depend_on_drive(candidate, is_driver_lib)) {
+                        result->set_full_path(candidate);
+                        return result;
+                    }
+                }
+            }
+
+            return nullptr;
+        }
 
         // Create a new codeseg, we should try search these files
         // Absolute yet ?
@@ -1038,16 +1078,29 @@ namespace eka2l1::hle {
     }
 
     void lib_manager::jump_trampoline_through_svc() {
-        kernel::thread *crr = kern_->crr_thread();
-        arm::core::thread_context &context = crr->get_thread_context();
-        address lookup_addr = (context.get_pc() | ((context.cpsr & 0x20) ? 1 : 0));
+        arm::core *cpu = kern_->get_cpu();
+        const bool thumb = (cpu->get_cpsr() & 0x20) != 0;
+
+        // CPU backends advance PC before invoking the SVC handler. The
+        // trampoline map is keyed by the address at which the SVC was
+        // installed, so recover that instruction address before lookup.
+        const address lookup_addr = (cpu->get_pc() - (thumb ? 2 : 4)) | (thumb ? 1 : 0);
+
+        auto branch_to = [cpu](const address target) {
+            std::uint32_t cpsr = cpu->get_cpsr() & ~0x20;
+            if (target & 1) {
+                cpsr |= 0x20;
+            }
+            cpu->set_cpsr(cpsr);
+            cpu->set_pc(target & ~1);
+        };
 
         auto ite = trampoline_lookup_.find(lookup_addr);
         if (ite != trampoline_lookup_.end()) {
-            context.set_pc(ite->second);
+            branch_to(ite->second);
         } else {
             LOG_ERROR(KERNEL, "Unable to find jump for patched address 0x{:X} (impossible)", lookup_addr);
-            context.set_pc(context.get_lr());
+            branch_to(cpu->get_lr());
         }
     }
 

--- a/src/emu/kernel/src/mutex.cpp
+++ b/src/emu/kernel/src/mutex.cpp
@@ -83,8 +83,9 @@ namespace eka2l1 {
             if (holding == thr) {
                 ++lock_count;
             } else {
-                assert(!holding->wait_obj);
-
+                // The holder may legitimately be blocked on another wait object -- its
+                // request semaphore, say -- while owning this mutex. It releases us
+                // when it resumes, so queueing behind it is correct.
                 kernel::thread *calm_down = thr;
                 waits.push(calm_down);
 

--- a/src/emu/kernel/src/object_ix.cpp
+++ b/src/emu/kernel/src/object_ix.cpp
@@ -135,11 +135,16 @@ namespace eka2l1::kernel {
         handle_inspect_info info = inspect_handle(handle);
 
         if (info.object_ix_index < objects.size()) {
-            if (objects[info.object_ix_index].free) {
+            const object_ix_record &record = objects[info.object_ix_index];
+            const std::uint32_t closable_handle = handle & ~0x8000U;
+            // EKA1 clients can retain a handle after the emulator has reopened the same
+            // object into that slot with a new instance value. EKA2 relies on the instance
+            // bits to reject stale handles, so keep the stricter check there.
+            if (record.free || (!kern->is_eka1() && (record.associated_handle != closable_handle))) {
                 return nullptr;
             }
 
-            return objects[info.object_ix_index].object;
+            return record.object;
         }
 
         LOG_WARN(KERNEL, "Can't find object with handle: 0x{:x}", handle);
@@ -152,20 +157,24 @@ namespace eka2l1::kernel {
         int ret_value = 0;
 
         if (info.object_ix_index < objects.size()) {
-            kernel_obj_ptr obj = objects[info.object_ix_index].object;
+            object_ix_record &record = objects[info.object_ix_index];
 
-            if (!obj) {
+            if (record.free || !record.object
+                || (!kern->is_eka1() && (record.associated_handle != handle))) {
                 return -1;
             }
 
+            kernel_obj_ptr obj = record.object;
+            const std::uint32_t associated_handle = record.associated_handle;
             ret_value = obj->decrease_access_count();
             totals--;
 
-            objects[info.object_ix_index].free = true;
-            objects[info.object_ix_index].object = nullptr;
+            record.free = true;
+            record.object = nullptr;
+            record.associated_handle = 0;
 
             // Find the handle in unclosed handle list
-            auto iterator = std::find(handles.begin(), handles.end(), handle);
+            auto iterator = std::find(handles.begin(), handles.end(), associated_handle);
             if (iterator != handles.end()) {
                 handles.erase(iterator);
             }
@@ -181,8 +190,13 @@ namespace eka2l1::kernel {
             if (index.free == false) {
                 index.object->decrease_access_count();
                 index.free = true;
+                index.object = nullptr;
+                index.associated_handle = 0;
             }
         }
+
+        handles.clear();
+        totals = 0;
     }
 
     bool object_ix::has(kernel_obj_ptr obj) {

--- a/src/emu/kernel/src/process.cpp
+++ b/src/emu/kernel/src/process.cpp
@@ -432,6 +432,22 @@ namespace eka2l1::kernel {
             process_handles.reset();
         }
 
+        // Break the parent/child links now, after the logons that may inspect the
+        // child list. A dead process must not linger in its parent's child list, nor
+        // keep children pointing back at it: launch-exit callbacks walk those raw
+        // pointers long after this object is freed.
+        while (!child_processes_.empty()) {
+            kernel::process *child = child_processes_.back();
+
+            if (child->parent_process_ == this) {
+                child->detatch_from_parent();
+            } else {
+                child_processes_.pop_back();
+            }
+        }
+
+        detatch_from_parent();
+
         kern->destroy(dll_lock);
 
         if (dll_static_chunk) {
@@ -507,12 +523,22 @@ namespace eka2l1::kernel {
     }
 
     void process::finish_logons() {
+        // The thread that armed a Logon/Rendezvous lives in another process and may
+        // already have exited, leaving a dangling requester in the queues.
+        // notify_info::complete() dereferences that requester to translate the
+        // request status, so completing a stale entry faults on a half-torn thread.
+        // Signal only the requesters that are still alive; the queues are cleared
+        // below either way.
         for (auto &req : logon_requests) {
-            req.complete(exit_reason);
+            if (kern->is_thread_alive(req.requester)) {
+                req.complete(exit_reason);
+            }
         }
 
         for (auto &req : rendezvous_requests) {
-            req.complete(exit_reason);
+            if (kern->is_thread_alive(req.requester)) {
+                req.complete(exit_reason);
+            }
         }
 
         logon_requests.clear();

--- a/src/emu/kernel/src/property.cpp
+++ b/src/emu/kernel/src/property.cpp
@@ -120,7 +120,14 @@ namespace eka2l1 {
                 return false;
             }
 
-            (*subscription_iterator)->complete(epoc::error_cancel);
+            // The subscriber thread may already have exited (e.g. this reference is only
+            // now being torn down via decrease_access_count). notify_info::complete()
+            // dereferences the requester thread, so only signal it while it is still alive;
+            // otherwise just drop the stale subscription.
+            if (kern->is_thread_alive((*subscription_iterator)->requester)) {
+                (*subscription_iterator)->complete(epoc::error_cancel);
+            }
+
             subscription_queue.erase(subscription_iterator);
 
             return true;
@@ -128,7 +135,10 @@ namespace eka2l1 {
 
         void property::notify_request(const std::int32_t err) {
             while (auto subscription = subscription_queue.pop()) {
-                subscription.value()->complete(err);
+                // Same rationale as cancel(): never complete to a requester that has died.
+                if (kern->is_thread_alive(subscription.value()->requester)) {
+                    subscription.value()->complete(err);
+                }
             }
         }
 

--- a/src/emu/kernel/src/scheduler.cpp
+++ b/src/emu/kernel/src/scheduler.cpp
@@ -186,6 +186,19 @@ namespace eka2l1::kernel {
             }
         }
 
+        // A ready thread can briefly outlive its process's memory model during a
+        // multi-step teardown. Drop the stale entries so switch_context receives a
+        // runnable thread with a valid address space.
+        while (next_thread) {
+            kernel::process *owner = next_thread->owning_process();
+            if (owner && owner->get_mem_model()) {
+                break;
+            }
+
+            dequeue_thread_from_ready(next_thread);
+            next_thread = next_ready_thread();
+        }
+
         switch_context(crr_thread, next_thread);
     }
 
@@ -281,6 +294,7 @@ namespace eka2l1::kernel {
 
             thr->state = thread_state::wait;
             dequeue_thread_from_ready(thr);
+            kern->prepare_reschedule();
         }
 
         // Schedule the thread to be waken up

--- a/src/emu/kernel/src/session.cpp
+++ b/src/emu/kernel/src/session.cpp
@@ -191,7 +191,11 @@ namespace eka2l1 {
 
                 if (msg) {
                     if ((msg->msg_status == ipc_message_status::accepted) || (msg->msg_status == ipc_message_status::delivered)) {
-                        if (msg->own_thr && (msg->own_thr->current_state() != kernel::thread_state::stop)) {
+                        // During kernel wipeout the owning threads and the scheduler are being
+                        // torn down, so signal_request() would dewait a thread whose scheduler
+                        // state is already gone (native crash in thread_scheduler::dewait). The
+                        // requests need not be completed then; only the normal-close path does.
+                        if (!kern->is_wiping() && msg->own_thr && (msg->own_thr->current_state() != kernel::thread_state::stop)) {
                             epoc::request_status *final_sts = msg->request_sts.get(msg->own_thr->owning_process());
                             if (final_sts) {
                                 msg->msg_status = ipc_message_status::completed;
@@ -220,10 +224,19 @@ namespace eka2l1 {
                 }
             }
 
-            disconnect_msg_->own_thr->decrease_access_count();
+            // unref clears own_thr when it releases a message whose owner
+            // already stopped, so the disconnect message may no longer carry
+            // the creator thread this pairs with (its count died with it).
+            if (disconnect_msg_->own_thr) {
+                disconnect_msg_->own_thr->decrease_access_count();
+            }
 
-            // Free the message pool anyway
+            // Free the message pool anyway. The pool dies with this session,
+            // so a message that is still referenced (free_msg leaves those to
+            // their final unref) must not call back into the freed session
+            // through set_slot_free.
             for (const auto &msg : msgs_pool) {
+                msg.second->msg_session = nullptr;
                 kern->free_msg(msg.second);
             }
 

--- a/src/emu/kernel/src/svc.cpp
+++ b/src/emu/kernel/src/svc.cpp
@@ -83,10 +83,52 @@ namespace eka2l1::epoc {
         return nullptr;
     }
 
+    static bool find_rom_entry_containing_addr(const loader::rom_dir &dir, const std::u16string &path_so_far,
+        const std::uint32_t addr, std::u16string &result) {
+        static constexpr std::uint8_t FILE_ATTRIB_DIR = 0x10;
+
+        for (const auto &entry : dir.entries) {
+            if (entry.attrib & FILE_ATTRIB_DIR) {
+                continue;
+            }
+
+            if ((entry.address_lin <= addr) && (addr - entry.address_lin < entry.size)) {
+                result = path_so_far + entry.name;
+                return true;
+            }
+        }
+
+        for (const auto &subdir : dir.subdirs) {
+            if (find_rom_entry_containing_addr(subdir, path_so_far + subdir.name + u"\\", addr, result)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     static std::optional<std::u16string> get_dll_full_path(kernel_system *kern, const std::uint32_t addr) {
         codeseg_ptr ss = get_codeseg_from_addr(kern, kern->crr_process(), addr, true);
         if (ss) {
             return ss->get_full_path();
+        }
+
+        // A statically linked XIP DLL runs in place from ROM and only gets a codeseg
+        // once it appears in some image's DLL reference chain, so an address inside
+        // one (gflm.dll, say) does not resolve above. The ROM file tree records the
+        // linear address range of every XIP entry, which is enough to name the image
+        // the address belongs to.
+        loader::rom *rom_info = kern->get_rom_info();
+        if (rom_info) {
+            std::u16string prefix(1, drive_to_char16(kern->get_lib_manager()->get_drive_rom()));
+            prefix += u":\\";
+
+            for (const auto &root : rom_info->root.root_dirs) {
+                std::u16string result;
+                if (find_rom_entry_containing_addr(root.dir, prefix, addr, result)) {
+                    return result;
+                }
+            }
         }
 
         return std::nullopt;
@@ -647,6 +689,28 @@ namespace eka2l1::epoc {
         full_path_ptr.get(crr_pr)->assign(crr_pr, path_utf8);
     }
 
+    // Exec::GetModuleNameFromAddress. Unlike Dll::FileName's executive it reports
+    // whether the address could be attributed at all, and its callers branch on that
+    // code: TExtendedLocale::GetLocaleDllName, and the SQL server on startup.
+    BRIDGE_FUNC(std::int32_t, get_module_name_from_address, std::int32_t addr, eka2l1::ptr<epoc::des8> module_name_ptr) {
+        std::optional<std::u16string> full_path = get_dll_full_path(kern, addr);
+
+        if (!full_path) {
+            LOG_TRACE(KERNEL, "No module contains address 0x{:X}", static_cast<std::uint32_t>(addr));
+            return epoc::error_not_found;
+        }
+
+        kernel::process *crr_pr = kern->crr_process();
+        epoc::des8 *module_name = module_name_ptr.get(crr_pr);
+
+        if (!module_name) {
+            return epoc::error_argument;
+        }
+
+        module_name->assign(crr_pr, common::ucs2_to_utf8(*full_path));
+        return epoc::error_none;
+    }
+
     /***********************************/
     /* LOCALE */
     /**********************************/
@@ -790,6 +854,13 @@ namespace eka2l1::epoc {
         if ((int)msg->args.get_arg_type(param) & (int)ipc_arg_type::flag_des) {
             epoc::desc_base *base = eka2l1::ptr<epoc::desc_base>(msg->args.args[param]).get(msg->own_thr->owning_process());
 
+            // The slot is typed as a descriptor, but the client may still have passed
+            // a null or unmapped address. Symbian answers KErrBadDescriptor there
+            // rather than faulting the server.
+            if (!base) {
+                return epoc::error_bad_descriptor;
+            }
+
             return base->get_length();
         }
 
@@ -811,7 +882,13 @@ namespace eka2l1::epoc {
 
         if ((int)type & (int)ipc_arg_type::flag_des) {
             kernel::process *own_pr = msg->own_thr->owning_process();
-            return eka2l1::ptr<epoc::des8>(msg->args.args[param]).get(own_pr)->get_max_length(own_pr);
+            epoc::des8 *base = eka2l1::ptr<epoc::des8>(msg->args.args[param]).get(own_pr);
+
+            if (!base) {
+                return epoc::error_bad_descriptor;
+            }
+
+            return base->get_max_length(own_pr);
         }
 
         return epoc::error_bad_descriptor;
@@ -895,6 +972,7 @@ namespace eka2l1::epoc {
 
         ipc_arg_type arg_type = msg->args.get_arg_type(param);
         if (!(static_cast<std::uint32_t>(arg_type) & static_cast<std::uint32_t>(ipc_arg_type::flag_des))) {
+            msg->unref();
             return epoc::error_argument;
         }
 
@@ -902,6 +980,7 @@ namespace eka2l1::epoc {
         std::uint8_t *param_ptr_host = param_ptr.get(msg->own_thr->owning_process());
 
         if (!param_ptr_host || !info_host) {
+            msg->unref();
             return epoc::error_argument;
         }
 
@@ -930,6 +1009,7 @@ namespace eka2l1::epoc {
 
         ipc_arg_type arg_type = msg->args.get_arg_type(param);
         if (!(static_cast<std::uint32_t>(arg_type) & static_cast<std::uint32_t>(ipc_arg_type::flag_des))) {
+            msg->unref();
             return epoc::error_argument;
         }
 
@@ -937,6 +1017,7 @@ namespace eka2l1::epoc {
         std::uint8_t *param_ptr_host = param_ptr.get(msg->own_thr->owning_process());
 
         if (!param_ptr_host || !info_host) {
+            msg->unref();
             return epoc::error_argument;
         }
 
@@ -944,6 +1025,7 @@ namespace eka2l1::epoc {
         epoc::desc8 *des_des = des_des_ptr.get(crr_process);
 
         if (!des_des) {
+            msg->unref();
             return epoc::error_argument;
         }
 
@@ -954,6 +1036,7 @@ namespace eka2l1::epoc {
 
         const std::int32_t result = do_ipc_manipulation(kern, msg->own_thr, param_ptr_host, info_copy, start_offset);
         if (result < 0) {
+            msg->unref();
             return result;
         }
 
@@ -3109,18 +3192,18 @@ namespace eka2l1::epoc {
 
         kernel::process *process_to_operate = thr_to_operate->owning_process();
 
-        if (is_write) {
-            if (len > static_cast<std::int32_t>(buf->get_length())) {
-                return epoc::error_overflow;
-            }
-        } else {
-            if (len > static_cast<std::int32_t>(buf->get_max_length(process_to_operate))) {
-                return epoc::error_underflow;
-            }
+        // The byte count comes from the separate length argument, not from the
+        // descriptor: callers hand over a plain buffer (a TPtr8 built with the
+        // two-argument constructor still has a zero length) and let the command header
+        // say how much of it to transfer. Both directions are therefore bounded by the
+        // descriptor's capacity, which get_max_length() reports as the length for the
+        // constant descriptor types that have no separate maximum.
+        if (len > static_cast<std::int32_t>(buf->get_max_length(crr))) {
+            return is_write ? epoc::error_overflow : epoc::error_underflow;
         }
 
         std::uint8_t *buf_ptr = reinterpret_cast<std::uint8_t *>(buf->get_pointer_raw(crr));
-        
+
         if (len == 4) {
             if (is_write) {
                 std::uint32_t data = *reinterpret_cast<std::uint32_t*>(buf_ptr);
@@ -3136,22 +3219,25 @@ namespace eka2l1::epoc {
 
                 std::uint32_t final_result_data = result.value();
                 std::memcpy(buf_ptr, &final_result_data, 4);
+
+                return epoc::error_none;
             }
 
-            return epoc::error_none;
-        }
-
-        std::uint8_t *dest_of_operate = reinterpret_cast<std::uint8_t *>(process_to_operate->get_ptr_on_addr_space(addr));
-
-        if (!dest_of_operate) {
-            LOG_WARN(KERNEL, "Destination to operate is null, return success still.");
-            return epoc::error_none;
-        }
-
-        if (is_write) {
-            std::memcpy(dest_of_operate, buf_ptr, len);
+            // Fall through to the instruction cache flush below: four bytes is exactly
+            // one ARM instruction, and patching one is what this command is for.
         } else {
-            std::memcpy(buf_ptr, dest_of_operate, len);
+            std::uint8_t *dest_of_operate = reinterpret_cast<std::uint8_t *>(process_to_operate->get_ptr_on_addr_space(addr));
+
+            if (!dest_of_operate) {
+                LOG_WARN(KERNEL, "Destination to operate is null, return success still.");
+                return epoc::error_none;
+            }
+
+            if (is_write) {
+                std::memcpy(dest_of_operate, buf_ptr, len);
+            } else {
+                std::memcpy(buf_ptr, dest_of_operate, len);
+            }
         }
 
         // Check if we should recompile
@@ -5645,6 +5731,81 @@ namespace eka2l1::epoc {
         return chn->do_request(request_nof_info, func, args[0], args[1], false);
     }
 
+    // TChannelCreateInfo8, as Exec::ChannelCreate receives it.
+    struct logical_channel_create_info {
+        epoc::version version;
+        std::int32_t unit;
+        eka2l1::ptr<epoc::desc8> physical_device;
+        eka2l1::ptr<epoc::desc8> info;
+    };
+
+    BRIDGE_FUNC(std::int32_t, logical_channel_create, eka2l1::ptr<epoc::desc8> device_name_des,
+        eka2l1::ptr<logical_channel_create_info> create_info_ptr, std::int32_t owner) {
+        kernel::process *process = kern->crr_process();
+        epoc::desc8 *device_name = device_name_des.get(process);
+        logical_channel_create_info *create_info = create_info_ptr.get(process);
+
+        if (!device_name || !create_info) {
+            return epoc::error_argument;
+        }
+
+        const std::string name = common::lowercase_string(device_name->to_std_string(process));
+        ldd::factory *factory = kern->get_by_name<ldd::factory>(name);
+
+        if (!factory) {
+            const auto factory_func = kern->suitable_ldd_instantiate_func(name.c_str());
+            if (!factory_func) {
+                LOG_TRACE(KERNEL, "Logical device {} is not emulated", name);
+                return epoc::error_not_found;
+            }
+
+            ldd::factory_instance factory_instance = factory_func(kern->get_system());
+            factory = kern->add_object(factory_instance);
+            if (!factory) {
+                return epoc::error_no_memory;
+            }
+
+            factory->install();
+        }
+
+        std::unique_ptr<ldd::channel> channel = factory->make_channel(create_info->version);
+        if (!channel) {
+            return epoc::error_not_supported;
+        }
+
+        ldd::channel *added_channel = kern->add_object(channel);
+        if (!added_channel) {
+            return epoc::error_no_memory;
+        }
+
+        added_channel->set_owner(process);
+        return kern->open_handle_with_thread(kern->crr_thread(), added_channel,
+            owner == epoc::owner_process ? kernel::owner_type::process : kernel::owner_type::thread);
+    }
+
+    // The emulated logical devices are built in, so there is no image to load. A
+    // channel is created straight from the factory instead, and E32Loader::DeviceLoad
+    // has nothing to do.
+    BRIDGE_FUNC(std::int32_t, logical_device_load) {
+        return epoc::error_not_supported;
+    }
+
+    BRIDGE_FUNC(std::int32_t, logical_device_free, eka2l1::ptr<epoc::desc8> device_name_des, std::int32_t) {
+        kernel::process *process = kern->crr_process();
+        epoc::desc8 *device_name = device_name_des.get(process);
+        if (!device_name) {
+            return epoc::error_argument;
+        }
+
+        const std::string name = common::lowercase_string(device_name->to_std_string(process));
+        ldd::factory *factory = kern->get_by_name<ldd::factory>(name);
+        if (!factory) {
+            return epoc::error_not_found;
+        }
+
+        return factory->decrease_access_count();
+    }
+
     BRIDGE_FUNC(std::int32_t, logical_channel_do_control_eka1, const int func, eka2l1::ptr<void> arg1,
         eka2l1::ptr<void> arg2, const kernel::handle h) {
         return logical_channel_do_control(kern, h, func, arg1, arg2);
@@ -5663,9 +5824,6 @@ namespace eka2l1::epoc {
         return 0;
     }
 
-    BRIDGE_FUNC(std::int32_t, get_locale_dll_name) {
-        return epoc::error_none;
-    }
 
     const eka2l1::hle::func_map svc_register_funcs_v10 = {
         /* FAST EXECUTIVE CALL */
@@ -5735,7 +5893,7 @@ namespace eka2l1::epoc {
         BRIDGE_REGISTER(0x3A, request_signal),
         BRIDGE_REGISTER(0x3B, handle_name),
         BRIDGE_REGISTER(0x3C, handle_full_name),
-        BRIDGE_REGISTER(0x3E, handle_info),
+        BRIDGE_REGISTER(0x3D, handle_info),
         BRIDGE_REGISTER(0x3E, handle_count),
         BRIDGE_REGISTER(0x3F, after),
         BRIDGE_REGISTER(0x41, message_complete),
@@ -5769,8 +5927,14 @@ namespace eka2l1::epoc {
         BRIDGE_REGISTER(0x78, thread_rename),
         BRIDGE_REGISTER(0x7B, process_logon),
         BRIDGE_REGISTER(0x7C, process_logon_cancel),
-        BRIDGE_REGISTER(0x7F, server_create),
+        BRIDGE_REGISTER(0x7D, thread_process),
+        BRIDGE_REGISTER(0x7E, server_create),
+        BRIDGE_REGISTER(0x7F, server_create), // ServerCreateWithOptions
         BRIDGE_REGISTER(0x80, session_create),
+        BRIDGE_REGISTER(0x81, session_create_from_handle),
+        BRIDGE_REGISTER(0x82, logical_device_load),
+        BRIDGE_REGISTER(0x83, logical_device_free),
+        BRIDGE_REGISTER(0x84, logical_channel_create),
         BRIDGE_REGISTER(0x85, timer_create),
         BRIDGE_REGISTER(0x86, timer_after), // Actually TimerHighRes
         BRIDGE_REGISTER(0x87, after), // Actually AfterHighRes
@@ -5801,6 +5965,7 @@ namespace eka2l1::epoc {
         BRIDGE_REGISTER(0xBA, message_queue_notify_data_available),
         BRIDGE_REGISTER(0xBB, message_queue_cancel_notify_available),
         BRIDGE_REGISTER(0xBD, property_define),
+        BRIDGE_REGISTER(0xBE, property_delete),
         BRIDGE_REGISTER(0xBF, property_attach),
         BRIDGE_REGISTER(0xC0, property_subscribe),
         BRIDGE_REGISTER(0xC1, property_cancel),
@@ -5828,7 +5993,7 @@ namespace eka2l1::epoc {
         BRIDGE_REGISTER(0xDF, mutex_is_held),
         BRIDGE_REGISTER(0xE0, leave_start),
         BRIDGE_REGISTER(0xE1, leave_end),
-        BRIDGE_REGISTER(0xE3, get_locale_dll_name),
+        BRIDGE_REGISTER(0xE3, get_module_name_from_address),
         BRIDGE_REGISTER(0xE6, session_security_info),
         BRIDGE_REGISTER(0xE9, btrace_out),
         BRIDGE_REGISTER(0xF6, thread_user_exiting),
@@ -6005,6 +6170,7 @@ namespace eka2l1::epoc {
         BRIDGE_REGISTER(0xDE, mutex_is_held),
         BRIDGE_REGISTER(0xDF, leave_start),
         BRIDGE_REGISTER(0xE0, leave_end),
+        BRIDGE_REGISTER(0xE2, get_module_name_from_address),
         BRIDGE_REGISTER(0xE5, session_security_info),
         BRIDGE_REGISTER(0xE8, btrace_out)
     };
@@ -6110,6 +6276,7 @@ namespace eka2l1::epoc {
         BRIDGE_REGISTER(0x6E, mutex_create),
         BRIDGE_REGISTER(0x6F, semaphore_create),
         BRIDGE_REGISTER(0x70, thread_open_by_id),
+        BRIDGE_REGISTER(0x71, process_open_by_id),
         BRIDGE_REGISTER(0x72, thread_kill),
         BRIDGE_REGISTER(0x73, thread_logon),
         BRIDGE_REGISTER(0x74, thread_logon_cancel),
@@ -6161,6 +6328,7 @@ namespace eka2l1::epoc {
         BRIDGE_REGISTER(0xBF, property_cancel),
         BRIDGE_REGISTER(0xC0, property_get_int),
         BRIDGE_REGISTER(0xC1, property_get_bin),
+        BRIDGE_REGISTER(0xC2, property_set_int),
         BRIDGE_REGISTER(0xC3, property_set_bin),
         BRIDGE_REGISTER(0xC4, property_find_get_int),
         BRIDGE_REGISTER(0xC5, property_find_get_bin),
@@ -6178,6 +6346,7 @@ namespace eka2l1::epoc {
         BRIDGE_REGISTER(0xDD, mutex_is_held),
         BRIDGE_REGISTER(0xDE, leave_start),
         BRIDGE_REGISTER(0xDF, leave_end),
+        BRIDGE_REGISTER(0xE1, get_module_name_from_address),
         BRIDGE_REGISTER(0xE4, session_security_info),
         BRIDGE_REGISTER(0xE7, btrace_out)
     };

--- a/src/emu/kernel/src/thread.cpp
+++ b/src/emu/kernel/src/thread.cpp
@@ -460,14 +460,16 @@ namespace eka2l1 {
                 return false;
             }
 
-            sleep_level = 0;
+            sleep_level = 1;
 
-            while (state == thread_state::run) {
-                wait_for_any_request();
-                sleep_level++;
+            // A host-side frame-pacing sleep. It must not consume or restore guest
+            // request signals: the request semaphore carries the active scheduler's
+            // accounting, and one extra signal there is a stray-signal panic.
+            if (!scheduler->sleep(this, ussecs, true)) {
+                sleep_level = 0;
+                return false;
             }
 
-            scheduler->sleep(this, ussecs, false);
             return true;
         }
 
@@ -482,13 +484,20 @@ namespace eka2l1 {
             kern->lock();
 
             if (sleep_nof_sts) {
-                (sleep_nof_sts.get(owning_process()))->set(errcode, kern->is_eka1());
+                // The wakeup event can already be in flight - popped from the timing
+                // queue and running outside the timing lock - when the sleeping thread
+                // is torn down. The guest request status page may be unmapped by then,
+                // so translation returns null. Guard it like notify_info::complete.
+                epoc::request_status *sts_real = sleep_nof_sts.get(owning_process());
+                if (sts_real) {
+                    sts_real->set(errcode, kern->is_eka1());
+                }
                 sleep_nof_sts = 0;
 
                 signal_request();
             } else {
-                signal_request(sleep_level);
                 sleep_level = 0;
+                scheduler->dewait(this);
             }
 
             sleep_nof_sts = 0;

--- a/src/emu/kernel/src/timer.cpp
+++ b/src/emu/kernel/src/timer.cpp
@@ -26,10 +26,23 @@
 #include <kernel/thread.h>
 #include <kernel/timer.h>
 #include <utils/err.h>
+#include <utils/reqsts.h>
 
 namespace eka2l1 {
     namespace kernel {
-        void timer_callback(uint64_t user, int ns_late);
+        void timer_callback(kernel_system *kern, uint64_t user, int ns_late);
+
+        // A timer event can become due while the guest is mid-way through issuing
+        // the request: it has written the request status (pending) but has not yet
+        // run SetActive() on the owning active object. Completing it then strands
+        // the active scheduler with a request it cannot see as ready, which it
+        // reports as the stray-signal panic E32USER-CBase 46. When that happens we
+        // reschedule the completion a short moment later so the still-running guest
+        // can finish issuing; the count is bounded so a bare TRequestStatus (waited
+        // on with User::WaitForRequest, which never sets the active flag) still
+        // completes after a negligible delay.
+        static constexpr std::int64_t TIMER_ACTIVATE_DEFER_US = 100;
+        static constexpr int TIMER_ACTIVATE_DEFER_LIMIT = 8;
 
         timer::timer(kernel_system *kern, ntimer *timing, std::string name,
             kernel::access_type access)
@@ -41,12 +54,22 @@ namespace eka2l1 {
             callback_type = timing->get_register_event("TimerCallback");
 
             if (callback_type == -1) {
-                callback_type = timing->register_event("TimerCallback", timer_callback);
+                // The event's userdata is the timer's kernel object id, not a
+                // pointer: a timer can be destroyed while its callback is already
+                // in flight on the timing thread (unschedule_event cannot recall
+                // it), so the callback re-resolves the id under the kernel lock
+                // and a dead timer becomes a safe no-op. The captured kernel
+                // shares the ntimer's lifetime (both torn down with the system).
+                kernel_system *kern_of_event = kern;
+                callback_type = timing->register_event("TimerCallback",
+                    [kern_of_event](std::uint64_t user, int ns_late) {
+                        timer_callback(kern_of_event, user, ns_late);
+                    });
             }
         }
 
         timer::~timer() {
-            timing->unschedule_event(callback_type, reinterpret_cast<std::uint64_t>(&info));
+            timing->unschedule_event(callback_type, static_cast<std::uint64_t>(unique_id()));
         }
 
         bool timer::after(kernel::thread *requester, eka2l1::ptr<epoc::request_status> sts, std::uint64_t us_signal) {
@@ -55,6 +78,7 @@ namespace eka2l1 {
             }
 
             outstanding = true;
+            activate_defer_count_ = 0;
 
             info.done_nof = epoc::notify_info(sts, requester);
             info.own_timer = this;
@@ -64,8 +88,8 @@ namespace eka2l1 {
             // Simulate some timeslice delay, and not finish immediately
             // Some games just set the microseconds to signal to 1, and then when it's report superfast, it acts weird!
             // For example: DDragon, which signals an object that has not yet been set to active in time! (cancel was called but ineffective cause finish got to it first)
-            timing->schedule_event(common::max<std::uint64_t>(MINIMUM_US_AFTER, us_signal), 
-                callback_type, reinterpret_cast<std::uint64_t>(&info));
+            timing->schedule_event(common::max<std::uint64_t>(MINIMUM_US_AFTER, us_signal),
+                callback_type, static_cast<std::uint64_t>(unique_id()));
             return true;
         }
         
@@ -96,28 +120,64 @@ namespace eka2l1 {
             // If the timer hasn't finished yet, please unschedule it.
             if (outstanding) {
                 // Cancel
-                timing->unschedule_event(callback_type, reinterpret_cast<std::uint64_t>(&info));
+                timing->unschedule_event(callback_type, static_cast<std::uint64_t>(unique_id()));
             }
 
             return request_finish();
         }
 
-        void timer_callback(uint64_t user, int ns_late) {
-            signal_info *info = reinterpret_cast<signal_info *>(user);
+        bool timer::fire_or_defer() {
+            if (!outstanding) {
+                return false;
+            }
 
-            if (!info) {
+            // EKA1 does not carry the active/pending request-status flags, so the
+            // race below cannot be detected there and the request completes at once.
+            kernel::thread *requester = info.done_nof.requester;
+            if (requester && !kern->is_eka1() && (activate_defer_count_ < TIMER_ACTIVATE_DEFER_LIMIT)) {
+                epoc::request_status *sts = info.done_nof.sts.get(requester->owning_process());
+
+                // Only defer while the requester is still running (not parked on
+                // its request semaphore): the race is the guest issuing the request
+                // and about to call SetActive. A thread blocked in WaitForRequest on
+                // a bare TRequestStatus (which never goes active) has a negative
+                // count, so it completes immediately with no added latency.
+                if (sts && (sts->flags & epoc::request_status::pending)
+                    && !(sts->flags & epoc::request_status::active)
+                    && (requester->request_count() >= 0)) {
+                    // Request issued but not yet made active: let the guest run on
+                    // and reschedule this completion a touch later.
+                    activate_defer_count_++;
+                    timing->schedule_event(TIMER_ACTIVATE_DEFER_US, callback_type,
+                        static_cast<std::uint64_t>(unique_id()));
+                    return false;
+                }
+            }
+
+            activate_defer_count_ = 0;
+            outstanding = false;
+            return true;
+        }
+
+        void timer::fire() {
+            if (!fire_or_defer()) {
                 return;
             }
 
-            kernel_system *kern = info->own_timer->get_kernel_object_owner();
+            info.done_nof.complete(epoc::error_none);
+        }
+
+        void timer_callback(kernel_system *kern, uint64_t user, int ns_late) {
+            // Resolve the timer from its object id under the kernel lock: the
+            // timer may have been destroyed (under that same lock) after this
+            // event was popped from the queue but before we got here.
             kern->lock();
 
-            if (!info->own_timer->request_finish()) {
-                kern->unlock();
-                return;
+            kernel::timer *tim = kern->get_by_id<kernel::timer>(static_cast<kernel::uid>(user));
+            if (tim) {
+                tim->fire();
             }
 
-            info->done_nof.complete(epoc::error_none);
             kern->unlock();
         }
     }

--- a/src/emu/kernel/src/timing.cpp
+++ b/src/emu/kernel/src/timing.cpp
@@ -54,11 +54,19 @@ namespace eka2l1 {
         pause_evt_.set();
 
         if (timer_thread_) {
-            timer_thread_->join();
+            if (timer_thread_->joinable()) {
+                timer_thread_->join();
+            }
+
+            timer_thread_.reset();
         }
 
         events_.clear();
         teletimer_->stop();
+    }
+
+    void ntimer::stop() {
+        wipeout();
     }
 
     void ntimer::reset() {
@@ -69,11 +77,15 @@ namespace eka2l1 {
         new_event_evt_.reset();
         pause_evt_.reset();
 
+        // Start the teletimer before the thread that reads it. The loop calls
+        // advance() -> microseconds() straight away, so starting it afterwards
+        // races the timestamp initialisation and can hand the loop a stale
+        // start_ from the previous run.
+        teletimer_->start();
+
         timer_thread_ = std::make_unique<std::thread>([this]() {
             loop();
         });
-
-        teletimer_->start();
     }
 
     void ntimer::set_realtime_level(const realtime_level lvl) {

--- a/src/emu/system/src/epoc.cpp
+++ b/src/emu/system/src/epoc.cpp
@@ -160,6 +160,14 @@ namespace eka2l1 {
         explicit system_impl(system *parent, system_create_components &param);
 
         ~system_impl() {
+            // Join the timer thread before anything else goes away: its event
+            // callbacks (kernel timers, animation scheduler redraws) run
+            // concurrently and reach into the kernel, window server and font state
+            // that the teardown below frees.
+            if (timing_) {
+                timing_->stop();
+            }
+
 #if ENABLE_SCRIPTING
             scripting_.reset();
 #endif

--- a/src/tests/common/linked.cpp
+++ b/src/tests/common/linked.cpp
@@ -31,3 +31,16 @@ TEST_CASE("single roundabout member is linked", "linked") {
     REQUIRE(member.alone());
     REQUIRE(queue.empty());
 }
+
+TEST_CASE("roundabout_reset_leaves_the_members_untouched", "linked") {
+    common::roundabout queue;
+    common::double_linked_queue_element member;
+
+    queue.push(&member);
+    queue.reset();
+
+    // The ring is empty, and the member still believes it is enqueued: reset()
+    // exists for the case where the members are already dead memory.
+    REQUIRE(queue.empty());
+    REQUIRE_FALSE(member.alone());
+}


### PR DESCRIPTION
One batch covering the kernel work this fork carries, organised by subject. The
four groups are independent; they are sent together because they were verified
together and splitting them further would mean four PRs waiting on each other.

## Object and IPC message lifetimes, and the order teardown runs in

Gathered from a series of crash reports whose stacks all land in a teardown or a
completion against something already freed.

**Looking an object up by where lower_bound lands.** `destroy()` located the object
with `lower_bound` and never checked that the iterator actually points at it. An
object not in that container resolves to the next live one, which is then destroyed
and erased in its place; everybody still holding it is left with a dangling pointer.
The same defect in the service framework's container went out as #625. `destroy()`
can also destroy further objects of the same type as a side effect -- a codeseg
drops its dependencies, a thread releases its owner -- each of which erases an
element of the vector being iterated, so the slot is located again before the erase.

**IPC messages.** `unref()` wrapped an unsigned count to `0xFFFFFFFF` on a double
release, poisoning the slot forever. A message released while still queued in a
server's delivered list stayed in that list, so the server later popped a freed --
by then possibly recycled -- slot and completed it against the wrong owner. A sync
message whose owner died in flight never had its slot reclaimed. And `free_msg`
forced the slot free even for a message another party still referenced, letting
`create_msg` recycle it under the in-flight exchange.

`message_ipc_copy` and its EKA1 twin take a reference on entry and released it only
on the success path; every error return leaked one, which is what left `free_msg`
looking at referenced messages in the first place.

**Handles.** `object_ix` ignored the instance bits that exist to reject a stale
handle, so a handle whose slot had been reopened for a different object resolved to
the new one. EKA1 clients legitimately retain handles across such a reopen, so the
stricter check is EKA2-only. `reset()` also left the object pointers and the
unclosed-handle list behind.

**Completions to a thread that has exited.** `notify_info::complete()` dereferences
the requester to translate the request status. Process logons and rendezvous, and
property subscriptions, are armed by threads in other processes that may be gone by
the time they fire; they are checked against the kernel's live thread list now, the
way the dispatcher's audio completions already are.

**Teardown order.** Chunks were destroyed before processes, but a process's memory
model walks its still-attached chunks when it goes. The message array ran its unref
side effects against sessions and servers already freed. The codedump collector
outlives a reboot while its intrusive lists point into the codesegs destroyed during
one, so it is emptied there -- without dequeuing members that are themselves dead
memory, hence `roundabout::reset()`. A session closing during wipeout signalled owner
threads whose scheduler state was already gone. A process left itself in its parent's
child list and its children pointing back at it. The scheduler could hand
`switch_context` a ready thread whose process had already lost its memory model. And
the timer thread was still running through all of it: it is joined first now, which
is what `ntimer::stop()` is for.

Two smaller things found on the way: `ntimer::reset()` started the teletimer after
the thread that reads it, and a `wait_for_request` that dequeues a thread did not ask
for a reschedule.

## Timer completions and the HLE sleep

**A timer callback could outlive its timer.** The scheduled event carried
`&timer::info` as its userdata. `unschedule_event` cannot recall an event that the
timing thread has already popped, so destroying a timer at that moment left the
callback about to dereference freed memory. The userdata is the timer's kernel object
id now, and the callback re-resolves it under the kernel lock, where a destroyed
timer is a safe no-op.

**A timer could complete a request the guest had not finished issuing.** The guest
writes the request status and then calls `SetActive` on the owning active object; a
timer firing between the two leaves the active scheduler woken with nothing it can
see as ready, which is `E32USER-CBase 46`. When the status is pending but not yet
active and the requester is still running, the completion is rescheduled a tenth of a
millisecond later, up to a bounded number of times -- so a bare `TRequestStatus`
waited on with `User::WaitForRequest`, which never goes active, still completes with
negligible delay. EKA1 has no such flags and is unaffected.

**The HLE sleep spent guest request signals.** `thread::sleep()` is host-side frame
pacing, but it drained the request semaphore with `wait_for_any_request()` in a loop
and `notify_sleep` signalled the same count back. The request semaphore carries the
active scheduler's accounting, where one signal too many or too few is that same
panic; the sleep now suspends the thread and wakes it without touching it.
`notify_sleep` also wrote through the guest request status without translating it
first, which is null once the sleeping thread's pages are gone.

## Resolving, loading and relocating an image

**A drive-less absolute path never resolved.** Symbian writes an image's path without
a drive letter (`\sys\bin\foo.dll`) and its loader searches the drive list for it.
Both of the library manager's entry points opened such a path verbatim instead, so
the image was simply not found.

**A ROM file that is really an E32 image was parsed as a ROM image.** `is_in_rom()`
says where the file lives, not what format it is: a file staged onto the ROM drive
from an RPKG is an ordinary E32 image and has to be parsed as one.

**An existence check tested the wrong variable**, so `open_and_get` probed the
caller's original path while opening the resolved one.

**The SVC trampoline read a stale context.** `jump_trampoline_through_svc` took the
PC out of the thread's saved context, which is only refreshed when the scheduler
switches the thread out. It reads the live core now, and recovers the address the SVC
was installed at -- the backends have already advanced the PC past it -- so the lookup
hits. The branch also carries the target's Thumb bit into the CPSR rather than leaving
the mode alone.

**Re-attaching a codeseg skipped the data relocations.** The saved copy of `.data`
holds link-time addresses, so restoring it after a detach has to repeat the data
relocations exactly as the first attachment did, while leaving the retained code
untouched. The relocation loop was extracted so both callers run the same code.

**A ROM codeseg hashed the wrong bytes**: it hashed `code_data`, which an XIP segment
does not own, instead of the image mapped in place.

**`Dll::FileName` could not name a statically linked XIP DLL.** Such a DLL only gets a
codeseg once it appears in some image's reference chain, so an address inside it
resolved to nothing. The ROM file tree records each XIP entry's linear address range,
which is enough to name the image containing the address -- which is what the callers
want it for, since they use it to derive their own drive.

An unresolved import is also worth more than the ordinal it failed on: the message now
names the importer and the offset the veneer was patched at, which is what turns the
eventual wild PC back into something traceable.

## Executive calls the tables got wrong or did not have

Checked against the executive numbering in the Symbian Belle SDK's
`epoc32/include/platform/exec_enum.h`, which the Symbian^3 table follows exactly.

**Two Symbian^3 entries were off by one.** `EExecServerCreate` is 0x7E and 0x7F is
`ServerCreateWithOptions`; the table had `ServerCreate` at 0x7F, so a server created
with options was dispatched to the two-argument call and `ServerCreate` itself went
nowhere. `EExecHandleInfo` is 0x3D, but it was registered at 0x3E alongside
`HandleCount` -- the map keeps the first of a duplicate key, so `Exec::HandleCount`
ran `handle_info`.

**`Exec::GetModuleNameFromAddress` (0xE3, 0xE2 and 0xE1 in the three tables) was a
stub named after one of its callers**, returning `KErrNone` without writing anything.
It answers with the name of the module containing the address now, and with
`KErrNotFound` when there is none -- which is what `TExtendedLocale::GetLocaleDllName`
and the SQL server's startup branch on.

**Symbian^3 was missing six more entries** the tables above and below it already have
or that nothing implemented: `ThreadProcess`, `SessionCreateFromHandle`,
`PropertyDelete`, and the three logical-device executives. Symbian 9.3 was missing
`ProcessOpenById` -- which the Flash Lite plug-in calls on startup -- and
`PropertySetInt`.

**The logical device executives are new.** `Exec::ChannelCreate` instantiates the
emulated factory on demand and hands back a channel handle, and `Exec::DeviceFree`
releases the factory. `E32Loader::DeviceLoad` has nothing to load, since the emulated
devices are built in rather than images, and says so.

**`Exec::MessageGetDesLength` and `MessageGetDesMaxLength` dereferenced the descriptor
without translating it first.** A slot typed as a descriptor can still carry a null or
unmapped address; Symbian answers `KErrBadDescriptor` there, while the emulator
faulted the server.

**The debug read/write command bounded the transfer by the wrong thing.** The byte
count comes from the command's own length argument, not from the descriptor, so
callers legitimately pass a plain output buffer -- a `TPtr8` built with the
two-argument constructor has length zero and a non-zero maximum. Checking against the
current length rejected every one of them, including the four-byte self-patching write
that a cracked S60v2 title does at startup and quits over. Both directions are bounded
by the descriptor's capacity now, and the four-byte write falls through to the
instruction cache flush it was skipping -- four bytes being exactly the ARM instruction
this command exists to patch.

## Two assumptions that do not hold

**A mutex holder may be waiting on something else.** `mutex::wait` asserted that the
current holder had no wait object. Owning a mutex while blocked on a request semaphore
is ordinary -- the holder releases the mutex when it resumes, so queueing behind it is
right.

**EKA1's system clock is not fine grained.** Its kernel refreshes the clock from the
64Hz tick interrupt, so `User::UTCTime()` and `TTime::HomeTime()` move in whole tick
periods and code of that era assumes two reads within one tick return the same value.
EKA2L1 sources a continuous microsecond clock instead: N-Gage Call of Duty computes
`frames * 100000 / (elapsed_us / 1000)` while its view starts up, guards only against
`elapsed_us` being zero, and takes an unhandled divide-by-zero for anything under a
millisecond. EKA2 backs the clock with the fast counter and is genuinely fine grained,
so it keeps the raw value.

The EKA1-affecting parts have no coverage in either test suite, neither of which has
an EKA1 device; they are unchanged from months of use on a 6680 and an N-Gage.
---

**Verification**: `ctest` green on this branch (plain Release, ASan, and ASan+UBSan). Merged with the one other open branch and run through the iOS Release simulator regression suite: 12/12 on the default suite (Final Battle, Calculator, N95 Calculator) plus 5/5 on the touch suite (Angry Birds on a Symbian^3 device), with the emulator log clean of panics, access violations and graphics halts, and every regression screenshot distinct.