### PR TITLE
drivers, qt, android: destroy the camera backend polymorphically, and share the MIF icon decoder

### DIFF
--- a/src/emu/android/app/src/main/cpp/src/launcher.cpp
+++ b/src/emu/android/app/src/main/cpp/src/launcher.cpp
@@ -31,8 +31,6 @@
 #include <common/pystr.h>
 #include <common/fileutils.h>
 #include <loader/mif.h>
-#include <loader/svgb.h>
-#include <loader/nvg.h>
 #include <services/fbs/fbs.h>
 #include <system/installation/firmware.h>
 #include <system/installation/rpkg.h>
@@ -158,38 +156,18 @@ namespace eka2l1::android {
                             data.resize(dest_size);
                             file_mif_parser.read_mif_entry(0, data.data(), dest_size);
 
-                            eka2l1::common::ro_buf_stream inside_stream(data.data(), data.size());
                             std::unique_ptr<eka2l1::common::wo_std_file_stream> outfile_stream =
                                     std::make_unique<eka2l1::common::wo_std_file_stream>(cached_path, true);
 
-                            eka2l1::loader::mif_icon_header header;
-                            inside_stream.read(&header, sizeof(eka2l1::loader::mif_icon_header));
+                            const bool converted = eka2l1::loader::convert_mif_icon_to_svg(data.data(),
+                                    data.size(), *outfile_stream);
+                            outfile_stream.reset();
 
-                            std::vector<eka2l1::loader::svgb_convert_error_description> errors;
-                            std::vector<eka2l1::loader::nvg_convert_error_description> errors_nvg;
-
-                            if (header.type == eka2l1::loader::mif_icon_type_svg) {
-                                if (!eka2l1::loader::convert_svgb_to_svg(inside_stream, *outfile_stream, errors)) {
-                                    if (errors[0].reason_ == eka2l1::loader::svgb_convert_error_invalid_file) {
-                                        outfile_stream->write(reinterpret_cast<const char *>(data.data()) + sizeof(eka2l1::loader::mif_icon_header), data.size() - sizeof(eka2l1::loader::mif_icon_header));
-                                    }
-                                }
-
-                                outfile_stream.reset();
+                            if (converted) {
                                 document = lunasvg::Document::loadFromFile(cached_path.c_str());
                             } else {
-                                inside_stream = eka2l1::common::ro_buf_stream(data.data() + sizeof(eka2l1::loader::mif_icon_header),
-                                                                              data.size() - sizeof(eka2l1::loader::mif_icon_header));
-
-                                if (eka2l1::loader::convert_nvg_to_svg(inside_stream, *outfile_stream, errors_nvg)) {
-                                    outfile_stream.reset();
-                                    document = lunasvg::Document::loadFromFile(cached_path.c_str());
-                                } else  {
-                                    LOG_ERROR(eka2l1::FRONTEND_UI, "Icon for app {} can't be decoded!", header.type, app_name);
-                                    outfile_stream.reset();
-
-                                    eka2l1::common::remove(cached_path);
-                                }
+                                LOG_ERROR(eka2l1::FRONTEND_UI, "Icon for app {} can't be decoded!", app_name);
+                                eka2l1::common::remove(cached_path);
                             }
                         }
                     }

--- a/src/emu/drivers/include/drivers/camera/backend/null/camera_collection_null.h
+++ b/src/emu/drivers/include/drivers/camera/backend/null/camera_collection_null.h
@@ -28,7 +28,7 @@ namespace eka2l1::drivers::camera {
             return 0;
         }
 
-        std::unique_ptr<instance> make_camera(const std::uint32_t camera_index) {
+        std::unique_ptr<instance> make_camera(const std::uint32_t camera_index) override {
             return nullptr;
         }
     };

--- a/src/emu/drivers/include/drivers/camera/camera_collection.h
+++ b/src/emu/drivers/include/drivers/camera/camera_collection.h
@@ -26,6 +26,11 @@
 namespace eka2l1::drivers::camera {
     class collection {
     public:
+        // get_collection() keeps the backend in a unique_ptr<collection> and, on
+        // the iOS simulator, reassigns it -- both destroy a derived object
+        // through this base pointer.
+        virtual ~collection() = default;
+
         virtual std::uint32_t count() const = 0;
         virtual std::unique_ptr<instance> make_camera(const std::uint32_t camera_index) = 0;
     };

--- a/src/emu/drivers/src/camera/camera_collection.cpp
+++ b/src/emu/drivers/src/camera/camera_collection.cpp
@@ -3,6 +3,8 @@
 
 #include <common/platform.h>
 
+#include <type_traits>
+
 #if EKA2L1_PLATFORM(ANDROID)
 #include <drivers/camera/backend/android/camera_collection_android.h>
 #elif EKA2L1_PLATFORM(IOS)
@@ -16,6 +18,11 @@
 #endif
 
 namespace eka2l1::drivers::camera {
+    // [expr.delete]/3: deleting a derived object through a base pointer without
+    // a virtual destructor is undefined.
+    static_assert(std::has_virtual_destructor_v<collection>,
+        "camera::collection is owned polymorphically and must be destroyed polymorphically");
+
     std::unique_ptr<collection> collection_detail = nullptr;
 
     collection *get_collection() {

--- a/src/emu/qt/src/applistwidget.cpp
+++ b/src/emu/qt/src/applistwidget.cpp
@@ -44,8 +44,6 @@
 #include <vector>
 
 #include <loader/mif.h>
-#include <loader/svgb.h>
-#include <loader/nvg.h>
 
 static QSize ICON_GRID_SIZE = QSize(64, 64);
 static QSize ICON_GRID_SPACING_SIZE = QSize(20, 20);
@@ -602,37 +600,15 @@ void applist_widget::add_registeration_item_native(eka2l1::apa_app_registry &reg
                     data.resize(dest_size);
                     file_mif_parser.read_mif_entry(0, data.data(), dest_size);
 
-                    eka2l1::common::ro_buf_stream inside_stream(data.data(), data.size());
                     std::unique_ptr<eka2l1::common::wo_std_file_stream> outfile_stream = std::make_unique<eka2l1::common::wo_std_file_stream>(cached_path, true);
+                    const bool converted = eka2l1::loader::convert_mif_icon_to_svg(data.data(), data.size(), *outfile_stream);
+                    outfile_stream.reset();
 
-                    eka2l1::loader::mif_icon_header header;
-                    inside_stream.read(&header, sizeof(eka2l1::loader::mif_icon_header));
-
-                    std::vector<eka2l1::loader::svgb_convert_error_description> errors;
-                    std::vector<eka2l1::loader::nvg_convert_error_description> errors_nvg;
-
-                    if (header.type == eka2l1::loader::mif_icon_type_svg) {
-                        if (!eka2l1::loader::convert_svgb_to_svg(inside_stream, *outfile_stream, errors)) {
-                            if (errors[0].reason_ == eka2l1::loader::svgb_convert_error_invalid_file) {
-                                outfile_stream->write(reinterpret_cast<const char *>(data.data()) + sizeof(eka2l1::loader::mif_icon_header), data.size() - sizeof(eka2l1::loader::mif_icon_header));
-                            }
-                        }
-
-                        outfile_stream.reset();
+                    if (converted) {
                         renderer = std::make_unique<QSvgRenderer>(QString::fromUtf8(cached_path.c_str()));
                     } else {
-                        inside_stream = eka2l1::common::ro_buf_stream(data.data() + sizeof(eka2l1::loader::mif_icon_header),
-                            data.size() - sizeof(eka2l1::loader::mif_icon_header));
-
-                        if (eka2l1::loader::convert_nvg_to_svg(inside_stream, *outfile_stream, errors_nvg)) {
-                            outfile_stream.reset();
-                            renderer = std::make_unique<QSvgRenderer>(QString::fromUtf8(cached_path.c_str()));
-                        } else  {
-                            LOG_ERROR(eka2l1::FRONTEND_UI, "Icon for app {} can't be decoded!", header.type, app_name.toStdString());
-                            outfile_stream.reset();
-
-                            eka2l1::common::remove(cached_path);
-                        }  
+                        LOG_ERROR(eka2l1::FRONTEND_UI, "Icon for app {} can't be decoded!", app_name.toStdString());
+                        eka2l1::common::remove(cached_path);
                     }
                 }
             }


### PR DESCRIPTION
Two small cleanups.

**camera::collection has no virtual destructor.** `get_collection()` owns the backend in a `unique_ptr<collection>`, and on the iOS simulator it *reassigns* that pointer over a live `collection_ios` — so a derived object is destroyed through the base pointer at runtime, not only at exit. UB either way ([expr.delete]/3). `collection_null::make_camera` also gains the `override` it was missing.

`ekatests` does not link `drivers`, so the invariant is a `static_assert` next to the pointer that owns it rather than a test case.

**The Qt and Android frontends still open-code MIF icon decoding.** `loader::convert_mif_icon_to_svg` already does this for every other caller (`services/ui/icon`, the iOS bridge). Routing them through it picks up two things the copies lacked:

- gzip-wrapped plain SVG payloads are inflated instead of being fed to the SVGB decoder;
- raster (`mif_icon_type_bmp`) entries are rejected instead of being handed to the NVG decoder just because they failed the "is it SVG" test.

The SVGB path is otherwise unchanged, fallback included. The copies also passed two arguments to a one-placeholder `LOG_ERROR`.