### PR TITLE
common: set thread priority through the QoS class on Darwin

### DIFF
--- a/src/emu/common/src/thread.cpp
+++ b/src/emu/common/src/thread.cpp
@@ -25,6 +25,10 @@
 #include <pthread.h>
 #endif
 
+#if EKA2L1_PLATFORM(DARWIN)
+#include <pthread/qos.h>
+#endif
+
 #include <common/cvt.h>
 #include <common/thread.h>
 
@@ -122,6 +126,33 @@ namespace eka2l1::common {
     }
 
     void set_thread_priority(const thread_priority pri) {
+#if EKA2L1_PLATFORM(DARWIN)
+        // Darwin schedules by QoS class, and pthread_setschedparam() is not a
+        // weaker way of saying the same thing: per <pthread/qos.h>, a call to it
+        // "will unset the QOS class" and the thread is then "permanently
+        // opted-out of the QOS class system", with later requests failing
+        // EPERM. So the portable path below does not merely fail to help here,
+        // it disables the mechanism that decides how these threads are run --
+        // including, on Apple silicon, whether they land on a P core.
+        qos_class_t qos = QOS_CLASS_DEFAULT;
+
+        switch (pri) {
+        case thread_priority_low:
+            qos = QOS_CLASS_UTILITY;
+            break;
+        case thread_priority_normal:
+            qos = QOS_CLASS_DEFAULT;
+            break;
+        case thread_priority_high:
+            qos = QOS_CLASS_USER_INITIATED;
+            break;
+        case thread_priority_very_high:
+            qos = QOS_CLASS_USER_INTERACTIVE;
+            break;
+        }
+
+        pthread_set_qos_class_self_np(qos, 0);
+#else
         pthread_t this_thread = pthread_self();
 
         std::int32_t max_prio = sched_get_priority_max(SCHED_OTHER);
@@ -136,6 +167,7 @@ namespace eka2l1::common {
         }
 
         pthread_setschedparam(this_thread, SCHED_OTHER, &params);
+#endif
     }
 #endif
 }

--- a/src/tests/common/CMakeLists.txt
+++ b/src/tests/common/CMakeLists.txt
@@ -14,4 +14,5 @@ set(COMMON_TEST_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/region.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/runlen.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sync.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/thread.cpp
     PARENT_SCOPE)

--- a/src/tests/common/thread.cpp
+++ b/src/tests/common/thread.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch.hpp>
+
+#include <common/platform.h>
+#include <common/thread.h>
+
+#if EKA2L1_PLATFORM(DARWIN)
+#include <pthread.h>
+#include <pthread/qos.h>
+
+#include <thread>
+
+using namespace eka2l1;
+
+namespace {
+    qos_class_t qos_after_setting(const common::thread_priority pri) {
+        qos_class_t observed = QOS_CLASS_UNSPECIFIED;
+
+        // On its own thread: the request is permanent for the calling thread,
+        // and the rest of the suite should not inherit it.
+        std::thread worker([&observed, pri]() {
+            common::set_thread_priority(pri);
+
+            int relative = 0;
+            pthread_get_qos_class_np(pthread_self(), &observed, &relative);
+        });
+
+        worker.join();
+        return observed;
+    }
+}
+
+// <pthread/qos.h>: pthread_setschedparam() "will unset the QOS class ... A thread
+// so modified is permanently opted-out of the QOS class system and calls to this
+// function to request a QOS class for such a thread will fail and return EPERM."
+//
+// So the observable contract is not just "some priority was applied": a thread
+// that went through set_thread_priority must report an actual QoS class rather
+// than QOS_CLASS_UNSPECIFIED, which is what the portable sched_param path leaves
+// behind.
+
+TEST_CASE("darwin_thread_priority_requests_a_qos_class", "common_thread") {
+    REQUIRE(qos_after_setting(common::thread_priority_low) != QOS_CLASS_UNSPECIFIED);
+    REQUIRE(qos_after_setting(common::thread_priority_normal) != QOS_CLASS_UNSPECIFIED);
+    REQUIRE(qos_after_setting(common::thread_priority_high) != QOS_CLASS_UNSPECIFIED);
+    REQUIRE(qos_after_setting(common::thread_priority_very_high) != QOS_CLASS_UNSPECIFIED);
+}
+
+TEST_CASE("darwin_thread_priority_order_survives_the_qos_mapping", "common_thread") {
+    // QoS classes are ordered by their enumerator values (qos.h lists them from
+    // BACKGROUND up to USER_INTERACTIVE), so a higher priority must not map to a
+    // class the scheduler treats as lower.
+    const qos_class_t low = qos_after_setting(common::thread_priority_low);
+    const qos_class_t normal = qos_after_setting(common::thread_priority_normal);
+    const qos_class_t high = qos_after_setting(common::thread_priority_high);
+    const qos_class_t very_high = qos_after_setting(common::thread_priority_very_high);
+
+    REQUIRE(low < normal);
+    REQUIRE(normal < high);
+    REQUIRE(high < very_high);
+
+    // Nothing should be parked on the efficiency-only class.
+    REQUIRE(low > QOS_CLASS_BACKGROUND);
+}
+#endif


### PR DESCRIPTION
`set_thread_priority()` used `pthread_setschedparam(SCHED_OTHER)` on every POSIX platform. On Darwin that is not a weaker way of expressing the same thing — it is actively counterproductive. From `<pthread/qos.h>`:

> Subsequent calls to interfaces such as `pthread_setschedparam()` that are incompatible or in conflict with the QOS class system will unset the QOS class requested with this interface [...] A thread so modified is **permanently opted-out** of the QOS class system and calls to this function to request a QOS class for such a thread will fail and return `EPERM`.

QoS is what Darwin actually schedules by, including — on Apple silicon — whether a thread is eligible for a P core. So the portable path does not merely fail to raise these threads, it opts them out of the mechanism that would.

Map the four priorities onto `UTILITY` / `DEFAULT` / `USER_INITIATED` / `USER_INTERACTIVE`. Every caller is an emulator worker already asking for high or very high: the timing thread, the graphics thread, and the two libuv loopers.

**Scope:** macOS and iOS. Other platforms keep the existing path unchanged.

**Tests** (`src/tests/common/thread.cpp`, Darwin-only) assert the observable half of the contract — a thread that went through `set_thread_priority` reports a real QoS class rather than `QOS_CLASS_UNSPECIFIED`, and the ordering survives the mapping. Both fail against the previous implementation (verified by reverting it).

They do not measure scheduling, and I am not claiming a benchmark here — the argument is the documented mechanism, not a number.