### PR TITLE
common, vfs: answer case sensitivity per volume, and recover names the mount fold missed

### DIFF
--- a/src/emu/common/include/common/fileutils.h
+++ b/src/emu/common/include/common/fileutils.h
@@ -98,7 +98,30 @@ namespace eka2l1::common {
 
     bool delete_folder(const std::string &target_folder);
 
-    bool is_system_case_insensitive();
+    /**
+     * @brief Whether the filesystem holding @p path matches names without regard to case.
+     *
+     * This is a property of the volume, not of the build: the same Apple platform
+     * gives a case-insensitive volume on macOS and a case-sensitive one on iOS, and a
+     * Linux user can mount either. @p path need not exist -- its nearest existing
+     * ancestor is what gets probed. Answers are cached per probed directory.
+     */
+    bool is_path_case_insensitive(const std::string &path);
+
+    /**
+     * @brief Resolve @p relative against @p base, matching each component without regard
+     *        to case.
+     *
+     * For use on case-sensitive volumes, where files placed there by hand keep the
+     * spelling they arrived with while EKA2L1 looks them up folded to lower case.
+     *
+     * A component that matches nothing is appended as it was given, so a path being
+     * created inside an existing mixed-case directory still resolves its parents.
+     *
+     * @param base      Host directory to resolve from. Returned unchanged if missing.
+     * @param relative  Path relative to @p base, separated by either separator.
+     */
+    std::string resolve_case_insensitive_path(const std::string &base, const std::string &relative);
 
     /*! \brief Create a directory. */
     void create_directory(std::string path);
@@ -176,7 +199,7 @@ namespace eka2l1::common {
      * 
      * @param folder_path       The path of the folder to search for the insensitive filename/folder name.
      * @param insensitive_name  The insensitve file name to search
-     * @param type              The type of entry to match (file or folder?)
+     * @param type              The type of entry to match, or FILE_INVALID for any.
      * 
      * @return std::string      Sensitive filename/folder name. Empty on not found.
      */

--- a/src/emu/common/src/fileutils.cpp
+++ b/src/emu/common/src/fileutils.cpp
@@ -28,6 +28,8 @@
 #include <re2/re2.h>
 
 #include <fstream>
+#include <map>
+#include <mutex>
 #include <stack>
 #include <utility>
 
@@ -435,7 +437,7 @@ namespace eka2l1::common {
         common::dir_entry entry;
 
         while (ite->next_entry(entry) == 0) {
-            if (type == entry.type) {
+            if ((type == FILE_INVALID) || (type == entry.type)) {
                 if (common::compare_ignore_case(common::utf8_to_ucs2(entry.name), insensitive_name_u16) == 0) {
                     return entry.name;
                 }
@@ -788,12 +790,113 @@ namespace eka2l1::common {
         return true;
     }
 
-    bool is_system_case_insensitive() {
+    bool is_path_case_insensitive(const std::string &path) {
 #if EKA2L1_PLATFORM(WIN32)
+        (void)path;
         return true;
+#elif defined(_PC_CASE_SENSITIVE)
+        // Walk up to something that exists: the caller may be asking about a file it is
+        // about to create, and pathconf() needs a real path.
+        std::string probe = path;
+
+        while (!probe.empty() && !exists(probe)) {
+            // file_directory() keeps the trailing separator, so drop it before asking
+            // again or the walk stops on the first parent instead of climbing.
+            while (!probe.empty() && eka2l1::is_separator(probe.back())) {
+                probe.pop_back();
+            }
+
+            const std::string parent = eka2l1::file_directory(probe);
+
+            if (parent == probe) {
+                break;
+            }
+
+            probe = parent;
+        }
+
+        while (!probe.empty() && (probe.size() > 1) && eka2l1::is_separator(probe.back())) {
+            probe.pop_back();
+        }
+
+        if (probe.empty() || !exists(probe)) {
+            return false;
+        }
+
+        static std::mutex probe_lock;
+        static std::map<std::string, bool> probed;
+
+        const std::lock_guard<std::mutex> guard(probe_lock);
+        auto cached = probed.find(probe);
+
+        if (cached != probed.end()) {
+            return cached->second;
+        }
+
+        // 1 = case-sensitive, 0 = not. A negative return means the volume does not answer,
+        // in which case assume the stricter of the two and let the caller fold names.
+        const long sensitive = ::pathconf(probe.c_str(), _PC_CASE_SENSITIVE);
+        const bool insensitive = (sensitive == 0);
+
+        probed.emplace(probe, insensitive);
+        return insensitive;
 #else
+        (void)path;
         return false;
 #endif
+    }
+
+    std::string resolve_case_insensitive_path(const std::string &base, const std::string &relative) {
+        if (!exists(base)) {
+            return add_path(base, relative);
+        }
+
+        const char separator = static_cast<char>(eka2l1::get_separator());
+        std::string resolved = base;
+
+        if (!resolved.empty() && !eka2l1::is_separator(resolved.back())) {
+            resolved += separator;
+        }
+
+        std::size_t pos = 0;
+
+        while (pos < relative.size()) {
+            while ((pos < relative.size()) && eka2l1::is_separator(relative[pos])) {
+                pos++;
+            }
+
+            std::size_t end = pos;
+
+            while ((end < relative.size()) && !eka2l1::is_separator(relative[end])) {
+                end++;
+            }
+
+            if (end == pos) {
+                break;
+            }
+
+            const std::string component = relative.substr(pos, end - pos);
+            const bool is_last = (end >= relative.size());
+
+            if (exists(resolved + component)) {
+                resolved += component;
+            } else {
+                // Intermediate components have to be directories; the last one can be either,
+                // and may legitimately not be there yet if the caller is creating it.
+                const std::string real = find_case_sensitive_file_name(resolved, component,
+                    is_last ? FILE_INVALID : FILE_DIRECTORY);
+
+                resolved += real.empty() ? component : real;
+            }
+
+            if (!is_last) {
+                resolved += separator;
+            }
+
+            pos = end;
+        }
+
+        return resolved;
     }
 
     bool copy_folder(const std::string &target_folder, const std::string &dest_folder_to_reside, const std::uint32_t flags, progress_changed_callback progress_cb,

--- a/src/emu/package/src/sis_script_interpreter.cpp
+++ b/src/emu/package/src/sis_script_interpreter.cpp
@@ -135,7 +135,7 @@ namespace eka2l1 {
             common::create_directories(rp);
 
             // Delete the file, starts over
-            if (common::is_system_case_insensitive() && common::exists(path)) {
+            if (common::is_path_case_insensitive(path) && common::exists(path)) {
                 if (!common::remove(path)) {
                     LOG_WARN(PACKAGE, "Unable to remove {} to extract new file", path);
                 }

--- a/src/emu/vfs/src/vfs.cpp
+++ b/src/emu/vfs/src/vfs.cpp
@@ -751,11 +751,27 @@ namespace eka2l1 {
 
             std::u16string vert_path_no_root = vert_path_copy.substr(root.size());
 
-            if (!common::is_system_case_insensitive()) {
+            // Fold to match what validate_for_host() did to the tree when it mounted the
+            // drive -- same predicate, so the two cannot drift apart.
+            if (common::is_platform_case_sensitive()) {
                 vert_path_no_root = common::lowercase_ucs2_string(vert_path_no_root);
             }
 
-            return eka2l1::add_path(map_path, vert_path_no_root);
+            const std::u16string folded_path = eka2l1::add_path(map_path, vert_path_no_root);
+            const std::string map_path_utf8 = common::ucs2_to_utf8(map_path);
+
+            if (common::is_path_case_insensitive(map_path_utf8)
+                || common::exists(common::ucs2_to_utf8(folded_path))) {
+                return folded_path;
+            }
+
+            // validate_for_host() folds the whole tree to lower case when it mounts a drive,
+            // which is why looking up the folded name works at all. It cannot cover what
+            // arrives afterwards, though: a game data folder copied straight into the drive
+            // through a file manager keeps the spelling it came with, and on a volume that
+            // distinguishes case it is then invisible. Recover it from the real entries.
+            return common::utf8_to_ucs2(common::resolve_case_insensitive_path(map_path_utf8,
+                common::ucs2_to_utf8(vert_path_no_root)));
         }
 
     public:
@@ -906,9 +922,10 @@ namespace eka2l1 {
                 return std::unique_ptr<directory>(nullptr);
             }
 
-            if (!common::is_system_case_insensitive()) {
+            if (common::is_platform_case_sensitive()) {
                 filter = common::lowercase_string(filter);
             }
+
 
             return std::make_unique<physical_directory>(this, new_path_utf8,
                 common::ucs2_to_utf8(vir_path), filter, type, attrib);

--- a/src/tests/common/CMakeLists.txt
+++ b/src/tests/common/CMakeLists.txt
@@ -2,6 +2,7 @@ set(COMMON_TEST_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/algorithm.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/allocator.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/casepath.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bytes.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/chunkyseri.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/crypt.cpp

--- a/src/tests/common/casepath.cpp
+++ b/src/tests/common/casepath.cpp
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch.hpp>
+
+#include <common/fileutils.h>
+#include <common/path.h>
+
+#include <cstdio>
+#include <fstream>
+#include <string>
+
+using namespace eka2l1;
+
+namespace {
+    // A scratch tree under the working directory. The resolver is about real
+    // directory entries, so there is nothing to fake here.
+    struct scratch_tree {
+        std::string root;
+
+        explicit scratch_tree(const std::string &name)
+            : root(name) {
+            common::delete_folder(root);
+            common::create_directories(root);
+        }
+
+        ~scratch_tree() {
+            common::delete_folder(root);
+        }
+
+        void make_dir(const std::string &relative) {
+            common::create_directories(eka2l1::add_path(root, relative));
+        }
+
+        void make_file(const std::string &relative) {
+            const std::string full = eka2l1::add_path(root, relative);
+            common::create_directories(eka2l1::file_directory(full));
+
+            std::ofstream out(full, std::ios::binary);
+            out.put('x');
+        }
+    };
+
+    // The resolver only has work to do where the volume distinguishes case. On a
+    // volume that does not, the direct lookup already succeeds and every
+    // assertion below would hold trivially.
+    bool volume_distinguishes_case(const std::string &dir) {
+        return !common::is_path_case_insensitive(dir);
+    }
+}
+
+TEST_CASE("case_insensitive_resolve_finds_entries_stored_in_another_case", "casepath") {
+    scratch_tree tree("casepath_resolve");
+
+    if (!volume_distinguishes_case(tree.root)) {
+        SUCCEED("volume matches names without regard to case; nothing to resolve");
+        return;
+    }
+
+    tree.make_file("SIMLIFE/SCRIPT/ISLAND.CFG");
+
+    const std::string resolved = common::resolve_case_insensitive_path(tree.root,
+        "simlife\\script\\island.cfg");
+
+    REQUIRE(common::exists(resolved));
+    REQUIRE(eka2l1::filename(resolved) == "ISLAND.CFG");
+}
+
+TEST_CASE("case_insensitive_resolve_keeps_the_prefix_it_did_resolve", "casepath") {
+    scratch_tree tree("casepath_prefix");
+
+    if (!volume_distinguishes_case(tree.root)) {
+        SUCCEED("volume matches names without regard to case; nothing to resolve");
+        return;
+    }
+
+    // A guest creating a save file inside a directory that arrived in upper case.
+    // The directory has to resolve even though the file itself is not there yet,
+    // otherwise the create lands in a directory that does not exist.
+    tree.make_dir("SIMLIFE");
+
+    const std::string resolved = common::resolve_case_insensitive_path(tree.root,
+        "simlife\\save.dat");
+
+    REQUIRE_FALSE(common::exists(resolved));
+    REQUIRE(common::exists(eka2l1::file_directory(resolved)));
+    REQUIRE(eka2l1::filename(resolved) == "save.dat");
+}
+
+TEST_CASE("case_insensitive_resolve_leaves_unmatched_components_alone", "casepath") {
+    scratch_tree tree("casepath_absent");
+
+    const std::string resolved = common::resolve_case_insensitive_path(tree.root,
+        "nowhere\\at\\all.dat");
+
+    // Nothing matched, so the answer is just the path as asked for -- the caller
+    // gets the same thing it would have built itself.
+    REQUIRE(resolved == common::resolve_case_insensitive_path(tree.root, "nowhere/at/all.dat"));
+    REQUIRE(eka2l1::filename(resolved) == "all.dat");
+    REQUIRE_FALSE(common::exists(resolved));
+}
+
+TEST_CASE("case_insensitive_resolve_passes_through_a_path_already_spelled_right", "casepath") {
+    scratch_tree tree("casepath_exact");
+
+    tree.make_file("data/entry.dat");
+
+    const std::string resolved = common::resolve_case_insensitive_path(tree.root,
+        "data\\entry.dat");
+
+    REQUIRE(common::exists(resolved));
+    REQUIRE(eka2l1::filename(resolved) == "entry.dat");
+}
+
+TEST_CASE("path_case_sensitivity_is_answered_per_path_not_per_build", "casepath") {
+    scratch_tree tree("casepath_probe");
+
+    // Whatever the answer is for this volume, it has to be stable, and it has to
+    // survive being asked about a path that does not exist yet -- callers ask
+    // before creating.
+    const bool insensitive = common::is_path_case_insensitive(tree.root);
+
+    REQUIRE(common::is_path_case_insensitive(tree.root) == insensitive);
+    REQUIRE(common::is_path_case_insensitive(eka2l1::add_path(tree.root, "not/created/yet.dat"))
+        == insensitive);
+
+    // And it has to agree with what the filesystem actually does.
+    tree.make_file("Probe.dat");
+    REQUIRE(common::exists(eka2l1::add_path(tree.root, "probe.dat")) == insensitive);
+}


### PR DESCRIPTION
`is_system_case_insensitive()` was a compile-time constant — true on Windows, false everywhere else. That is wrong on macOS, whose default APFS volume *does* match names without regard to case, and it is not a property of the build in the first place: the same Apple toolchain produces a binary that runs against a case-insensitive volume on macOS and a case-sensitive one on iOS, and a Linux user can mount either.

### `is_path_case_insensitive(path)`

Answered by asking the volume (`pathconf` `_PC_CASE_SENSITIVE`), cached per probed directory. The path need not exist yet — the nearest existing ancestor is probed, since callers ask before creating. Windows still answers true without probing; a volume that will not say keeps today’s answer.

The one existing caller outside the vfs — the SIS interpreter deciding whether to remove a file before extracting over it — was getting the wrong answer on macOS.

### What the vfs does, and deliberately does not do

Lookups keep folding to lower case exactly as before. The predicate is now the same one `validate_for_host()` uses — that is what folds the whole tree at mount time and makes the folded lookup valid in the first place — so the two cannot drift apart.

I tried making the vfs stop folding on volumes that match names for us, since the guest’s own spelling would then be enough. It regresses: 4 of 12 checks in an iOS end-to-end suite fail, apps render but stop responding to input. I did not chase it down, and it is not needed for the problem below, so that half is not here.

### Recovering what the mount fold could not reach

`validate_for_host()` only folds what is present when the drive is mounted. A game data folder copied straight into the drive afterwards through a file manager keeps the spelling it came with, and on a volume that distinguishes case it is then invisible to every lookup.

`resolve_case_insensitive_path()` recovers it by walking the path against real directory entries, and only runs when the folded lookup already missed. A component that matches nothing is appended as given rather than discarding the walk — so a guest creating a save file inside a directory that arrived in upper case still resolves its parents. `find_case_sensitive_file_name()` takes `FILE_INVALID` to mean either kind, which the last component needs.

### Tests

`src/tests/common/casepath.cpp`, run on both kinds of volume (a case-sensitive APFS image via `hdiutil` for the second):

| | case-insensitive volume | case-sensitive volume |
|---|---|---|
| full suite | 3274 assertions, 171 cases | 3277 assertions, 171 cases |

The three extra assertions are the resolve cases actually executing; where the volume matches names for us they have nothing to do and say so. The probe case checks its answer against what the filesystem actually does, either way. Verified by mutation: making the resolver discard partial progress fails the prefix case.