### PR TITLE
window: composite window updates on the next frame boundary

### DIFF
--- a/src/emu/services/src/window/classes/winuser.cpp
+++ b/src/emu/services/src/window/classes/winuser.cpp
@@ -488,16 +488,24 @@ namespace eka2l1::epoc {
             const std::uint64_t crr = timing->microseconds();
             const std::uint64_t time_spend_per_frame_us = 1000000 / scr->refresh_rate;
 
-            std::uint64_t wait_time = 0;
+            // Composite on the next frame boundary, never right away - including
+            // when this window has been idle for longer than a frame. The
+            // boundaries are taken on the global clock, so every window shares
+            // them: updates landing in the same interval coalesce into one
+            // composite that shows the last state, the way a real display only
+            // scans out whatever the frame buffer holds at the vsync.
+            //
+            // Publishing an idle window's first update immediately instead is
+            // what made clients flash an intermediate frame: an EGL client that
+            // pauses between scenes submits its construction frame and the
+            // completed frame a millisecond or two apart, and compositing the
+            // first one on arrival puts it on screen for a full frame interval
+            // before the completed one is paced in.
+            const std::uint64_t next_frame_boundary = ((crr + time_spend_per_frame_us)
+                / time_spend_per_frame_us) * time_spend_per_frame_us;
 
-            if (crr < time_spend_per_frame_us + last_draw_) {
-                // Originally - (crr - last_draw_), but preventing overflow
-                wait_time = time_spend_per_frame_us + last_draw_ - crr;
-            } else {
-                wait_time = 0;
-            }
-
-            last_draw_ = ((crr + time_spend_per_frame_us - 1) / time_spend_per_frame_us) * time_spend_per_frame_us;
+            const std::uint64_t wait_time = next_frame_boundary - crr;
+            last_draw_ = next_frame_boundary;
 
             if (crr - last_fps_sync_ >= common::microsecs_per_sec) {
                 scr->last_fps = fps_count_;


### PR DESCRIPTION
`canvas_base::try_update` paces screen composites at the screen's refresh rate, but only for a window that drew within the last frame interval. A window idle for longer gets `wait_time = 0` and is composited on arrival:

```cpp
if (crr < time_spend_per_frame_us + last_draw_) {
    wait_time = time_spend_per_frame_us + last_draw_ - crr;
} else {
    wait_time = 0;      // idle for more than a frame -> composite now
}
```

Real hardware does the opposite: whatever the frame buffer holds at the vsync is what gets scanned out, so several updates inside one interval collapse into a single visible frame. The fast path breaks that for any client that pauses between scenes and then submits more than one update in quick succession.

An EGL client that draws its backdrop and its completed scene in two swaps a couple of milliseconds apart had the first swap published immediately, putting a half-built frame on screen for a full frame interval before the completed one was paced in. Timestamped probes on an OpenVG title (Talking Tom on the X7) caught it directly — swap, composite 1.0ms later, the completed swap 1.2ms after that, and its composite only at the next boundary:

```
t=87551275 SWAP       (backdrop only; previous swap was 124ms earlier)
t=87551661 try_update wait=0
t=87552295 COMPOSITE  <- half-built frame on screen
t=87553473 SWAP       (completed frame, 1.2ms later)
t=87553834 try_update wait=25996
t=87580114 COMPOSITE  <- 27.8ms of a black scene in between
```

This PR always schedules on the next frame boundary. The boundaries are computed on the global clock, so every window shares them and updates landing in the same interval coalesce.

Steady state is unchanged — a client drawing every frame was already waiting out the remainder of the interval. Only the first update after an idle gap is affected, and it now waits at most one frame interval for anything that follows it.

**Verification** (iOS Release build, simulator): regression suite 12/12 (Final Battle, Calculator, N95 Calculator), touch/GLES suite 5/5 (Angry Birds), with the Angry Birds menu still at 60 FPS — the drawer-blocking GLES path keeps its pacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MFrcea6gxipPMQiYohBiTG