### PR TITLE
applist, sensor: answer AppLanguage from the phone language, and stay off a wiped kernel

### DIFF
--- a/src/emu/services/src/applist/applist.cpp
+++ b/src/emu/services/src/applist/applist.cpp
@@ -674,11 +674,19 @@ namespace eka2l1 {
     }
 
     void applist_server::app_language(service::ipc_context &ctx) {
-        LOG_TRACE(SERVICE_APPLIST, "AppList::AppLanguage stubbed to returns ELangEnglish");
+        // Apparc derives this from the phone language -- "Get application language
+        // for current phone language" in aplappinforeader.cpp, which then narrows it
+        // to the nearest localised resource file the app actually ships. Answering a
+        // constant here pins every app's UI to English whatever the locale says.
+        // EKA2L1 has no per-app resource set to narrow against, so the phone language
+        // is the whole answer; keep the old reply for the values that are not one
+        // (ELangTest and the internal "any").
+        language app_lang = kern->get_current_language();
+        if ((app_lang < language::en) || (app_lang == language::any)) {
+            app_lang = language::en;
+        }
 
-        language default_lang = language::en;
-
-        ctx.write_data_to_descriptor_argument<language>(1, default_lang);
+        ctx.write_data_to_descriptor_argument<language>(1, app_lang);
         ctx.complete(0);
     }
 

--- a/src/emu/services/src/sensor/sensor.cpp
+++ b/src/emu/services/src/sensor/sensor.cpp
@@ -310,8 +310,12 @@ namespace eka2l1 {
 
             // Taking the kernel lock before touching the session or the IPC message
             // serialises this completion against StopListening, CloseChannel and
-            // session teardown, all of which run on the emulated thread.
-            if (callback_state->session_) {
+            // session teardown, all of which run on the emulated thread. The lock
+            // does not help during wipeout, though: the session is still reachable
+            // while the threads and the scheduler behind it are already gone, so
+            // completing would dewait a thread that no longer has scheduler state.
+            // Same reason session::disconnect() checks it before signalling.
+            if (!kern->is_wiping() && callback_state->session_) {
                 callback_state->session_->complete_channel_data_request_locked(kern, channel_id, data, packet_sent);
             }
 

--- a/src/tests/epoc/CMakeLists.txt
+++ b/src/tests/epoc/CMakeLists.txt
@@ -11,6 +11,7 @@ set(CORE_TEST_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/spi.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/svgb.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/package/manager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/services/applist/language.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/applist/registeration.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/applist/recognize.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/fbs/bitmap.cpp

--- a/src/tests/epoc/services/applist/language.cpp
+++ b/src/tests/epoc/services/applist/language.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch.hpp>
+
+#include <common/types.h>
+
+// AppList::AppLanguage writes this enum straight into the guest's TLanguage, so
+// the two numberings have to agree. Reference values are Symbian's own TLanguage,
+// which carries its indices as comments in epoc32/include/aiftool.rh
+// (ELangTest // 00, ELangEnglish // 01, ...).
+//
+// Numbering only started to matter when the reply stopped being a constant, so
+// these anchors sample the whole run rather than just the low end. Note that
+// index 95 and 99 do not line up with TLanguage (ELangUzbek and ELangOther);
+// that predates this and is left alone here.
+
+namespace {
+    constexpr int lang_index(const language lang) {
+        return static_cast<int>(lang);
+    }
+}
+
+TEST_CASE("language_enum_agrees_with_symbian_tlanguage_numbering", "applist_language") {
+    REQUIRE(lang_index(language::test) == 0);   // ELangTest
+    REQUIRE(lang_index(language::en) == 1);     // ELangEnglish
+    REQUIRE(lang_index(language::fr) == 2);     // ELangFrench
+    REQUIRE(lang_index(language::de) == 3);     // ELangGerman
+    REQUIRE(lang_index(language::fi) == 9);     // ELangFinnish
+
+    // The block Symbian inserts before Portuguese; getting it wrong shifts
+    // everything above it by three.
+    REQUIRE(lang_index(language::am) == 10);    // ELangAmerican
+    REQUIRE(lang_index(language::sf) == 11);    // ELangSwissFrench
+    REQUIRE(lang_index(language::sg) == 12);    // ELangSwissGerman
+    REQUIRE(lang_index(language::po) == 13);    // ELangPortuguese
+
+    REQUIRE(lang_index(language::ru) == 16);    // ELangRussian
+    REQUIRE(lang_index(language::hr) == 45);    // ELangCroatian
+    REQUIRE(lang_index(language::et) == 49);    // ELangEstonian
+    REQUIRE(lang_index(language::uk) == 93);    // ELangUkrainian
+    REQUIRE(lang_index(language::ur) == 94);    // ELangUrdu
+    REQUIRE(lang_index(language::vi) == 96);    // ELangVietnamese
+    REQUIRE(lang_index(language::cy) == 97);    // ELangWelsh
+    REQUIRE(lang_index(language::zu) == 98);    // ELangZulu
+}
+
+TEST_CASE("app_language_fallback_only_catches_the_non_languages", "applist_language") {
+    // The values applist_server::app_language replaces with English. Everything
+    // between them is a real TLanguage and must pass straight through.
+    REQUIRE(language::test < language::en);
+    REQUIRE_FALSE(language::fr < language::en);
+    REQUIRE_FALSE(language::zu < language::en);
+    REQUIRE(lang_index(language::any) > lang_index(language::zu));
+}


### PR DESCRIPTION
### AppList::AppLanguage

It returned `ELangEnglish` unconditionally. Apparc derives this from the phone language — *"Get application language for current phone language"*, `aplappinforeader.cpp` — and then narrows it to the nearest localised resource file the app ships. EKA2L1 has no per-app resource set to narrow against, so the phone language is the whole answer; a constant instead pinned every app's UI to English however the locale was configured. `ELangTest` and the internal `any` keep answering English as before.

That reply goes straight into the guest's `TLanguage`, so the enum's numbering now matters for every value rather than just for English. `src/tests/epoc/services/applist/language.cpp` pins it against Symbian's own indices, which `epoc32/include/aiftool.rh` carries as comments. Verified by mutation: inserting one enumerator fails the test.

Two entries do not line up (index 95 and 99, where Symbian has `ELangUzbek` and `ELangOther`). That predates this and is left alone — flagging it rather than folding an unrelated change in here.

### Sensor backend callback

It checked only that the session was still there. During kernel wipeout it is — the threads and the scheduler behind it are not, so the completion dewaits a thread with no scheduler state left. `session::disconnect()` already guards the same signalling with `is_wiping()` for the same reason.

No test for this one: reaching it needs a live kernel mid-wipeout, which `ekatests` cannot stand up.