### PR TITLE
Retain EGL window surfaces during server redraws

### DIFF
--- a/src/emu/dispatch/src/libraries/egl/def.cpp
+++ b/src/emu/dispatch/src/libraries/egl/def.cpp
@@ -62,6 +62,7 @@ namespace eka2l1::dispatch {
     
     egl_surface::~egl_surface() {
         if (backed_window_) {
+            backed_window_->clear_presented_surface(handle_);
             backed_window_->remove_canvas_observer(this);
         }
     }

--- a/src/emu/dispatch/src/libraries/egl/egl.cpp
+++ b/src/emu/dispatch/src/libraries/egl/egl.cpp
@@ -497,29 +497,11 @@ namespace eka2l1::dispatch {
         if (surface->backed_window_) {
             egl_context *ctx = surface->bounded_context_;
             surface->scale(ctx, drv);
+            surface->backed_window_->set_presented_surface(surface->handle_);
 
             if (ctx && surface->backed_window_->can_be_physically_seen()) {
                 drivers::graphics_command_builder &window_builder = surface->backed_window_->driver_builder_;
-                window_builder.set_feature(drivers::graphics_feature::blend, false);
-                window_builder.set_feature(drivers::graphics_feature::depth_test, false);
-
-                eka2l1::rect dest_rect = surface->backed_window_->abs_rect;
-                dest_rect.scale(surface->backed_screen_->display_scale_factor);
-
-                int rotation = 0;
-
-                if (surface->backed_window_->flags & epoc::window::flag_fix_native_orientation) {
-                    // Surface is also upside down. So a 180 flip :(
-                    rotation = (surface->backed_screen_->current_mode().rotation + 180) % 360;
-                    eka2l1::drivers::advance_draw_pos_around_origin(dest_rect, rotation);
-
-                    if (rotation % 180 != 0) {
-                        std::swap(dest_rect.size.x, dest_rect.size.y);
-                    }
-                }
-
-                window_builder.draw_bitmap(surface->handle_, 0, dest_rect, eka2l1::rect(eka2l1::vec2(0, 0), eka2l1::vec2(0, 0)),
-                    eka2l1::vec2(0, 0), static_cast<float>(rotation), drivers::bitmap_draw_flag_flip);
+                surface->backed_window_->draw_presented_surface(window_builder);
 
                 surface->backed_window_->content_changed(true);
             }

--- a/src/emu/services/include/services/window/classes/winuser.h
+++ b/src/emu/services/include/services/window/classes/winuser.h
@@ -109,6 +109,9 @@ namespace eka2l1::epoc {
         std::unique_ptr<epoc::gdi_store_command_segment> pending_segment_;
         std::vector<canvas_observer*> observers_;
 
+        // EGL window surfaces are not part of the GDI redraw command store.
+        drivers::handle presented_surface_handle_{ 0 };
+
         explicit canvas_base(window_server_client_ptr client, screen *scr, window *parent, const epoc::window_type type_of_window, const epoc::display_mode dmode, const std::uint32_t client_handle);
         virtual ~canvas_base() override;
 
@@ -118,6 +121,10 @@ namespace eka2l1::epoc {
         virtual void handle_extent_changed(const eka2l1::vec2 &new_size, const eka2l1::vec2 &new_pos) = 0;
         virtual void add_draw_command(gdi_store_command &command);
         virtual void prepare_for_draw() {}
+
+        void set_presented_surface(drivers::handle handle);
+        void clear_presented_surface(drivers::handle handle);
+        bool draw_presented_surface(drivers::graphics_command_builder &builder);
 
         virtual bool scroll(eka2l1::rect clip_space, const eka2l1::vec2 offset, eka2l1::rect source_rect) {
             return true;

--- a/src/emu/services/src/window/classes/winuser.cpp
+++ b/src/emu/services/src/window/classes/winuser.cpp
@@ -152,6 +152,45 @@ namespace eka2l1::epoc {
         }
     }
 
+    void canvas_base::set_presented_surface(const drivers::handle handle) {
+        presented_surface_handle_ = handle;
+    }
+
+    void canvas_base::clear_presented_surface(const drivers::handle handle) {
+        if (presented_surface_handle_ == handle) {
+            presented_surface_handle_ = 0;
+        }
+    }
+
+    bool canvas_base::draw_presented_surface(drivers::graphics_command_builder &builder) {
+        if (!presented_surface_handle_ || !can_be_physically_seen()) {
+            return false;
+        }
+
+        builder.set_feature(drivers::graphics_feature::blend, false);
+        builder.set_feature(drivers::graphics_feature::depth_test, false);
+        builder.clip_bitmap_region(visible_region, scr->display_scale_factor);
+
+        eka2l1::rect dest_rect = abs_rect;
+        dest_rect.scale(scr->display_scale_factor);
+
+        int rotation = 0;
+        if (flags & flag_fix_native_orientation) {
+            rotation = (scr->current_mode().rotation + 180) % 360;
+            drivers::advance_draw_pos_around_origin(dest_rect, rotation);
+
+            if (rotation % 180 != 0) {
+                std::swap(dest_rect.size.x, dest_rect.size.y);
+            }
+        }
+
+        builder.draw_bitmap(presented_surface_handle_, 0, dest_rect,
+            eka2l1::rect(eka2l1::vec2(0, 0), eka2l1::vec2(0, 0)),
+            eka2l1::vec2(0, 0), static_cast<float>(rotation),
+            drivers::bitmap_draw_flag_flip);
+        return true;
+    }
+
     bool canvas_base::is_dsa_active() const {
         return !directs_.empty();
     }
@@ -1261,7 +1300,12 @@ namespace eka2l1::epoc {
                         break;
                     }
                 }
+            }
 
+            // A window surface is its background; stored GDI commands appear above it.
+            draw_presented_surface(builder);
+
+            if (!segments.empty()) {
                 builder.clip_bitmap_region(visible_region, scr->display_scale_factor);
 
                 gdi_command_builder gdi_builder(client->get_ws().get_graphics_driver(), builder,


### PR DESCRIPTION
## Summary

Retain the most recently swapped EGL window surface on its WindowServer canvas and draw it again during a full server recomposition.

This fixes EGL-backed windows going black after a visibility change triggers a server redraw. A native dialog is a common reproducer: its body is visible briefly, then the screen clear removes both the app surface and dialog surface while only stored GDI content (such as the softkey bar) can be replayed.

## Root cause

`eglSwapBuffers` queued the current EGL surface only in the client redraw builder. A full WindowServer redraw clears the screen and walks the window tree, but EGL surface content is outside the GDI redraw command store, so it was not part of that recomposition.

Symbian's own WindowServer treats a window surface as persistent scene state rather than a GDI redraw command:

- [`RWindowBase::SetBackgroundSurface` creates a GCE surface layer associated with the window, and documents that `CWindowGc` rendering appears in front of it](https://github.com/SymbianSource/oss.FCL.sf.os.graphics/blob/ff133bc50e6158bfb08cc093b0f0055321dcde99/windowing/windowserver/nga/CLIENT/RWINDOW.CPP#L1660-L1728).
- [The OpenWF WindowServer creates and inserts a background surface element into the scene in window order](https://github.com/SymbianSource/oss.FCL.sf.os.graphics/blob/ff133bc50e6158bfb08cc093b0f0055321dcde99/windowing/windowserver/nga/SERVER/openwfc/windowelementset.cpp#L1258-L1334).
- [Its redraw path reserves the surface extent separately from the window background fill](https://github.com/SymbianSource/oss.FCL.sf.os.graphics/blob/ff133bc50e6158bfb08cc093b0f0055321dcde99/windowing/windowserver/nga/SERVER/openwfc/wnredraw.cpp#L306-L363).

## Changes

- Store the latest swapped driver surface handle on the backing canvas.
- Reuse one surface drawing path for immediate EGL presentation and server recomposition.
- Draw the surface before replaying stored GDI commands, preserving the documented surface/GDI stacking order.
- Clear the retained handle when its EGL surface is destroyed, without allowing an older surface to clear a newer one.

## Validation

- Release iOS Simulator build: passed.
- Nokia X7-00 / RM-707 Symbian Belle in EKA2L1:
  - native delete dialog remained visible for more than 12 seconds;
  - app background, library controls, bottom action UI, dialog body, and softkey bar remained visible together;
  - cancel, reopen, and cancel/reopen cycles restored the underlying window without artifacts;
  - continuous 30 FPS recording showed no transient dialog disappearance or black full-window frame.
- Asphalt 6 EGL startup/render smoke test: passed.

No unit test was added because the failure requires EGL swap state, WindowServer visibility changes, z-ordered recomposition, and the graphics driver command stream; the simulator regression exercises that integration path directly.