### PR TITLE
Fix OpenVG path tessellation and audio frame positions

### DIFF
--- a/src/emu/dispatch/include/dispatch/libraries/vg/gnuVG_context.hh
+++ b/src/emu/dispatch/include/dispatch/libraries/vg/gnuVG_context.hh
@@ -131,6 +131,7 @@ namespace gnuVG {
 		VGfloat stroke_width, stroke_dash_phase;
 		bool stroke_dash_phase_reset;
 		VGfloat miter_limit;
+		VGCapStyle cap_style;
 		VGJoinStyle join_style;
 
 		/* Paint info */
@@ -298,6 +299,7 @@ namespace gnuVG {
 		// getters for stroke data
 		VGfloat get_stroke_width();
 		VGfloat get_miter_limit();
+		VGCapStyle get_cap_style();
 		VGJoinStyle get_join_style();
 		std::vector<VGfloat> get_dash_pattern();
 		VGfloat get_dash_phase();

--- a/src/emu/dispatch/include/dispatch/libraries/vg/gnuVG_path.hh
+++ b/src/emu/dispatch/include/dispatch/libraries/vg/gnuVG_path.hh
@@ -94,6 +94,10 @@ namespace gnuVG {
 				      const VGubyte *pathSegments,
 				      const T *pathData) {
 			path_dirty = true;
+			// OpenVG stores path coordinates as compact values decoded by S * scale + bias.
+			auto decode = [this](T value) {
+				return static_cast<VGfloat>(value) * scale + bias;
+			};
 
 			VGint remaining_segments = numSegments;
 			const VGubyte *sgmt = pathSegments;
@@ -111,24 +115,24 @@ namespace gnuVG {
 					/* commands with ONE parameter */
 				case VG_HLINE_TO:
 				case VG_VLINE_TO:
-					s_coordinates.push_back((VGfloat)(*(dat++)));
+					s_coordinates.push_back(decode(*(dat++)));
 					break;
 
 					/* commands with TWO parameters */
 				case VG_SQUAD_TO:
 				case VG_LINE_TO:
 				case VG_MOVE_TO:
-					s_coordinates.push_back((VGfloat)(*(dat++)));
-					s_coordinates.push_back((VGfloat)(*(dat++)));
+					s_coordinates.push_back(decode(*(dat++)));
+					s_coordinates.push_back(decode(*(dat++)));
 					break;
 
 					/* commands with FOUR parameters */
 				case VG_SCUBIC_TO:
 				case VG_QUAD_TO:
-					s_coordinates.push_back((VGfloat)(*(dat++)));
-					s_coordinates.push_back((VGfloat)(*(dat++)));
-					s_coordinates.push_back((VGfloat)(*(dat++)));
-					s_coordinates.push_back((VGfloat)(*(dat++)));
+					s_coordinates.push_back(decode(*(dat++)));
+					s_coordinates.push_back(decode(*(dat++)));
+					s_coordinates.push_back(decode(*(dat++)));
+					s_coordinates.push_back(decode(*(dat++)));
 					break;
 
 					/* commands with FIVE parameters */
@@ -136,21 +140,21 @@ namespace gnuVG {
 				case VG_SCWARC_TO:
 				case VG_LCCWARC_TO:
 				case VG_LCWARC_TO:
-					s_coordinates.push_back((VGfloat)(*(dat++)));
-					s_coordinates.push_back((VGfloat)(*(dat++)));
-					s_coordinates.push_back((VGfloat)(*(dat++)));
-					s_coordinates.push_back((VGfloat)(*(dat++)));
-					s_coordinates.push_back((VGfloat)(*(dat++)));
+					s_coordinates.push_back(decode(*(dat++)));
+					s_coordinates.push_back(decode(*(dat++)));
+					s_coordinates.push_back(decode(*(dat++)));
+					s_coordinates.push_back(decode(*(dat++)));
+					s_coordinates.push_back(decode(*(dat++)));
 					break;
 
 					/* commands with SIX parameters */
 				case VG_CUBIC_TO:
-					s_coordinates.push_back((VGfloat)(*(dat++)));
-					s_coordinates.push_back((VGfloat)(*(dat++)));
-					s_coordinates.push_back((VGfloat)(*(dat++)));
-					s_coordinates.push_back((VGfloat)(*(dat++)));
-					s_coordinates.push_back((VGfloat)(*(dat++)));
-					s_coordinates.push_back((VGfloat)(*(dat++)));
+					s_coordinates.push_back(decode(*(dat++)));
+					s_coordinates.push_back(decode(*(dat++)));
+					s_coordinates.push_back(decode(*(dat++)));
+					s_coordinates.push_back(decode(*(dat++)));
+					s_coordinates.push_back(decode(*(dat++)));
+					s_coordinates.push_back(decode(*(dat++)));
 					break;
 				}
 				sgmt++;
@@ -161,55 +165,7 @@ namespace gnuVG {
 		void vgAppendPathData(VGint numSegments,
 				      const VGubyte *pathSegments,
 				      const VGfloat *pathData) {
-			path_dirty = true;
-
-			VGint remaining_segments = numSegments;
-			const VGubyte *sgmt = pathSegments;
-			size_t nrcoords = 0;
-
-			while(remaining_segments) {
-				switch( (*sgmt) & (~0x00000001) ) {
-					/* commands with ZERO parameters */
-				case VG_CLOSE_PATH:
-					break;
-
-					/* commands with ONE parameter */
-				case VG_HLINE_TO:
-				case VG_VLINE_TO:
-					nrcoords += 1;
-					break;
-
-					/* commands with TWO parameters */
-				case VG_SQUAD_TO:
-				case VG_LINE_TO:
-				case VG_MOVE_TO:
-					nrcoords += 2;
-					break;
-
-					/* commands with FOUR parameters */
-				case VG_SCUBIC_TO:
-				case VG_QUAD_TO:
-					nrcoords += 4;
-					break;
-
-					/* commands with FIVE parameters */
-				case VG_SCCWARC_TO:
-				case VG_SCWARC_TO:
-				case VG_LCCWARC_TO:
-				case VG_LCWARC_TO:
-					nrcoords += 5;
-					break;
-
-					/* commands with SIX parameters */
-				case VG_CUBIC_TO:
-					nrcoords += 6;
-					break;
-				}
-				sgmt++;
-				remaining_segments--;
-			}
-			s_segments.insert(s_segments.end(), pathSegments, pathSegments + numSegments);
-			s_coordinates.insert(s_coordinates.end(), pathData, pathData + nrcoords);
+			vgAppendPathData<VGfloat>(numSegments, pathSegments, pathData);
 		}
 
 		template <typename T>
@@ -223,7 +179,6 @@ namespace gnuVG {
 			}
 
 			path_dirty = true;
-			size_t nrcoords = 0;
 
 			for (VGint i = 0; i < numSegments; i++) {
 				std::size_t num_coords = 0;
@@ -234,12 +189,9 @@ namespace gnuVG {
 					num_coords = s_segment_start_offset_in_coords[startIndex + i + 1] - start_offset;
 				}
 
-				if constexpr (std::is_same_v<T, float>) {
-					std::memcpy(s_coordinates.data() + start_offset, pathData, num_coords * sizeof(float));
-				} else {
-					for (std::size_t i = 0; i < num_coords; i++) {
-						s_coordinates[start_offset + i] = (VGfloat)pathData[i];
-					}
+				for (std::size_t coordinate_index = 0; coordinate_index < num_coords; coordinate_index++) {
+					s_coordinates[start_offset + coordinate_index]
+						= static_cast<VGfloat>(pathData[coordinate_index]) * scale + bias;
 				}
 
 				pathData += num_coords;

--- a/src/emu/dispatch/src/libraries/vg/gnuVG_context.cc
+++ b/src/emu/dispatch/src/libraries/vg/gnuVG_context.cc
@@ -37,6 +37,7 @@ namespace gnuVG {
 		, stroke_width(1.0f)
 		, stroke_dash_phase_reset(false)
 		, miter_limit(4.0f)
+		, cap_style(VG_CAP_BUTT)
 		, join_style(VG_JOIN_MITER)
 		, current_framebuffer(&screen_buffer)
 		, idalloc(1)
@@ -252,6 +253,10 @@ namespace gnuVG {
 
 	VGfloat Context::get_miter_limit() {
 		return miter_limit;
+	}
+
+	VGCapStyle Context::get_cap_style() {
+		return cap_style;
 	}
 
 	VGJoinStyle Context::get_join_style() {
@@ -553,6 +558,16 @@ namespace gnuVG {
 
 			/* Stroke parameters */
 		case VG_STROKE_CAP_STYLE:
+			switch((VGCapStyle)value) {
+			case VG_CAP_BUTT:
+			case VG_CAP_ROUND:
+			case VG_CAP_SQUARE:
+				cap_style = (VGCapStyle)value;
+				break;
+			default:
+				set_error(VG_ILLEGAL_ARGUMENT_ERROR);
+				break;
+			}
 			break;
 		case VG_STROKE_JOIN_STYLE:
 			switch((VGJoinStyle)value) {
@@ -844,7 +859,7 @@ namespace gnuVG {
 
 			/* Stroke parameters */
 		case VG_STROKE_CAP_STYLE:
-			break;
+			return cap_style;
 		case VG_STROKE_JOIN_STYLE:
 			return join_style;
 		case VG_STROKE_DASH_PHASE_RESET:
@@ -1043,7 +1058,7 @@ namespace gnuVG {
 		const float *texcoord2d,
 		const std::size_t texcoord_buffer_size,
 		const std::int32_t texcoord_stride) {
-		eka2l1::drivers::input_descriptor descriptor[2];
+		eka2l1::drivers::input_descriptor descriptor[2]{};
 		eka2l1::drivers::handle buffers[2];
 
 		if (!vertex2d) {
@@ -1673,14 +1688,15 @@ namespace gnuVG {
 	}
 
 	void Context::render_elements(const GraphicState &state, const std::uint32_t *indices, std::int32_t nr_indices) {
-		if(active_shader) {
+		if(active_shader && indices && nr_indices > 0) {
 			if (!index_buffer_pusher.is_initialized()) {
 				index_buffer_pusher.initialize(eka2l1::common::MB(2));
 			}
 
 			std::size_t indices_offset = 0;
 			eka2l1::drivers::handle index_buffer_handle = index_buffer_pusher.push_buffer(state.driver,
-				reinterpret_cast<const std::uint8_t*>(indices), 6 * sizeof(std::uint32_t), indices_offset);
+				reinterpret_cast<const std::uint8_t*>(indices),
+				static_cast<std::size_t>(nr_indices) * sizeof(std::uint32_t), indices_offset);
 
 			active_shader->set_current_graphics_command_builder(cmd_builder_);
 			active_shader->render_elements(index_buffer_handle, indices_offset, nr_indices);

--- a/src/emu/dispatch/src/libraries/vg/gnuVG_path.cc
+++ b/src/emu/dispatch/src/libraries/vg/gnuVG_path.cc
@@ -251,8 +251,9 @@ namespace gnuVG {
 			ma.memrealloc = GvgAllocator::gvg_realloc;
 
 		}
-		if(!tess)
-			tess = tessNewTess(ma_p);
+		if(tess)
+			tessDeleteTess(tess);
+		tess = tessNewTess(ma_p);
 	}
 
 	void Path::vgDrawPath_fill_regular(const GraphicState &state) {

--- a/src/emu/dispatch/src/libraries/vg/gnuVG_simplified_path.cc
+++ b/src/emu/dispatch/src/libraries/vg/gnuVG_simplified_path.cc
@@ -43,6 +43,7 @@ namespace gnuVG {
 
 	static Point pen, last_direction, first_direction;
 	static JoinStyle join_style, default_join_style;
+	static VGCapStyle cap_style;
 
 	static Point contour_start;
 	static bool start_new_contour;
@@ -87,8 +88,10 @@ namespace gnuVG {
 		if (dsq == 0.0)
 			return VG_FALSE; /* Points are coincident */
 		disc = 1.0 / dsq - 1.0 / 4.0;
-		if (disc < 0.0)
+		if (disc < -1.0e-7)
 			return VG_FALSE; /* Points are too far apart */
+		if (disc < 0.0)
+			disc = 0.0; /* Exact diameters can round a few ULPs below zero. */
 
 		s = sqrt(disc);
 		sdx = s*dx;
@@ -172,6 +175,27 @@ namespace gnuVG {
 
 		if(pen == end_point)
 			return;
+
+		// Appendix A of the OpenVG specification requires radii that are too
+		// small for the endpoints to be scaled up uniformly before solving for
+		// the center. Without this correction the fallback half ellipse does not
+		// end at the requested point.
+		if (rh != 0.0f && rv != 0.0f) {
+			const VGfloat rotation = rot * static_cast<VGfloat>(M_PI / 180.0);
+			const VGfloat cosine = cos(rotation);
+			const VGfloat sine = sin(rotation);
+			const VGfloat dx = (pen.x - end_point.x) * 0.5f;
+			const VGfloat dy = (pen.y - end_point.y) * 0.5f;
+			const VGfloat x = cosine * dx + sine * dy;
+			const VGfloat y = -sine * dx + cosine * dy;
+			const VGfloat radii_check = x * x / (rh * rh) + y * y / (rv * rv);
+
+			if (radii_check > 1.0f) {
+				const VGfloat correction = sqrt(radii_check);
+				rh *= correction;
+				rv *= correction;
+			}
+		}
 
 		Point c0, c1;
 		VGboolean success = findEllipses(rh, rv, rot,
@@ -340,11 +364,12 @@ namespace gnuVG {
 					    c1_m.x, c1_m.y,
 					    c2_m.x, c2_m.y,
 					    ep_m.x, ep_m.y);
-				add_cubic(c1_m, c2_m, end_point);
-				pen = end_point;
+				Point cubic_end = (k == 1) ? end_point : ep_m;
+				add_cubic(c1_m, c2_m, cubic_end);
+				pen = cubic_end;
 				bbox_modifier(c1_m.x, c1_m.y);
 				bbox_modifier(c2_m.x, c2_m.y);
-				bbox_modifier(end_point.x, end_point.y);
+				bbox_modifier(cubic_end.x, cubic_end.y);
 			}
 		}
 	}
@@ -766,6 +791,49 @@ namespace gnuVG {
 			t_array.push_back(vertice_index[k]);
 	}
 
+	static Point point_at(unsigned int index) {
+		const unsigned int offset = index << 1;
+		return Point(v_array[offset], v_array[offset + 1]);
+	}
+
+	static void offset_point(unsigned int index, const Point &offset) {
+		const unsigned int vertex_offset = index << 1;
+		v_array[vertex_offset] += offset.x;
+		v_array[vertex_offset + 1] += offset.y;
+	}
+
+	static void add_round_fan(const Point &center, unsigned int first_index,
+		unsigned int last_index, VGfloat sweep) {
+		const Point first = point_at(first_index);
+		const Point radius = first - center;
+		const VGfloat start_angle = atan2(radius.y, radius.x);
+		const VGfloat max_step = static_cast<VGfloat>(M_PI / 12.0);
+		int steps = static_cast<int>(ceil(fabs(sweep) / max_step));
+		if (steps < 1)
+			steps = 1;
+
+		const unsigned int center_index = nr_vertices;
+		push_vertice(center);
+		unsigned int previous = first_index;
+		for (int step = 1; step <= steps; ++step) {
+			unsigned int next = last_index;
+			if (step != steps) {
+				const VGfloat angle = start_angle + sweep * step / steps;
+				next = nr_vertices;
+				push_vertice(center + Point(cos(angle) * radius.length(),
+					sin(angle) * radius.length()));
+			}
+			if (sweep < 0.0f) {
+				const unsigned int triangle[] = { previous, next, center_index };
+				push_triangle(triangle);
+			} else {
+				const unsigned int triangle[] = { previous, center_index, next };
+				push_triangle(triangle);
+			}
+			previous = next;
+		}
+	}
+
 	static void add_miter_join(VGfloat angle, const Point &last_normal, const Point &new_normal) {
 		// convert the angle between the direction into the angle
 		// between the old line segment and the new
@@ -803,16 +871,54 @@ namespace gnuVG {
 	}
 
 	static void add_bevel_join(VGfloat angle, const Point &last_normal, const Point &new_normal) {
+		const unsigned int join_center = nr_vertices;
+		push_vertice(pen);
 		if(angle < 0.0f) { // bevel on left side of direction
 			unsigned int triangle[] = {
-				previous_segment[1], current_segment[0], previous_segment[3]
+				previous_segment[1], current_segment[0], join_center
 			};
 			push_triangle(triangle);
 		} else { // bevel on right side
 			unsigned int triangle[] = {
-				previous_segment[3], current_segment[0], current_segment[2]
+				previous_segment[3], join_center, current_segment[2]
 			};
 			push_triangle(triangle);
+		}
+	}
+
+	static void add_round_join(VGfloat angle) {
+		if (angle < 0.0f)
+			add_round_fan(pen, previous_segment[1], current_segment[0], angle);
+		else
+			add_round_fan(pen, previous_segment[3], current_segment[2], angle);
+	}
+
+	static void add_open_contour_caps() {
+		if (nr_vertices == 0 || first_direction.length() == 0.0f
+			|| last_direction.length() == 0.0f)
+			return;
+
+		switch (cap_style) {
+		case VG_CAP_ROUND:
+			add_round_fan(contour_start, first_segment[0], first_segment[2],
+				static_cast<VGfloat>(M_PI));
+			add_round_fan(pen, current_segment[3], current_segment[1],
+				static_cast<VGfloat>(M_PI));
+			break;
+		case VG_CAP_SQUARE: {
+			const Point start_extension = (-stroke_width * 0.5f / first_direction.length())
+				* first_direction;
+			const Point end_extension = (stroke_width * 0.5f / last_direction.length())
+				* last_direction;
+			offset_point(first_segment[0], start_extension);
+			offset_point(first_segment[2], start_extension);
+			offset_point(current_segment[1], end_extension);
+			offset_point(current_segment[3], end_extension);
+			break;
+		}
+		case VG_CAP_BUTT:
+		default:
+			break;
 		}
 	}
 
@@ -840,8 +946,7 @@ namespace gnuVG {
 					break;
 
 				case join_round:
-					// xxx not properly implemented yet
-					add_bevel_join(angle, last_normal, new_normal);
+					add_round_join(angle);
 					break;
 				case join_miter:
 					add_bevel_join(angle, last_normal, new_normal);
@@ -931,6 +1036,9 @@ namespace gnuVG {
 		// store the miter limit internally
 		miter_limit = context->get_miter_limit();
 
+		// store the cap style internally
+		cap_style = context->get_cap_style();
+
 		// get default join style
 		switch(context->get_join_style()) {
 		case VG_JOIN_STYLE_FORCE_SIZE:
@@ -990,6 +1098,8 @@ namespace gnuVG {
 				join_style = default_join_style;
 				close_to_first_segment();
 				add_join(first_direction);
+			} else if (dash_pattern.empty()) {
+				add_open_contour_caps();
 			}
 
 			join_style = no_join;

--- a/src/emu/dispatch/src/libraries/vg/gnuVG_simplified_path.cc
+++ b/src/emu/dispatch/src/libraries/vg/gnuVG_simplified_path.cc
@@ -286,11 +286,16 @@ namespace gnuVG {
 					    c2_m.x, c2_m.y,
 					    ep_m.x, ep_m.y);
 				last_qp = ep;
-				add_cubic(c1_m, c2_m, ep_m);
-				pen = ep_m;
+				// Matrix evaluation can leave a tiny rounding error at an exact
+				// quadrant boundary. Keep the path endpoint identical to the
+				// endpoint supplied by the guest, as the partial-arc path does.
+				Point cubic_end = (k == quadrants - 1 && last_angle == 0.0f)
+					? end_point : ep_m;
+				add_cubic(c1_m, c2_m, cubic_end);
+				pen = cubic_end;
 				bbox_modifier(c1_m.x, c1_m.y);
 				bbox_modifier(c2_m.x, c2_m.y);
-				bbox_modifier(ep_m.x, ep_m.y);
+				bbox_modifier(cubic_end.x, cubic_end.y);
 			}
 
 			if(last_angle > 0.0f) {

--- a/src/emu/drivers/include/drivers/audio/stream.h
+++ b/src/emu/drivers/include/drivers/audio/stream.h
@@ -23,6 +23,11 @@
 #include <functional>
 
 namespace eka2l1::drivers {
+    constexpr std::uint64_t frames_to_microseconds(const std::uint64_t frames,
+        const std::uint32_t sample_rate) {
+        return sample_rate ? frames * 1000000ULL / sample_rate : 0;
+    }
+
     using data_callback = std::function<std::size_t(std::int16_t *, std::size_t)>;
     class audio_driver;
 

--- a/src/emu/drivers/src/audio/backend/player_shared.cpp
+++ b/src/emu/drivers/src/audio/backend/player_shared.cpp
@@ -203,7 +203,10 @@ namespace eka2l1::drivers {
         if (!output_stream_ || !freq_ || !output_stream_->current_frame_position(&pos_in_frames)) {
             return 0;
         }
-        return pos_in_frames * channels_ * 1000000ULL / freq_;
+        // Audio backends report PCM frames, not interleaved scalar samples. A
+        // frame already contains one sample for every channel, so multiplying
+        // by channels_ makes stereo media report time at exactly 2x speed.
+        return frames_to_microseconds(pos_in_frames, freq_);
     }
 
     player_shared::player_shared(audio_driver *driver)

--- a/src/emu/drivers/src/audio/backend/tinysoundfont/player_tsf.cpp
+++ b/src/emu/drivers/src/audio/backend/tinysoundfont/player_tsf.cpp
@@ -386,7 +386,7 @@ namespace eka2l1::drivers {
         if (!output_ || !output_->current_frame_position(&pos_in_frames)) {
             return 0;
         }
-        return pos_in_frames * output_->get_channels() * 1000000ULL / output_->get_sample_rate();
+        return frames_to_microseconds(pos_in_frames, output_->get_sample_rate());
     }
 
     bool player_tsf::set_dest_encoding(const std::uint32_t enc) {

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -20,6 +20,8 @@ target_link_libraries(ekatests PRIVATE
     epocloader
     epocpkg
     epocservs
+    epocdispatch
+    libtess2
     lunasvg)
 
 # The fixtures are copied next to the executable, and the tests open them by a

--- a/src/tests/epoc/CMakeLists.txt
+++ b/src/tests/epoc/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(CORE_TEST_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/devices.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/drivers/audio.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/graphics/openvg.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mem.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/vfs.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/kernel/ipc_arg.cpp

--- a/src/tests/epoc/CMakeLists.txt
+++ b/src/tests/epoc/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(CORE_TEST_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/devices.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/drivers/audio.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mem.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/vfs.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/kernel/ipc_arg.cpp

--- a/src/tests/epoc/drivers/audio.cpp
+++ b/src/tests/epoc/drivers/audio.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include <catch2/catch.hpp>
+#include <drivers/audio/stream.h>
+
+TEST_CASE("Audio frame positions use frames rather than channel samples", "[audio]") {
+    using eka2l1::drivers::frames_to_microseconds;
+
+    REQUIRE(frames_to_microseconds(48000, 48000) == 1000000);
+    REQUIRE(frames_to_microseconds(22050, 44100) == 500000);
+    REQUIRE(frames_to_microseconds(1234, 0) == 0);
+}

--- a/src/tests/epoc/graphics/openvg.cpp
+++ b/src/tests/epoc/graphics/openvg.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include <catch2/catch.hpp>
+#include <dispatch/libraries/vg/gnuVG_context.hh>
+#include <dispatch/libraries/vg/gnuVG_path.hh>
+#include <dispatch/libraries/vg/gnuVG_simplified_path.hh>
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+namespace {
+    struct stroke_mesh {
+        std::vector<VGfloat> vertices;
+        std::vector<unsigned int> indices;
+    };
+
+    stroke_mesh make_stroke_mesh(VGCapStyle cap_style, VGJoinStyle join_style,
+        const std::vector<gnuVG::SimplifiedPath::Segment> &segments) {
+        gnuVG::Context context;
+        const gnuVG::GraphicState state{};
+        context.vgSetf(VG_STROKE_LINE_WIDTH, 2.0f);
+        context.vgSeti(state, VG_STROKE_CAP_STYLE, cap_style);
+        context.vgSeti(state, VG_STROKE_JOIN_STYLE, join_style);
+
+        gnuVG::SimplifiedPath path(&context);
+        path.segments = segments;
+
+        stroke_mesh result;
+        path.get_stroke_shape([&result](const gnuVG::SimplifiedPath::StrokeData &data) {
+            result.vertices.assign(data.vertices, data.vertices + data.nr_vertices * 2);
+            result.indices.assign(data.indices, data.indices + data.nr_indices);
+        });
+        return result;
+    }
+
+    std::pair<VGfloat, VGfloat> x_extent(const stroke_mesh &mesh) {
+        VGfloat minimum = mesh.vertices[0];
+        VGfloat maximum = mesh.vertices[0];
+        for (std::size_t i = 0; i < mesh.vertices.size(); i += 2) {
+            minimum = std::min(minimum, mesh.vertices[i]);
+            maximum = std::max(maximum, mesh.vertices[i]);
+        }
+        return { minimum, maximum };
+    }
+}
+
+TEST_CASE("OpenVG path data applies scale and bias on append and modify", "[openvg]") {
+    gnuVG::Context context;
+    gnuVG::Path path(&context, VG_PATH_DATATYPE_S_16, 2.0f, -1.0f,
+        VG_PATH_CAPABILITY_ALL);
+    const VGubyte segments[] = { VG_MOVE_TO, VG_LINE_TO };
+    const std::int16_t initial[] = { 1, 2, 3, 4 };
+
+    path.vgAppendPathData(2, segments, initial);
+    const std::vector<VGfloat> expected_initial = { 1.0f, 3.0f, 5.0f, 7.0f };
+    REQUIRE(path.s_coordinates == expected_initial);
+
+    const std::int16_t replacement[] = { -2, 5 };
+    REQUIRE(path.vgModifyPathCoords(1, 1, replacement) == VG_NO_ERROR);
+    const std::vector<VGfloat> expected_modified = { 1.0f, 3.0f, -5.0f, 9.0f };
+    REQUIRE(path.s_coordinates == expected_modified);
+}
+
+TEST_CASE("OpenVG stroke cap state validates and round-trips", "[openvg]") {
+    gnuVG::Context context;
+    const gnuVG::GraphicState state{};
+
+    REQUIRE(context.vgGeti(VG_STROKE_CAP_STYLE) == VG_CAP_BUTT);
+    context.vgSeti(state, VG_STROKE_CAP_STYLE, VG_CAP_ROUND);
+    REQUIRE(context.vgGeti(VG_STROKE_CAP_STYLE) == VG_CAP_ROUND);
+
+    context.vgSeti(state, VG_STROKE_CAP_STYLE, 0x7fffffff);
+    REQUIRE(context.get_error() == VG_ILLEGAL_ARGUMENT_ERROR);
+    REQUIRE(context.vgGeti(VG_STROKE_CAP_STYLE) == VG_CAP_ROUND);
+}
+
+TEST_CASE("OpenVG arc fallback advances through both cubic quadrants", "[openvg]") {
+    gnuVG::Context context;
+    gnuVG::SimplifiedPath path(&context);
+    const VGubyte segments[] = { VG_MOVE_TO, VG_SCCWARC_TO };
+    // The endpoints are farther apart than the supplied unit radii, forcing
+    // the half-ellipse fallback described by the OpenVG arc algorithm.
+    const VGfloat coordinates[] = { 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 3.0f, 0.0f };
+
+    path.simplify_path(segments, coordinates, 2);
+
+    REQUIRE(path.segments.size() == 3);
+    REQUIRE(path.segments[1].t == gnuVG::SimplifiedPath::sp_cubic_to);
+    REQUIRE(path.segments[1].ep != gnuVG::Point(3.0f, 0.0f));
+    REQUIRE(path.segments[2].ep.x == Approx(3.0f));
+    REQUIRE(path.segments[2].ep.y == Approx(0.0f));
+}
+
+TEST_CASE("OpenVG open-contour caps extend the stroke as specified", "[openvg]") {
+    using segment = gnuVG::SimplifiedPath::Segment;
+    const std::vector<segment> line = {
+        { gnuVG::SimplifiedPath::sp_move_to, {}, {}, { 0.0f, 0.0f } },
+        { gnuVG::SimplifiedPath::sp_line_to, {}, {}, { 10.0f, 0.0f } }
+    };
+
+    const stroke_mesh butt = make_stroke_mesh(VG_CAP_BUTT, VG_JOIN_BEVEL, line);
+    const stroke_mesh round = make_stroke_mesh(VG_CAP_ROUND, VG_JOIN_BEVEL, line);
+    const stroke_mesh square = make_stroke_mesh(VG_CAP_SQUARE, VG_JOIN_BEVEL, line);
+
+    REQUIRE(x_extent(butt) == std::make_pair(0.0f, 10.0f));
+    REQUIRE(x_extent(round) == std::make_pair(-1.0f, 11.0f));
+    REQUIRE(x_extent(square) == std::make_pair(-1.0f, 11.0f));
+    REQUIRE(round.indices.size() > butt.indices.size());
+}
+
+TEST_CASE("OpenVG round and miter joins add their required outer geometry", "[openvg]") {
+    using segment = gnuVG::SimplifiedPath::Segment;
+    const std::vector<segment> corner = {
+        { gnuVG::SimplifiedPath::sp_move_to, {}, {}, { 0.0f, 0.0f } },
+        { gnuVG::SimplifiedPath::sp_line_to, {}, {}, { 10.0f, 0.0f } },
+        { gnuVG::SimplifiedPath::sp_line_to, {}, {}, { 10.0f, 10.0f } }
+    };
+
+    const stroke_mesh bevel = make_stroke_mesh(VG_CAP_BUTT, VG_JOIN_BEVEL, corner);
+    const stroke_mesh round = make_stroke_mesh(VG_CAP_BUTT, VG_JOIN_ROUND, corner);
+    const stroke_mesh miter = make_stroke_mesh(VG_CAP_BUTT, VG_JOIN_MITER, corner);
+
+    REQUIRE(round.indices.size() > bevel.indices.size());
+    REQUIRE(miter.vertices.size() == bevel.vertices.size() + 2);
+    REQUIRE(miter.indices.size() == bevel.indices.size() + 3);
+}

--- a/src/tests/epoc/graphics/openvg.cpp
+++ b/src/tests/epoc/graphics/openvg.cpp
@@ -84,12 +84,13 @@ TEST_CASE("OpenVG stroke cap state validates and round-trips", "[openvg]") {
     REQUIRE(context.vgGeti(VG_STROKE_CAP_STYLE) == VG_CAP_ROUND);
 }
 
-TEST_CASE("OpenVG arc fallback advances through both cubic quadrants", "[openvg]") {
+TEST_CASE("OpenVG oversized arc scales radii and preserves its endpoint", "[openvg]") {
     gnuVG::Context context;
     gnuVG::SimplifiedPath path(&context);
     const VGubyte segments[] = { VG_MOVE_TO, VG_SCCWARC_TO };
-    // The endpoints are farther apart than the supplied unit radii, forcing
-    // the half-ellipse fallback described by the OpenVG arc algorithm.
+    // OpenVG Appendix A scales undersized radii uniformly. The resulting
+    // half ellipse consists only of complete quadrants, whose transformed
+    // endpoint must still be the exact endpoint supplied by the guest.
     const VGfloat coordinates[] = { 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 3.0f, 0.0f };
 
     path.simplify_path(segments, coordinates, 2);
@@ -98,7 +99,7 @@ TEST_CASE("OpenVG arc fallback advances through both cubic quadrants", "[openvg]
     REQUIRE(path.segments[1].t == gnuVG::SimplifiedPath::sp_cubic_to);
     REQUIRE(path.segments[1].ep != gnuVG::Point(3.0f, 0.0f));
     REQUIRE(path.segments[2].ep.x == Approx(3.0f));
-    REQUIRE(path.segments[2].ep.y == Approx(0.0f));
+    REQUIRE(path.segments[2].ep.y == 0.0f);
 }
 
 TEST_CASE("OpenVG open-contour caps extend the stroke as specified", "[openvg]") {


### PR DESCRIPTION
## Summary

- derive shared and TinySoundFont player positions from PCM frames instead of interleaved channel samples
- upload the complete OpenVG tessellator index set and reset libtess state before retessellating a reused path
- apply the OpenVG path scale/bias contract on append and modify, including float paths
- correct arc radius adjustment/endpoints and implement validated butt, round, and square caps plus round joins
- repair bevel geometry while retaining valid miter tips and bevel fallback at the miter limit

## Why these changes are general

`audio_output_stream::current_frame_position()` reports PCM frames. A frame already contains every channel, so multiplying by the channel count makes stereo media position advance at exactly 2x wall time. Both player implementations now share one frame-to-time conversion.

The OpenVG failure was below any individual guest: `Context::render_elements()` always uploaded six indices but drew `nr_indices`, so paths larger than two triangles read beyond the uploaded index data. The adjacent fixes enforce OpenVG state/path contracts and make reused path geometry deterministic rather than special-casing a title.

## Unit-test rationale

The new tests exercise contracts that distinguish the fixes from the old behavior:

- 48,000 frames at 48 kHz and 22,050 frames at 44.1 kHz map to one second and half a second without any channel term; zero sample rate is guarded.
- signed 16-bit path coordinates are checked after both append and modify with scale 2 and bias -1, so a raw-copy implementation fails.
- an arc whose endpoints exceed the supplied radii must enlarge the radii, traverse two cubic quadrants, and still end at the requested point.
- cap state defaults, valid round-trip, and invalid-value behavior are checked.
- butt, round, and square caps are compared by geometric extent; bevel, round, and miter joins are compared by generated mesh topology, including the retained miter tip.

## Verification

- `cmake --build build/macos --target ekatests -j6`
- `ctest --test-dir build/macos --output-on-failure` (180 test cases, 3,321 assertions)
- targeted `[audio],[openvg]` run (6 test cases, 22 assertions)
- Release iOS simulator build
- iOS regression suite run twice, once after install and once without reinstalling: 12/12 checks passed each time (Final Battle 90-second dwell, Calculator interactions, N95 Calculator, string catalog)

The investigation notes remain on the downstream `ios-next` branch and are intentionally excluded from this PR.