### PR TITLE
Fix GLES1 shader compilation, a startup deadlock, and the CPU backend setting on desktop

### DIFF
--- a/src/emu/cpu/src/arm_factory.cpp
+++ b/src/emu/cpu/src/arm_factory.cpp
@@ -112,7 +112,29 @@ namespace eka2l1::arm {
             resolved = arm_emulator_type::dyncom;
         }
 #else
-        (void)requested;
+        // Three of the four enum values have no core on some desktop host: unicorn
+        // support is gone everywhere, 12l1r needs a 32-bit ARM host, and dynarmic is
+        // compiled out of dyncom-only builds. cpu_backend is free text out of
+        // config.yml, so an unsupported name otherwise reaches create_core, which
+        // answers null and takes the emulator down during startup with nothing said.
+        if (requested == arm_emulator_type::unicorn) {
+            reason = "the unicorn backend is no longer supported";
+            resolved = arm_emulator_type::dyncom;
+        }
+
+#if !EKA2L1_ARCH(ARM)
+        if (requested == arm_emulator_type::r12l1) {
+            reason = "the 12l1r recompiler needs a 32-bit ARM host";
+            resolved = arm_emulator_type::dyncom;
+        }
+#endif
+
+#if !EKA2L1_CPU_HAS_DYNARMIC
+        if (requested == arm_emulator_type::dynarmic) {
+            reason = "dynarmic is not compiled into this build";
+            resolved = arm_emulator_type::dyncom;
+        }
+#endif
 #endif
 
         if (out_reason) {
@@ -152,7 +174,11 @@ namespace eka2l1::arm {
     }
 
     exclusive_monitor_instance create_exclusive_monitor(arm_emulator_type arm_type, const std::size_t core_count) {
-        switch (arm_type) {
+        // Resolve exactly as create_core does. Its caller passes the same requested
+        // type to both, and a downgraded core must not be paired with a monitor
+        // built for the backend that was asked for. create_core reports the
+        // downgrade; staying quiet here keeps it to a single message.
+        switch (resolve_emulator_type(arm_type)) {
         case arm_emulator_type::unicorn:
             return nullptr;
 

--- a/src/emu/dispatch/src/libraries/gles1/shadergen.cpp
+++ b/src/emu/dispatch/src/libraries/gles1/shadergen.cpp
@@ -37,6 +37,48 @@ namespace eka2l1::dispatch {
         } else {
             input_decl += "#version 140\n"
                 "#extension GL_ARB_explicit_attrib_location : require\n";
+
+            // inverse() only became a GLSL built-in in 1.50, and the desktop context can
+            // go as low as GL 3.1 (see gl_context::s_desktop_opengl_versions), so raising
+            // the shader version is not an option. Supply our own instead. Strict drivers
+            // (Apple's) reject the built-in call outright, which fails every GLES1 program.
+            external_func +=
+                "mat4 eka2l1Inverse(mat4 m) {\n"
+                "\tfloat a00 = m[0][0], a01 = m[0][1], a02 = m[0][2], a03 = m[0][3];\n"
+                "\tfloat a10 = m[1][0], a11 = m[1][1], a12 = m[1][2], a13 = m[1][3];\n"
+                "\tfloat a20 = m[2][0], a21 = m[2][1], a22 = m[2][2], a23 = m[2][3];\n"
+                "\tfloat a30 = m[3][0], a31 = m[3][1], a32 = m[3][2], a33 = m[3][3];\n"
+                "\tfloat b00 = a00 * a11 - a01 * a10;\n"
+                "\tfloat b01 = a00 * a12 - a02 * a10;\n"
+                "\tfloat b02 = a00 * a13 - a03 * a10;\n"
+                "\tfloat b03 = a01 * a12 - a02 * a11;\n"
+                "\tfloat b04 = a01 * a13 - a03 * a11;\n"
+                "\tfloat b05 = a02 * a13 - a03 * a12;\n"
+                "\tfloat b06 = a20 * a31 - a21 * a30;\n"
+                "\tfloat b07 = a20 * a32 - a22 * a30;\n"
+                "\tfloat b08 = a20 * a33 - a23 * a30;\n"
+                "\tfloat b09 = a21 * a32 - a22 * a31;\n"
+                "\tfloat b10 = a21 * a33 - a23 * a31;\n"
+                "\tfloat b11 = a22 * a33 - a23 * a32;\n"
+                "\tfloat det = b00 * b11 - b01 * b10 + b02 * b09 + b03 * b08 - b04 * b07 + b05 * b06;\n"
+                "\treturn mat4(\n"
+                "\t\ta11 * b11 - a12 * b10 + a13 * b09,\n"
+                "\t\ta02 * b10 - a01 * b11 - a03 * b09,\n"
+                "\t\ta31 * b05 - a32 * b04 + a33 * b03,\n"
+                "\t\ta22 * b04 - a21 * b05 - a23 * b03,\n"
+                "\t\ta12 * b08 - a10 * b11 - a13 * b07,\n"
+                "\t\ta00 * b11 - a02 * b08 + a03 * b07,\n"
+                "\t\ta32 * b02 - a30 * b05 - a33 * b01,\n"
+                "\t\ta20 * b05 - a22 * b02 + a23 * b01,\n"
+                "\t\ta10 * b10 - a11 * b08 + a13 * b06,\n"
+                "\t\ta01 * b08 - a00 * b10 - a03 * b06,\n"
+                "\t\ta30 * b04 - a31 * b02 + a33 * b00,\n"
+                "\t\ta21 * b02 - a20 * b04 - a23 * b00,\n"
+                "\t\ta11 * b07 - a10 * b09 - a12 * b06,\n"
+                "\t\ta00 * b09 - a01 * b07 + a02 * b06,\n"
+                "\t\ta31 * b01 - a30 * b03 - a32 * b00,\n"
+                "\t\ta20 * b03 - a21 * b01 + a22 * b00) / det;\n"
+                "}\n";
         }
 
         input_decl += "layout (location = 0) in vec4 inPosition;\n";
@@ -92,8 +134,9 @@ namespace eka2l1::dispatch {
             main_body += "\tmNormal = uNormal;\n";
         }
 
-        main_body += "\tmat3 modelViewTrInv = mat3(inverse(transpose(uViewModelMat)));\n"
-                     "\tmNormal = modelViewTrInv * mNormal;\n";
+        main_body += fmt::format("\tmat3 modelViewTrInv = mat3({}(transpose(uViewModelMat)));\n",
+                         is_es ? "inverse" : "eka2l1Inverse")
+                   + "\tmNormal = modelViewTrInv * mNormal;\n";
 
         if (vertex_statuses & egl_context_es1::VERTEX_STATE_NORMAL_ENABLE_RESCALE) {
             // This bit is from ANGLE's renderer T_T

--- a/src/emu/qt/CMakeLists.txt
+++ b/src/emu/qt/CMakeLists.txt
@@ -256,6 +256,19 @@ add_custom_command(
         COMMAND ${CMAKE_COMMAND} -E copy_directory "${PROJECT_SOURCE_DIR}/src/emu/qt/resources/" "$<TARGET_FILE_DIR:eka2l1_qt>/resources/"
     )
 
+if (EKA2L1_ENABLE_SCRIPTING_ABILITY AND EKA2L1_SCRIPTING_LUA)
+    # Stage the Lua runtime with the frontend as well as with the scripting
+    # library. Packaging may remove bin/ after a successful build; an
+    # incremental rebuild does not relink the unchanged static library and
+    # therefore would not rerun that target's asset-copy command.
+    add_custom_command(
+            TARGET eka2l1_qt
+            POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:eka2l1_qt>/scripts/eka2l1"
+            COMMAND ${CMAKE_COMMAND} -E copy_directory "${PROJECT_SOURCE_DIR}/src/emu/scripting/lua/eka2l1/" "$<TARGET_FILE_DIR:eka2l1_qt>/scripts/eka2l1/"
+        )
+endif ()
+
 if (EKA2L1_ENABLE_SCRIPTING_ABILITY)
     if (LUA_DLL_PATH)
         add_custom_command(
@@ -267,7 +280,9 @@ if (EKA2L1_ENABLE_SCRIPTING_ABILITY)
 
     set_target_properties(eka2l1_qt PROPERTIES ENABLE_EXPORTS 1)
 
-    if (UNIX AND (NOT APPLE) AND (CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU"))
+    if (APPLE)
+        target_link_libraries(eka2l1_qt PRIVATE -Wl,-force_load,$<TARGET_FILE:scripting>)
+    elseif(UNIX AND (CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU"))
         target_link_libraries(eka2l1_qt PRIVATE -Wl,--whole-archive $<TARGET_FILE:scripting> -Wl,--no-whole-archive)
     elseif(MSVC)
         set_target_properties(eka2l1_qt PROPERTIES LINK_FLAGS /WHOLEARCHIVE:scripting.lib)

--- a/src/emu/qt/src/main.cpp
+++ b/src/emu/qt/src/main.cpp
@@ -87,9 +87,10 @@ int main(int argc, char *argv[]) {
     eka2l1::common::copy_folder(app_path_str + "/patch", data_path_str + "/patch", 0, nullptr);
     eka2l1::common::copy_folder(app_path_str + "/resources", data_path_str + "/resources", 0, nullptr);
 
-    if (!eka2l1::common::exists(data_path_str + "/scripts/")) {
-        eka2l1::common::copy_folder(app_path_str + "/scripts", data_path_str + "/scripts", 0, nullptr);
-    }
+    // Keep shipped compatibility scripts current across application upgrades.
+    // copy_folder merges into the destination, so separately named user scripts
+    // remain untouched while updated bundled scripts replace stale copies.
+    eka2l1::common::copy_folder(app_path_str + "/scripts", data_path_str + "/scripts", 0, nullptr);
     
     if (!eka2l1::common::exists(data_path_str + "/compat/")) {
         eka2l1::common::copy_folder(app_path_str + "/compat", data_path_str + "/compat", 0, nullptr);

--- a/src/emu/qt/src/thread.cpp
+++ b/src/emu/qt/src/thread.cpp
@@ -245,8 +245,13 @@ namespace eka2l1::desktop {
 
         state.joystick_controller->start_polling();
 
+        // Do not reset graphics_event here. The initialization above set it to release the OS
+        // thread, which consumes the signal itself now that common::event is auto-reset. Clearing
+        // it before that waiter has re-acquired the event lock erases the wake, and the OS thread
+        // never leaves its startup wait -- no guest instruction ever runs, and the later shutdown
+        // handshake over the same event deadlocks with it.
+
         // Keep running. User which want to change the graphics backend will have to restart EKA2L1.
-        state.graphics_event.reset();
         state.graphics_driver->run();
 
         result = graphics_driver_thread_deinitialization(state);
@@ -290,10 +295,10 @@ namespace eka2l1::desktop {
                 break;
             }
 
-            // Try wait for initialization from other parties to make this success. Reset only
-            // after the wait returned, so a request raised while we were busy is not dropped.
+            // Try wait for initialization from other parties to make this success. The wait
+            // consumes the signal by itself; resetting afterwards would drop a request raised
+            // between the wait returning and the reset.
             state.init_event.wait();
-            state.init_event.reset();
         }
 
         // Register SEH handler for this thread
@@ -318,7 +323,6 @@ namespace eka2l1::desktop {
 
             if (state.should_emu_pause && !state.should_emu_quit) {
                 state.pause_event.wait();
-                state.pause_event.reset();
             }
         }
 
@@ -354,7 +358,6 @@ namespace eka2l1::desktop {
         // Instantiate UI and High-level interface threads
         std::thread os_thread_obj(os_thread, std::ref(state));
         state.init_done_event.wait();
-        state.init_done_event.reset();
 
         eka2l1::common::arg_parser parser(argc, argv);
 

--- a/src/emu/system/src/epoc.cpp
+++ b/src/emu/system/src/epoc.cpp
@@ -650,7 +650,7 @@ namespace eka2l1 {
             (cpu_type == arm_emulator_type::dynarmic) ? "dynarmic" : "dyncom",
             conf_->ios_use_jit, arm::host_can_jit());
 #else
-        cpu_type = /*arm::string_to_arm_emulator_type(conf_->cpu_backend);*/ arm_emulator_type::dynarmic;
+        cpu_type = arm::string_to_arm_emulator_type(conf_->cpu_backend);
 #endif
         dvcmngr_ = std::make_unique<device_manager>(conf_);
 


### PR DESCRIPTION
Four desktop fixes found while getting GLES1 titles running on macOS. None of
them are macOS-only in principle, but that is where they surface first.

### `inverse()` is not a GLSL 1.40 built-in

Every GLES1 draw was dropped on macOS — the generated vertex shader failed with
`Invalid call of undeclared identifier 'inverse'`, so no program was ever
created and 3D titles rendered nothing but the clear colour. `inverse()` only
became a built-in in GLSL 1.50, and the desktop path emits `#version 140`;
permissive drivers accept it anyway, Apple's does not. Raising the version is
not an option because the desktop context falls back as far as GL 3.1
(`gl_context::s_desktop_opengl_versions`), so the shader now carries its own
`mat4` inverse. **The GLES output is unchanged byte for byte.**

### `graphics_event` loses its wake-up

Launching straight into an app (`--app`) deadlocked most of the time: empty
window, not a single guest instruction executed. `common::event` is auto-reset,
so the wait consumes the signal itself, but the graphics thread still set the
event and reset it a few statements later — when the waiter had not yet
re-acquired the event lock, that reset erased its wake. The same event carries
the shutdown handshake in the other direction, so quitting then hung in
`join()` too. The other post-wait resets in that file can swallow a concurrent
signal the same way and go with it.

This one is older than it looks: the POSIX event has consumed on wait since it
was introduced, and `3d88ef0fa` brought Win32 in line, so all three platforms
are now exposed.

### The configured CPU backend was ignored

The desktop branch hardcoded dynarmic. Reading the setting again is only safe
with a guard, though: three of the four backend names have no core on a given
host, and `create_core` answers null for them, which takes the emulator down
before it logs anything. `resolve_emulator_type` now downgrades those to dyncom
with a reason, as it already did for iOS, and `create_exclusive_monitor`
resolves too so a downgraded core is not paired with the wrong monitor. Default
behaviour is unchanged — `cpu_backend` itself defaults to `"dynarmic"`.

### Bundled Lua scripts never reached the emulator

The scripting archive was force-loaded only on non-Apple UNIX, so on macOS the
linker dropped the objects whose static initialisers register the Lua API.
`scripts/eka2l1` was staged by the scripting library alone, which an
incremental rebuild does not relink. And `scripts/` in the data directory was
skipped whenever it already existed, pinning users to whatever shipped with
their first install (`copy_folder` merges, so user scripts stay put, and
`patch/`+`resources/` right above are already copied unconditionally).

### Verification

macOS arm64, RelWithDebInfo, Nokia 5320 (RM-409), dyncom and dynarmic both.

- Jelly Chase went from clear-colour-only with 253,425 dropped draws to a full
  60 FPS render, with zero shader errors in the log. 7Days and Snakes likewise.
- `--app` went from 1/5 successful launches to 20/20 after the event fix, with
  the remaining failures explained (thread samples pinned the OS thread in the
  startup wait every time).
- CPU backend matrix: `unicorn`, `r12l1`, an unrecognised value, `dyncom` and
  `dynarmic` all boot and launch a game. Before the guard, `unicorn` and
  `r12l1` killed the emulator during startup with nothing in the log.

Not verified: Windows and Linux builds. The shader change cannot affect GLES
targets, and the event change removes resets that are redundant under the
current auto-reset semantics on every platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SMfWiuoPsUqW3K2zCwKYVx
