### PR TITLE
package: avoid resolving wildcard stub paths

### DIFF
--- a/src/emu/common/src/fileutils.cpp
+++ b/src/emu/common/src/fileutils.cpp
@@ -430,8 +430,10 @@ namespace eka2l1::common {
     std::string find_case_sensitive_file_name(const std::string &folder_path, const std::string &insensitive_name, const file_type type) {
         auto ite = make_directory_iterator(folder_path, "");
         // next_entry() only populates dir_entry::type when detail is enabled.
-        // Without it, type-filtered lookups can never match on POSIX.
-        ite->detail = true;
+        // Ask for it only when the caller filters by type: on POSIX this stats
+        // every entry, which turns a name-only lookup in a large ROM directory
+        // into thousands of unnecessary system calls.
+        ite->detail = (type != FILE_INVALID);
         const std::u16string insensitive_name_u16 = common::utf8_to_ucs2(insensitive_name);
 
         common::dir_entry entry;
@@ -877,6 +879,16 @@ namespace eka2l1::common {
 
             const std::string component = relative.substr(pos, end - pos);
             const bool is_last = (end >= relative.size());
+
+            // A wildcard component is a pattern for a later directory lookup,
+            // not a literal host filename. Looking for it case-insensitively can
+            // never resolve the pattern and needlessly walks the whole directory.
+            // Once a pattern appears, neither it nor any suffix can name a concrete
+            // path yet, so keep the already-resolved prefix and append the rest.
+            if (component.find_first_of("*?") != std::string::npos) {
+                resolved += relative.substr(pos);
+                break;
+            }
 
             if (exists(resolved + component)) {
                 resolved += component;

--- a/src/emu/package/src/sis_script_interpreter.cpp
+++ b/src/emu/package/src/sis_script_interpreter.cpp
@@ -580,27 +580,17 @@ namespace eka2l1 {
             // Process file
             for (auto &wrap_file : install_block.files.fields) {
                 sis_file_des *file = reinterpret_cast<sis_file_des *>(wrap_file.get());
-                std::string raw_path = "";
-                std::string install_path = "";
+                const std::u16string file_target = resolve_file_target(file->target.unicode_string, install_drive);
 
                 if (file->target.unicode_string.length() > 0) {
                     // A package does not get to install to a path it has no business
                     // naming. See is_valid_target_path for what that means, and why
                     // the entry is skipped rather than the install failed.
-                    if (!package::is_valid_target_path(resolve_file_target(file->target.unicode_string, install_drive))) {
+                    if (!package::is_valid_target_path(file_target)) {
                         LOG_ERROR(PACKAGE, "SIS names an invalid install target, skipping it: {}",
                             common::ucs2_to_utf8(file->target.unicode_string));
                         continue;
                     }
-
-                    install_path = get_install_path(file->target.unicode_string, install_drive);
-
-                    const std::optional<std::u16string> raw_path_opt = io->get_raw_path(common::utf8_to_ucs2(install_path));
-                    if (!raw_path_opt) {
-                        LOG_ERROR(PACKAGE, "Unable to resolve SIS install target: {}", install_path);
-                        return false;
-                    }
-                    raw_path = common::ucs2_to_utf8(*raw_path_opt);
                 }
 
                 // Register before the operation switch, the way
@@ -609,8 +599,7 @@ namespace eka2l1 {
                 // matter at uninstall time (FILENULL). An entry a text prompt asked
                 // to skip is never installed, so it is not the package's to own.
                 if (register_files && !skip_next_file) {
-                    register_file_description(io, file, resolve_file_target(file->target.unicode_string, install_drive),
-                        parent_tree.package_info);
+                    register_file_description(io, file, file_target, parent_tree.package_info);
                 }
 
                 switch (file->op) {
@@ -667,6 +656,17 @@ namespace eka2l1 {
                         }
 
                         if (!install_data->data_units.fields.empty()) {
+                            std::string raw_path;
+                            if (!file_target.empty()) {
+                                const std::string install_path = get_install_path(file->target.unicode_string, install_drive);
+                                const std::optional<std::u16string> raw_path_opt = io->get_raw_path(common::utf8_to_ucs2(install_path));
+                                if (!raw_path_opt) {
+                                    LOG_ERROR(PACKAGE, "Unable to resolve SIS install target: {}", install_path);
+                                    return false;
+                                }
+                                raw_path = common::ucs2_to_utf8(*raw_path_opt);
+                            }
+
                             extract_target_info info;
                             info.file_path_ = raw_path;
                             info.data_unit_block_index_ = file->idx;
@@ -674,11 +674,10 @@ namespace eka2l1 {
 
                             extract_targets.push_back(info);
                             extract_target_accumulated_size += file->uncompressed_len;
-                        }
 
-                        const std::string raw_path_lower = common::lowercase_string(raw_path);
-                        if (FOUND_STR(raw_path_lower.find(".sis")) || FOUND_STR(raw_path_lower.find(".sisx"))) {
-                            if (!install_data->data_units.fields.empty() && (loader::identify_sis_type(raw_path).has_value())) {
+                            const std::string raw_path_lower = common::lowercase_string(raw_path);
+                            if ((FOUND_STR(raw_path_lower.find(".sis")) || FOUND_STR(raw_path_lower.find(".sisx")))
+                                && loader::identify_sis_type(raw_path).has_value()) {
                                 LOG_INFO(PACKAGE, "Detected an SmartInstaller SIS, path at: {}", raw_path);
                                 gathered_sis_paths.push_back(common::utf8_to_ucs2(raw_path));
                             }

--- a/src/tests/common/casepath.cpp
+++ b/src/tests/common/casepath.cpp
@@ -128,6 +128,31 @@ TEST_CASE("case_insensitive_resolve_passes_through_a_path_already_spelled_right"
     REQUIRE(eka2l1::filename(resolved) == "entry.dat");
 }
 
+TEST_CASE("case_insensitive_resolve_does_not_treat_wildcards_as_literal_names", "casepath") {
+    scratch_tree tree("casepath_wildcard");
+
+    if (!volume_distinguishes_case(tree.root)) {
+        SUCCEED("volume matches names without regard to case; wildcard fallback is not used");
+        return;
+    }
+
+    tree.make_dir("RESOURCE/APPS");
+
+#if !defined(_WIN32)
+    // POSIX permits '*' in a literal filename. It is a useful sentinel here:
+    // the old resolver enumerated APPS and incorrectly treated this entry as a
+    // case-insensitive match for a guest wildcard pattern.
+    tree.make_file("RESOURCE/APPS/VisualRadio.r*");
+#endif
+
+    const std::string resolved = common::resolve_case_insensitive_path(tree.root,
+        "resource\\apps\\visualradio.r*");
+    const std::string expected_prefix = eka2l1::add_path(tree.root,
+        "RESOURCE/APPS/");
+
+    REQUIRE(resolved == expected_prefix + "visualradio.r*");
+}
+
 TEST_CASE("path_case_sensitivity_is_answered_per_path_not_per_build", "casepath") {
     scratch_tree tree("casepath_probe");
 


### PR DESCRIPTION
## Summary

- stop case-insensitive path recovery when a wildcard component is reached
- avoid detailed directory entries for name-only case recovery
- defer SIS host path resolution until payload extraction is actually scheduled
- add a regression test for wildcard paths on case-sensitive filesystems

## Problem

ROM stub controllers contain wildcard targets such as VisualRadio.r*. They have no payload data, but the installer resolved every target as a concrete host path. On a case-sensitive filesystem, each wildcard missed the literal existence check and caused a full directory scan; detailed iteration also statted every entry. Large ROMs multiplied this work enough to delay application-registry loading for minutes.

The virtual wildcard targets are still registered for package ownership. Normal SIS files continue to resolve their host paths when extraction is queued.

## Verification

- full C++ suite: 181 test cases, 3322 assertions passed
- iOS Release simulator regression: 12/12 passed
- physical iPhone: 152 ROM stubs completed and 236 application records loaded; cached relaunch completed without reprocessing stubs