### PR TITLE
ci(ios): ship signed builds in the rolling release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -257,26 +257,18 @@ jobs:
         path: build/eka2l1-qt-x64.AppImage
       if: matrix.label == 'linux'
 
-  # Both slices are built unsigned. Signing a device build on CI mints a
-  # development certificate per run and Apple caps how many an account may hold,
-  # so a signing CI is a CI that eventually stops working; nothing here needs a
-  # signature to prove the code compiles and links.
+  # Pull requests and branch pushes only need an unsigned device build to prove
+  # the code compiles and links. A push to master additionally produces the
+  # App Store-signed IPA used by both TestFlight and the rolling release.
+  # That release path requires APPLE_TEAM_ID, APPSTORE_ISSUER_ID,
+  # APPSTORE_KEY_ID, and APPSTORE_PRIVATE_KEY repository secrets. A persisted
+  # IOS_DEV_SIGNING_KEY (.p12, base64 encoded) and its password are strongly
+  # recommended so automatic signing does not create a certificate on every run.
   build-ios:
-    runs-on: macos-latest
+    runs-on: macos-26
     env:
       EKA2L1_IOS_CONFIGURATION: Release
-
-    # Device only. Both slices are arm64 and compile almost the same translation
-    # units, so the simulator build was mostly a second copy of the device one at
-    # twice the wall clock -- and what actually has to keep working is that the app
-    # builds for a phone. The cost is that code behind TARGET_OS_SIMULATOR (the
-    # synthetic camera backend) is no longer compiled by CI; add the label back if
-    # that grows past a stub.
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - label: device
+      EKA2L1_IOS_ARCHIVE_PATH: build/ios-device/EKA2L1.xcarchive
 
     steps:
     - uses: actions/checkout@v4
@@ -290,20 +282,52 @@ jobs:
       id: cache-ffmpeg
       uses: actions/cache@v4
       with:
-        path: src/external/ffmpeg/ios/${{ matrix.label }}
-        key: ffmpeg-ios-${{ matrix.label }}-${{ hashFiles('.git/modules/src/external/ffmpeg/HEAD') }}
+        path: src/external/ffmpeg/ios/device
+        key: ffmpeg-ios-device-${{ hashFiles('.git/modules/src/external/ffmpeg/HEAD') }}
 
-    - name: Build
-      run: ./scripts/build_ios.sh ${{ matrix.label }}
+    - name: Build unsigned device app
+      if: github.event_name != 'push' || github.ref != 'refs/heads/master'
+      run: ./scripts/build_ios.sh device
+
+    - name: Build, sign, and upload iOS release
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      env:
+        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
+        APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+        APPSTORE_PRIVATE_KEY: ${{ secrets.APPSTORE_PRIVATE_KEY }}
+        IOS_DEV_SIGNING_KEY: ${{ secrets.IOS_DEV_SIGNING_KEY }}
+        IOS_DEV_SIGNING_KEY_PASSWORD: ${{ secrets.IOS_DEV_SIGNING_KEY_PASSWORD }}
+        IOS_DIST_SIGNING_KEY: ${{ secrets.IOS_DIST_SIGNING_KEY }}
+        IOS_DIST_SIGNING_KEY_PASSWORD: ${{ secrets.IOS_DIST_SIGNING_KEY_PASSWORD }}
+      run: ./scripts/ios_release.sh
 
     - name: Compute git short sha
       id: git_short_sha
       run: echo "value=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
-    - uses: actions/upload-artifact@v4
+    - name: Upload unsigned iOS build
+      if: github.event_name != 'push' || github.ref != 'refs/heads/master'
+      uses: actions/upload-artifact@v4
       with:
-        name: eka2l1-${{ steps.git_short_sha.outputs.value }}-ios-${{ matrix.label }}
-        path: build/ios-${{ matrix.label }}/src/emu/ios/Release-iphone*/EKA2L1.app
+        name: eka2l1-${{ steps.git_short_sha.outputs.value }}-ios-device
+        path: build/ios-device/src/emu/ios/Release-iphoneos/EKA2L1.app
+
+    - name: Upload signed IPA
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      uses: actions/upload-artifact@v4
+      with:
+        name: eka2l1-${{ steps.git_short_sha.outputs.value }}-ios-signed
+        path: build/ios-release/EKA2L1-iOS.ipa
+        if-no-files-found: error
+
+    - name: Upload iOS dSYM
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      uses: actions/upload-artifact@v4
+      with:
+        name: eka2l1-${{ steps.git_short_sha.outputs.value }}-ios-dSYM
+        path: ${{ env.EKA2L1_IOS_ARCHIVE_PATH }}/dSYMs
+        if-no-files-found: warn
 
   # One check with a stable name for branch protection to require. The matrix
   # job names carry their runner labels, so they change whenever an image is
@@ -411,7 +435,7 @@ jobs:
         fi
 
   roll-release:
-   needs: [build-android, build-desktop]
+   needs: [build-android, build-desktop, build-ios]
    runs-on: "ubuntu-latest"
    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
    permissions:
@@ -447,6 +471,11 @@ jobs:
       with:
         name: "eka2l1-${{ steps.git_short_sha.outputs.value }}-android"
 
+    - name: Download signed iOS artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: "eka2l1-${{ steps.git_short_sha.outputs.value }}-ios-signed"
+
     - name: Rename artifacts for release
       run: |
         (cd windows-files && zip -r ../EKA2L1-Windows-x86_64.zip .)
@@ -472,3 +501,4 @@ jobs:
           EKA2L1-MacOS-x86_64.zip
           EKA2L1-Linux-x86_64.AppImage
           EKA2L1-Android.apk
+          EKA2L1-iOS.ipa

--- a/scripts/ios_release.sh
+++ b/scripts/ios_release.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Build an App Store-signed archive, upload it to TestFlight, and export the
+# same archive as the IPA attached to the rolling GitHub release.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+required_secrets=(
+    APPLE_TEAM_ID
+    APPSTORE_ISSUER_ID
+    APPSTORE_KEY_ID
+    APPSTORE_PRIVATE_KEY
+)
+for name in "${required_secrets[@]}"; do
+    if [ -z "${!name:-}" ]; then
+        echo "Required environment variable ${name} is not configured" >&2
+        exit 1
+    fi
+done
+
+temp_root="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+release_temp="$(mktemp -d "${temp_root}/eka2l1-ios-release.XXXXXX")"
+keychain_path="${release_temp}/eka2l1-signing.keychain-db"
+key_path="${release_temp}/AuthKey_${APPSTORE_KEY_ID}.p8"
+archive_path="${EKA2L1_IOS_ARCHIVE_PATH:-build/ios-device/EKA2L1.xcarchive}"
+ipa_path="${EKA2L1_IOS_IPA_PATH:-build/ios-release/EKA2L1-iOS.ipa}"
+keychain_created=false
+
+cleanup() {
+    rm -f "${release_temp}/dev_cert.p12" "${release_temp}/dist_cert.p12" "${key_path}"
+    if [ "${keychain_created}" = true ]; then
+        security delete-keychain "${keychain_path}" || true
+        security list-keychains -d user -s login.keychain-db
+    fi
+    rm -rf "${release_temp}"
+}
+trap cleanup EXIT
+
+printf '%s\n' "${APPSTORE_PRIVATE_KEY}" > "${key_path}"
+chmod 600 "${key_path}"
+
+# Persisting the development certificate in repository secrets avoids creating
+# one per ephemeral runner and eventually exhausting Apple's certificate cap.
+if [ -n "${IOS_DEV_SIGNING_KEY:-}" ] || [ -n "${IOS_DIST_SIGNING_KEY:-}" ]; then
+    keychain_password="$(uuidgen)"
+    security create-keychain -p "${keychain_password}" "${keychain_path}"
+    keychain_created=true
+    security set-keychain-settings -lut 21600 "${keychain_path}"
+    security unlock-keychain -p "${keychain_password}" "${keychain_path}"
+
+    if [ -n "${IOS_DEV_SIGNING_KEY:-}" ]; then
+        printf '%s' "${IOS_DEV_SIGNING_KEY}" | base64 --decode > "${release_temp}/dev_cert.p12"
+        security import "${release_temp}/dev_cert.p12" \
+            -P "${IOS_DEV_SIGNING_KEY_PASSWORD:-}" \
+            -A -t cert -f pkcs12 -k "${keychain_path}"
+    fi
+    if [ -n "${IOS_DIST_SIGNING_KEY:-}" ]; then
+        printf '%s' "${IOS_DIST_SIGNING_KEY}" | base64 --decode > "${release_temp}/dist_cert.p12"
+        security import "${release_temp}/dist_cert.p12" \
+            -P "${IOS_DIST_SIGNING_KEY_PASSWORD:-}" \
+            -A -t cert -f pkcs12 -k "${keychain_path}"
+    fi
+
+    security set-key-partition-list -S apple-tool:,apple: \
+        -k "${keychain_password}" "${keychain_path}" > /dev/null
+    security list-keychains -d user -s "${keychain_path}" login.keychain-db
+else
+    echo "Warning: no persisted signing certificate is configured; Xcode may create one automatically." >&2
+fi
+
+export EKA2L1_IOS_CONFIGURATION="${EKA2L1_IOS_CONFIGURATION:-Release}"
+export EKA2L1_IOS_DEVELOPMENT_TEAM="${APPLE_TEAM_ID}"
+export EKA2L1_IOS_ARCHIVE_PATH="${archive_path}"
+export EKA2L1_ASC_KEY_PATH="${key_path}"
+export EKA2L1_ASC_KEY_ID="${APPSTORE_KEY_ID}"
+export EKA2L1_ASC_KEY_ISSUER_ID="${APPSTORE_ISSUER_ID}"
+./scripts/build_ios.sh archive
+
+upload_options="${release_temp}/UploadOptions.plist"
+cat > "${upload_options}" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store-connect</string>
+    <key>destination</key>
+    <string>upload</string>
+    <key>signingStyle</key>
+    <string>automatic</string>
+    <key>teamID</key>
+    <string>${APPLE_TEAM_ID}</string>
+    <key>uploadSymbols</key>
+    <true/>
+    <key>manageAppVersionAndBuildNumber</key>
+    <true/>
+</dict>
+</plist>
+EOF
+
+xcodebuild -exportArchive \
+    -archivePath "${archive_path}" \
+    -exportOptionsPlist "${upload_options}" \
+    -exportPath "${release_temp}/upload" \
+    -allowProvisioningUpdates \
+    -authenticationKeyPath "${key_path}" \
+    -authenticationKeyID "${APPSTORE_KEY_ID}" \
+    -authenticationKeyIssuerID "${APPSTORE_ISSUER_ID}"
+
+export_options="${release_temp}/ExportOptions.plist"
+cat > "${export_options}" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store-connect</string>
+    <key>destination</key>
+    <string>export</string>
+    <key>signingStyle</key>
+    <string>automatic</string>
+    <key>teamID</key>
+    <string>${APPLE_TEAM_ID}</string>
+    <key>manageAppVersionAndBuildNumber</key>
+    <false/>
+</dict>
+</plist>
+EOF
+
+xcodebuild -exportArchive \
+    -archivePath "${archive_path}" \
+    -exportOptionsPlist "${export_options}" \
+    -exportPath "${release_temp}/export" \
+    -allowProvisioningUpdates \
+    -authenticationKeyPath "${key_path}" \
+    -authenticationKeyID "${APPSTORE_KEY_ID}" \
+    -authenticationKeyIssuerID "${APPSTORE_ISSUER_ID}"
+
+exported_ipa="$(find "${release_temp}/export" -maxdepth 2 -type f -name '*.ipa' -print -quit)"
+if [ -z "${exported_ipa}" ]; then
+    echo "No IPA was produced under ${release_temp}/export" >&2
+    exit 1
+fi
+
+mkdir -p "$(dirname "${ipa_path}")"
+cp "${exported_ipa}" "${ipa_path}"
+echo "Exported signed IPA to ${ipa_path}"


### PR DESCRIPTION
## Summary

- keep pull requests and non-master pushes on the existing unsigned iOS compile check
- on pushes to `master`, build an App Store-signed archive, upload it to TestFlight, and export a signed IPA from the same archive
- make `roll-release` wait for the iOS release path and attach `EKA2L1-iOS.ipa` to the rolling GitHub release
- keep the signing, TestFlight upload, IPA export, and temporary-keychain cleanup in `scripts/ios_release.sh` instead of embedding it in the workflow

## Repository setup

The master release path requires these Actions secrets:

- `APPLE_TEAM_ID`
- `APPSTORE_ISSUER_ID`
- `APPSTORE_KEY_ID`
- `APPSTORE_PRIVATE_KEY`

`IOS_DEV_SIGNING_KEY` and `IOS_DEV_SIGNING_KEY_PASSWORD` are strongly recommended so ephemeral runners do not create a new development certificate on every release. `IOS_DIST_SIGNING_KEY` and its password remain optional when cloud-managed distribution signing is available.

## Validation

- `actionlint .github/workflows/build.yml`
- `bash -n scripts/ios_release.sh`
- `shellcheck scripts/ios_release.sh`
- verified the release script fails early and clearly when a required signing variable is absent
- `git diff --check`
