### PR TITLE
kernel: stop EKA1 sends from reading an argument-type header that is not there

### DIFF
--- a/src/emu/kernel/src/svc.cpp
+++ b/src/emu/kernel/src/svc.cpp
@@ -5336,14 +5336,20 @@ namespace eka2l1::epoc {
         return result;
     }
 
+    // Reaching these two means the client used the legacy TAny*[4] send, which
+    // writes four words and no argument-type header. Whether the kernel is old
+    // enough for is_ipc_old() does not come into it: EKA1 runs up to and
+    // including Symbian OS 8.1a, and is_ipc_old() stops at epoc7, so on 7.0,
+    // 8.0 and 8.1a it would have session_send_general read a fifth word the
+    // client never wrote.
     BRIDGE_FUNC(std::int32_t, session_send_sync_eka1, kernel::handle session_handle, const std::int32_t ord,
         std::uint32_t *args, eka2l1::ptr<epoc::request_status> status) {
-        return session_send_general(kern, session_handle, ord, args, status, kern->is_ipc_old(), true);
+        return session_send_general(kern, session_handle, ord, args, status, true, true);
     }
 
     BRIDGE_FUNC(std::int32_t, session_send_eka1, kernel::handle session_handle, const std::int32_t ord,
         std::uint32_t *args, eka2l1::ptr<epoc::request_status> status) {
-        return session_send_general(kern, session_handle, ord, args, status, kern->is_ipc_old(), false);
+        return session_send_general(kern, session_handle, ord, args, status, true, false);
     }
 
     std::int32_t thread_ipc_to_des_eka1(kernel_system *kern, address client_ptr_addr, epoc::des8 *des_ptr, std::int32_t offset, kernel::handle client_thread_h,

--- a/src/tests/epoc/CMakeLists.txt
+++ b/src/tests/epoc/CMakeLists.txt
@@ -2,6 +2,7 @@ set(CORE_TEST_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/devices.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mem.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/vfs.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/kernel/ipc_arg.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/e32img.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/gdr.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/mbm.cpp

--- a/src/tests/epoc/kernel/ipc_arg.cpp
+++ b/src/tests/epoc/kernel/ipc_arg.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch.hpp>
+
+#include <common/types.h>
+#include <kernel/ipc.h>
+
+using namespace eka2l1;
+
+// EKA2 shipped in Symbian OS 8.1b. Everything up to and including 8.1a runs
+// EKA1, which is why epocver puts epoc7, epoc80 and epoc81a below the eka2
+// marker. The legacy IPC client ABI is the older boundary: it is what
+// is_ipc_old() answers for, and it stops at epoc7.
+//
+// The gap between the two is the whole reason session_send_eka1 cannot decide
+// on kernel version. An EKA1 client always sends four words and no
+// argument-type header, but for these three releases is_ipc_old() is false, so
+// keying off it makes the kernel read a fifth word the client never wrote.
+
+TEST_CASE("eka1_releases_exist_above_the_legacy_ipc_boundary", "ipc_arg") {
+    // The EKA1 side of the marker, in release order.
+    REQUIRE(epocver::epoc6 < epocver::epoc7);
+    REQUIRE(epocver::epoc7 < epocver::epoc80);
+    REQUIRE(epocver::epoc80 < epocver::epoc81a);
+    REQUIRE(epocver::epoc81a < epocver::eka2);
+
+    // ... and 8.1b, the first EKA2 release, on the other side of it.
+    REQUIRE(epocver::eka2 < epocver::epoc81b);
+
+    // So these three are EKA1 while already being at or past the legacy IPC
+    // boundary: the window session_send_eka1 has to cover on its own.
+    for (const epocver ver : { epocver::epoc7, epocver::epoc80, epocver::epoc81a }) {
+        REQUIRE(ver < epocver::eka2);        // is_eka1()
+        REQUIRE_FALSE(ver < epocver::epoc7); // is_ipc_old()
+    }
+}
+
+TEST_CASE("legacy_ipc_args_carry_no_per_slot_types", "ipc_arg") {
+    // What session_send_general puts in flag when told there is no header.
+    ipc_arg legacy(1, 2, 3, 4, 0xFFFFFFFF);
+
+    const ipc_arg_type first = legacy.get_arg_type(0);
+    for (int slot = 1; slot < 4; slot++) {
+        REQUIRE(legacy.get_arg_type(slot) == first);
+    }
+
+    // A real header does distinguish slots -- three bits each, low slot first.
+    const int header = static_cast<int>(ipc_arg_type::handle)
+        | (static_cast<int>(ipc_arg_type::des8) << 3)
+        | (static_cast<int>(ipc_arg_type::desc16) << 6);
+    ipc_arg typed(1, 2, 3, 4, header);
+
+    REQUIRE(typed.get_arg_type(0) == ipc_arg_type::handle);
+    REQUIRE(typed.get_arg_type(1) == ipc_arg_type::des8);
+    REQUIRE(typed.get_arg_type(2) == ipc_arg_type::desc16);
+    REQUIRE(typed.get_arg_type(3) == ipc_arg_type::unspecified);
+}


### PR DESCRIPTION
`session_send_sync_eka1` and `session_send_eka1` passed `kern->is_ipc_old()` as `session_send_general`'s `no_header_flag`. The two boundaries do not line up:

| | boundary | covers |
|---|---|---|
| `is_eka1()` | `< eka2` | eka1, epocu6, epoc6, **epoc7, epoc80, epoc81a** |
| `is_ipc_old()` | `< epoc7` | eka1, epocu6, epoc6 |

EKA2 shipped in Symbian OS 8.1b, so EKA1 covers everything up to and including 8.1a — `epoc7`, `epoc80`, `epoc81a` in this tree. On those three releases `is_ipc_old()` is false, so `session_send_general` took the `else` branch and read a **fifth word past the client's four**, using whatever followed the array on the guest stack as the argument-type header — and with it the `pin_mask` bits that get handed to the server side (`svc.cpp` `msg_to_construct->flags`, `server.cpp` `dat_hle->flags`). That is the whole S60v2 generation: 6600, 6680, N-Gage.

Reaching either bridge already says the client used the legacy `TAny*[4]` send, which has no header at all. The answer belongs to the entry point, not to the kernel version.

### Tests

- The version window itself: `epoc7`/`epoc80`/`epoc81a` are below the `eka2` marker while already at or past the legacy IPC boundary. Reordering the enum fails it (verified).
- What the no-header sentinel means once `get_arg_type()` decodes it per slot, against a real header that does distinguish slots.

The dispatch itself has no unit seam — nothing in `ekatests` stands up a `kernel_system` — so that half is covered only by running S60v2 guests.