### PR TITLE
system: wire up the four iOS hooks that were left with no caller

### DIFF
--- a/src/emu/config/include/config/options.inl
+++ b/src/emu/config/include/config/options.inl
@@ -82,6 +82,7 @@ OPTION(btnet-password, btnet_password, "")
 OPTION(btnet-discovery-mode, btnet_discovery_mode, 0)
 OPTION(enable-upnp, enable_upnp, true)
 OPTION(extensive-logging, extensive_logging, false)
+OPTION(ios-use-jit, ios_use_jit, false)
 
 #ifdef OPTION
 #undef OPTION

--- a/src/emu/system/src/epoc.cpp
+++ b/src/emu/system/src/epoc.cpp
@@ -138,6 +138,7 @@ namespace eka2l1 {
 
         config::state *conf_;
         config::app_settings *app_settings_;
+        std::string cache_root_;
 
         std::atomic<bool> exit = false;
         std::atomic<bool> paused = false;
@@ -628,9 +629,26 @@ namespace eka2l1 {
         , adriver(param.audio_)
         , conf_(param.conf_)
         , app_settings_(param.settings_)
+        , cache_root_(param.cache_root_)
         , exit(false) {
 #if EKA2L1_ARCH(ARM)
         cpu_type = arm_emulator_type::r12l1;
+#elif EKA2L1_PLATFORM(IOS)
+        // dyncom by default: dynarmic's A32 backend is not robust enough to be
+        // the one an App Store build lands on, and the JIT win is in sustained
+        // execution rather than the launch this decides. Builds that carry it
+        // (EKA2L1_IOS_DYNARMIC) let the user opt in, through ios_use_jit rather
+        // than cpu_backend -- the latter defaults to "dynarmic" for desktop and
+        // may already be persisted, which must not enable a JIT by itself.
+        cpu_type = arm_emulator_type::dyncom;
+#if EKA2L1_IOS_DYNARMIC
+        if (conf_->ios_use_jit && arm::host_can_jit()) {
+            cpu_type = arm_emulator_type::dynarmic;
+        }
+#endif
+        LOG_INFO(SYSTEM, "iOS CPU backend: {} (JIT opt-in: {}, JIT permission: {})",
+            (cpu_type == arm_emulator_type::dynarmic) ? "dynarmic" : "dyncom",
+            conf_->ios_use_jit, arm::host_can_jit());
 #else
         cpu_type = /*arm::string_to_arm_emulator_type(conf_->cpu_backend);*/ arm_emulator_type::dynarmic;
 #endif
@@ -702,6 +720,12 @@ namespace eka2l1 {
 
         if (paused) {
             return 1;
+        }
+
+        if (dispatcher_) {
+            // Objects orphaned by a dead process are destroyed here, where no kernel lock is
+            // held: an audio teardown waits out the render callback, which needs that lock.
+            dispatcher_->flush_pending_teardown();
         }
 
         bool should_step = false;
@@ -865,7 +889,10 @@ namespace eka2l1 {
         std::string current_dir;
         common::get_current_directory(current_dir);
 
-        const std::string temp_folder = eka2l1::absolute_path("cache/temp/", current_dir);
+        const std::string cache_root = cache_root_.empty()
+            ? eka2l1::absolute_path("cache/", current_dir)
+            : cache_root_;
+        const std::string temp_folder = eka2l1::add_path(cache_root, "temp/");
 
         eka2l1::common::delete_folder(temp_folder);
         eka2l1::common::create_directories(temp_folder);
@@ -1174,7 +1201,7 @@ namespace eka2l1 {
             return;
         }
 
-        get_lib_manager()->load_patch_libraries(PATCH_FOLDER_PATH);
+        get_lib_manager()->load_patch_libraries(runtime_resource_path(PATCH_FOLDER_PATH));
         dispatch::libraries::register_functions(kern_.get(), dispatcher_.get());
 
         service::init_services_post_bootup(parent_);


### PR DESCRIPTION
Four small changes in `system/epoc.cpp` (plus one line in `options.inl`). They are unrelated to each other but share a shape: the supporting half is already in the tree — the field, the function, the frontend that fills it in — and nothing consumes it, so the behaviour it exists for does not happen.

### The JIT opt-in does nothing

`config::state::ios_use_jit` is written by the iOS settings screen and read by nobody. iOS is arm64, so `EKA2L1_ARCH(ARM)` (which is `__arm__`, 32-bit only) is false and the `#else` asks for dynarmic unconditionally: a build carrying the JIT runs it whenever `host_can_jit()` says the process may, and a build without it falls back through `resolve_emulator_type()`'s downgrade with a warning. Decide explicitly instead — dyncom, and dynarmic only when the option asks and the process really has permission.

`ios-use-jit` was also missing from `options.inl`, so the toggle never survived a restart.

Kept separate from `cpu_backend` deliberately: that field defaults to `"dynarmic"` for desktop and may already be persisted in a user's `config.yml`, which must not turn a JIT on by itself.

### Audio outlives the process that was playing it

`dispatcher::on_process_exit()` moves a dead process's `dsp_medium`s into `mediums_pending_destroy_` instead of destroying them there — destroying one stops the host stream, which waits out the render callback in flight, and that callback needs the kernel lock this may itself be holding. The drain it defers to, `flush_pending_teardown()`, has no caller anywhere in the tree. Nothing frees them until `dispatcher::shutdown()`, and a medium still alive is a host audio stream still playing.

Drained at the top of `system_impl::loop()`, which holds no kernel lock. The lock order is the one this path already establishes: `loop()` takes `mut`, and guest execution below it takes the kernel lock via `lib_manager::call_svc` → `dispatcher::resolve`.

### The cache root is computed and then dropped

`system_create_components` carries `cache_root_`, the iOS frontend sets it to `NSCachesDirectory` and even deletes the tree older builds left behind in `Documents`. `epoc.cpp` then extracts a mounted zip to `"cache/temp/"` relative to the working directory — which on iOS is `Documents/data`, so it lands right back where the frontend just cleaned up. Regenerable data does not belong in `Documents`. Non-iOS behaviour is unchanged: an empty `cache_root_` keeps the old path.

### Patch DLLs are looked for where they are not

`src/emu/ios/CMakeLists.txt` ships them in the bundle and states the contract: *"the emulator reads its shipped resources through paths relative to the working directory ... a missing copy here means a null shader FILE* and an unpatched guest, not a silent fallback."* The shaders go through `runtime_resource_path()`, and `install_required_rom_patches()` resolves the very same folder with it — only `load_patch_libraries()` was left on the raw relative path, so on iOS no patch DLL loads at all. `runtime_resource_path()` returns its argument unchanged when no root is set, so every other platform is untouched.

### Verification

Simulator, Release, with `EKA2L1_IOS_DYNARMIC` both ON and OFF — the App Store configuration compiles the JIT out, so both sides of the `#if` are exercised. Regression suite 12/12 (Final Battle, Calculator, N95 Calculator, string catalog). In the resulting run: the log states `iOS CPU backend: dyncom (JIT opt-in: false, JIT permission: true)`, the patch DLLs load, and no cache tree appears under `Documents/data`.