### PR TITLE
Install the real ROM out of a dump's ROM folder

### DIFF
--- a/src/emu/loader/src/rom.cpp
+++ b/src/emu/loader/src/rom.cpp
@@ -34,6 +34,10 @@ namespace eka2l1::loader {
     };
 
     loader::rom_dir *rom::burn_tree_find_dir(const std::string &vir_path) {
+        if (root.root_dirs.empty()) {
+            return nullptr;
+        }
+
         auto ite = path_iterator(vir_path);
         loader::rom_dir *last_dir_found = &(root.root_dirs[0].dir);
 
@@ -283,6 +287,14 @@ namespace eka2l1::loader {
             common::seek_where::beg);
 
         romf.root = read_root_dir_list(romf, stream);
+
+        // Nothing in the header identifies a ROM image, so a file that is not one at all still parses -
+        // it just ends up with no root directory, because the offsets read out of it point nowhere. Say
+        // so here instead of handing back a rom whose burn tree every caller then has to guard against.
+        if (romf.root.root_dirs.empty()) {
+            LOG_ERROR(LOADER, "ROM image has no root directory, it is likely not a ROM at all");
+            return std::nullopt;
+        }
 
         return romf;
     }

--- a/src/emu/system/src/installation/archive.cpp
+++ b/src/emu/system/src/installation/archive.cpp
@@ -54,14 +54,17 @@ namespace eka2l1::loader {
 
         kind type = unknown;
 
-        // rom_and_rpkg. Indices into the entry list.
+        // Index into the entry list of the image that becomes SYM.ROM. Set for both layouts.
         std::size_t rom_index = 0;
+
+        // rom_and_rpkg. Index into the entry list.
         std::size_t rpkg_index = 0;
         bool has_rpkg = false;
 
         // data_dump. Lowercased, ends with '/'.
         std::string z_prefix;
         std::vector<std::size_t> z_files;
+        // Everything sitting in the dump's ROM folder; `rom_index` is the one picked out of it.
         std::vector<std::size_t> rom_files;
         // The pack's own devices.yml, when it ships one.
         std::size_t devices_yml_index = 0;
@@ -115,6 +118,32 @@ namespace eka2l1::loader {
         return false;
     }
 
+    /**
+     * @brief Pick the image to install out of everything found in a dump's ROM folder.
+     *
+     * The folder is not always just the one file: N-Gage packs keep the raw sections the ROM was
+     * assembled from (`BOOT-<uid>.dmp`, `ROOT-<uid>.dmp`) next to `SYM.ROM`, and the boot section is an
+     * 8 KB block that parses into a ROM with no root directory at all. Prefer the name the emulator
+     * writes itself, then a .rom extension, and only then fall back to the largest file.
+     */
+    static std::size_t pick_rom_file(const std::vector<common::archive_entry_info> &entries,
+        const std::vector<std::size_t> &candidates) {
+        std::size_t best = candidates.front();
+        int best_rank = -1;
+
+        for (const std::size_t index : candidates) {
+            const std::string name = common::lowercase_string(eka2l1::filename(entries[index].path, false));
+            const int rank = (name == "sym.rom") ? 2 : (has_extension(name, ".rom") ? 1 : 0);
+
+            if ((rank > best_rank) || ((rank == best_rank) && (entries[index].size > entries[best].size))) {
+                best = index;
+                best_rank = rank;
+            }
+        }
+
+        return best;
+    }
+
     static archive_device_layout determine_layout(const std::vector<common::archive_entry_info> &entries) {
         archive_device_layout layout;
 
@@ -162,6 +191,7 @@ namespace eka2l1::loader {
             if (!layout.z_files.empty() && !layout.rom_files.empty()) {
                 layout.type = archive_device_layout::data_dump;
                 layout.z_prefix = z_prefix;
+                layout.rom_index = pick_rom_file(entries, layout.rom_files);
 
                 return layout;
             }
@@ -373,11 +403,11 @@ namespace eka2l1::loader {
         // The ROM is written under the name the emulator looks for straight away, so placing it later is
         // just a move.
         const std::string rom_temp_file = add_path(temp_rom_path, "SYM.ROM");
-        destinations[layout.rom_files.front()] = rom_temp_file;
+        destinations[layout.rom_index] = rom_temp_file;
 
         if (layout.rom_files.size() > 1) {
-            LOG_WARN(SYSTEM, "Archive holds {} ROM images for this device, using {}", layout.rom_files.size(),
-                entries[layout.rom_files.front()].path);
+            LOG_WARN(SYSTEM, "The ROM folder of this dump holds {} files, using {}", layout.rom_files.size(),
+                entries[layout.rom_index].path);
         }
 
         const std::string packaged_devices_yml = add_path(temp_rom_path, "devices.yml");


### PR DESCRIPTION
## Problem

An archive laid out as an unpacked dump (`data/drives/z/<code>` plus `data/roms/<code>`) had **every**
file in its ROM folder collected into `rom_files`, and `install_archive_data_dump` then installed
`rom_files.front()` — the first entry in archive order. That is only correct when the folder holds
exactly one file.

The N-Gage QD dump keeps the raw sections the image was assembled from right next to it:

```
Data/roms/rh-4/BOOT-101FB2B1.dmp    8 KB
Data/roms/rh-4/ROOT-101FB2B1.dmp   15.8 MB
Data/roms/rh-4/SYM.ROM             19.0 MB
```

so the device was installed with the 8 KB boot block as its `SYM.ROM`. The import reported success;
booting the device took the process down:

```
E loader/src/rom.cpp:259 [Loader]: Can't read number of directories in root directory!
T kernel/src/kernel.cpp:1365 [Kernel]: Rom mapped to address: 0x108404000
...
EXC_BAD_ACCESS (SIGSEGV) KERN_INVALID_ADDRESS at 0x40
  eka2l1::loader::rom::burn_tree_find_dir(...)
  eka2l1::loader::rom::burn_tree_find_entry(...)
  eka2l1::rom_file_system::open_file(...)
  eka2l1::hle::lib_manager::load(...)
  eka2l1::hle::lib_manager::load_patch_libraries(...)
  eka2l1::system_impl::initialize_user_parties()
```

## Changes

**`system/installation/archive.cpp`** — pick the image instead of taking the first entry: prefer the
name the emulator writes itself (`sym.rom`), then a `.rom` extension, then the largest file in the
folder. Packs whose ROM folder holds a single `SYM.ROM` are unaffected, and the ROM+RPKG branch
(which already picked the largest `.rom`) is untouched.

**`loader/rom.cpp`** — nothing in a ROM header identifies the file as a ROM, so `load_rom` happily
"parsed" the boot block: it read `rom_base = 0xE795F001` and `rom_size = 0xE1A01104` out of ARM
instructions, seeked to an offset derived from those, failed to read a root directory count, and
still returned a `rom`. The first burn-tree lookup then indexed `root.root_dirs[0]` on an empty
vector. A ROM that parses into zero root directories is not a ROM: `load_rom` returns `std::nullopt`
for it, and `burn_tree_find_dir` returns `nullptr` rather than indexing an empty vector. A bad dump
now fails the boot cleanly, and `install_rom` reports `rom_file_corrupt` instead of registering a
device from garbage.

## Verification

Driven from a host harness calling `loader::install_archive` directly, against real packs:

| Pack | Layout | Before | After |
|---|---|---|---|
| N-Gage QD Dev (RH-4) | dump | `SYM.ROM` 8192 bytes, crash on boot | 19 MB image, boots to the app list |
| N85 | dump | RM-333, 9511 drive Z files | unchanged |
| N70 | ROM + RPKG | RM-84, 5025 drive Z files | unchanged |

`load_rom` on the 8 KB boot block returns `nullopt` after the change; on the real image it returns
`rom_base = 0x50000000` (EKA1) as before. Booting the fixed RH-29 device logs no panic or access
violation. iOS Release regression suite 12/12.
