### PR TITLE
fbs: give the atlas its own packer, and size fallbacks off the canonical

### DIFF
--- a/src/emu/services/include/services/fbs/adapter/font_adapter.h
+++ b/src/emu/services/include/services/fbs/adapter/font_adapter.h
@@ -79,36 +79,47 @@ namespace eka2l1::epoc::adapter {
         virtual bool does_glyph_exist(std::size_t idx, std::uint32_t code, const std::uint32_t metric_identifier) = 0;
 
         /**
-         * @brief   Initialize getting glyph atlas.
-         * 
-         * Each pixel is 8 bits.
-         * 
-         * @param   atlas_ptr Pointer to destination data which glyph bitmap will be written to.
-         * @param   atlas_size Size of the atlas.
-         * 
-         * @returns Handle to the atlas get context. -1 on failure.
+         * @brief   Measure how much atlas space each glyph needs.
+         *
+         * Packing the glyphs is the caller's job -- the atlas is its buffer,
+         * and only it can see every glyph that has to fit -- so an adapter is
+         * asked to do the two things only it can: say how big a glyph is, and
+         * draw one. A glyph the face cannot supply reports an empty size and
+         * must be skipped by the caller.
+         *
+         * @param   idx                 Index of the face to measure against.
+         * @param   codes               The Unicode codepoints to measure.
+         * @param   count               How many codepoints `codes` holds.
+         * @param   metric_identifier   The size, as this adapter addresses it.
+         * @param   sizes               On return, each glyph's size in pixels.
+         *
+         * @returns True on success.
          */
-        virtual std::int32_t begin_get_atlas(std::uint8_t *atlas_ptr, const eka2l1::vec2 atlas_size) = 0;
+        virtual bool measure_atlas_glyphs(const std::size_t idx, const int *codes, const std::size_t count,
+            const std::uint32_t metric_identifier, eka2l1::vec2 *sizes) = 0;
 
         /**
-         * \brief Get an atlas contains glyphs bitmap.
-         * 
-         * \param handle        Handle to the atlas get context returned in begin_get_atlas.
-         * \param idx           Index of the typeface we want to get glyph bitmaps from.
-         * \param start_code    First unicode point in a range to get glyph bitmap. 0 to use unicode array.
-         * \param unicode_point Pointer to an array of unicode point which we want to rasterize. NULL to ingore.
-         * \param num_code      Number of unicode point to rasterize.
-         * \param font_size     Size of the font to render.
-         * \param info          Pointer to array which will contains character info in the atlas. Can be NULL to ignore.
-         * 
-         * \returns True on success. 
+         * @brief   Draw glyphs into an atlas, at positions the caller chose.
+         *
+         * `positions` holds the top-left corner each glyph is to be drawn at,
+         * one per codepoint, in the same order as `codes`. They come from the
+         * caller's packing of the sizes measure_atlas_glyphs() reported, so an
+         * adapter draws where it is told rather than deciding for itself.
+         *
+         * @param   idx                 Index of the face to draw from.
+         * @param   codes               The Unicode codepoints to draw.
+         * @param   count               How many codepoints `codes` holds.
+         * @param   metric_identifier   The size, as this adapter addresses it.
+         * @param   atlas               The atlas buffer to draw into.
+         * @param   atlas_size          Its dimensions; the width is also the row stride.
+         * @param   positions           Where each glyph goes.
+         * @param   info                On return, each glyph's placement and metrics.
+         *
+         * @returns True on success.
          */
-        virtual bool get_glyph_atlas(const std::int32_t handle, const std::size_t idx, const char16_t start_code, int *unicode_point,
-            const char16_t num_code, const std::uint32_t metric_identifier, character_info *info)
-            = 0;
-
-        // End getting atlas.
-        virtual void end_get_atlas(const std::int32_t handle) = 0;
+        virtual bool render_atlas_glyphs(const std::size_t idx, const int *codes, const std::size_t count,
+            const std::uint32_t metric_identifier, std::uint8_t *atlas, const eka2l1::vec2 atlas_size,
+            const eka2l1::vec2 *positions, character_info *info) = 0;
 
         /**
          * \brief Get total number of font this file consists of.

--- a/src/emu/services/include/services/fbs/adapter/freetype_font_adapter.h
+++ b/src/emu/services/include/services/fbs/adapter/freetype_font_adapter.h
@@ -32,18 +32,10 @@
 namespace eka2l1::epoc::adapter {
    class freetype_font_adapter : public font_file_adapter_base {
    private:
-       struct atlas_pack_state {
-           std::uint8_t *atlas_base_;
-           eka2l1::vec2 atlas_size_;
-           std::vector<stbrp_node> atlas_node_;
-           stbrp_context atlas_context_;
-       };
-
        std::vector<std::uint8_t> data_;
        std::vector<FT_Face> faces_;
        bool is_valid_;
 
-       common::identity_container<std::unique_ptr<atlas_pack_state>> pack_states_;
        std::vector<std::uint32_t> current_font_sizes_;
 
    protected:
@@ -72,12 +64,12 @@ namespace eka2l1::epoc::adapter {
 
        void free_glyph_bitmap(std::uint8_t *data) override;
 
-       std::int32_t begin_get_atlas(std::uint8_t *atlas_ptr, const eka2l1::vec2 atlas_size) override;
+       bool measure_atlas_glyphs(const std::size_t idx, const int *codes, const std::size_t count,
+           const std::uint32_t metric_identifier, eka2l1::vec2 *sizes) override;
 
-       bool get_glyph_atlas(const std::int32_t handle, const std::size_t idx, const char16_t start_code, int *unicode_point, const char16_t num_code,
-           const std::uint32_t metric_identifier, character_info *info) override;
-
-       void end_get_atlas(const std::int32_t handle) override;
+       bool render_atlas_glyphs(const std::size_t idx, const int *codes, const std::size_t count,
+           const std::uint32_t metric_identifier, std::uint8_t *atlas, const eka2l1::vec2 atlas_size,
+           const eka2l1::vec2 *positions, character_info *info) override;
 
        glyph_bitmap_type get_output_bitmap_type() const override {
            return antialised_glyph_bitmap;

--- a/src/emu/services/include/services/fbs/adapter/gdr_font_adapter.h
+++ b/src/emu/services/include/services/fbs/adapter/gdr_font_adapter.h
@@ -29,19 +29,11 @@
 #include <vector>
 
 namespace eka2l1::epoc::adapter {
-    struct gdr_font_atlas_pack_context {
-        std::vector<stbrp_node> pack_nodes_;
-        std::unique_ptr<stbrp_context> pack_context_;
-        std::uint8_t *pack_dest_;
-        eka2l1::vec2 pack_size_;
-    };
-
     class gdr_font_file_adapter : public font_file_adapter_base {
         loader::gdr::file_store store_;
         std::unique_ptr<common::ro_stream> buf_stream_;
 
         std::vector<std::uint32_t *> dynamic_alloc_list_;
-        common::identity_container<gdr_font_atlas_pack_context> pack_contexts_;
 
     protected:
         const loader::gdr::character *get_character(const std::size_t idx, std::uint32_t code, const std::uint32_t metric_identifier);
@@ -68,12 +60,12 @@ namespace eka2l1::epoc::adapter {
 
         void free_glyph_bitmap(std::uint8_t *data) override;
 
-        std::int32_t begin_get_atlas(std::uint8_t *atlas_ptr, const eka2l1::vec2 atlas_size) override;
+        bool measure_atlas_glyphs(const std::size_t idx, const int *codes, const std::size_t count,
+            const std::uint32_t metric_identifier, eka2l1::vec2 *sizes) override;
 
-        bool get_glyph_atlas(const std::int32_t handle, const std::size_t idx, const char16_t start_code, int *unicode_point,
-            const char16_t num_code, const std::uint32_t metric_identifier, character_info *info) override;
-
-        void end_get_atlas(const std::int32_t handle) override;
+        bool render_atlas_glyphs(const std::size_t idx, const int *codes, const std::size_t count,
+            const std::uint32_t metric_identifier, std::uint8_t *atlas, const eka2l1::vec2 atlas_size,
+            const eka2l1::vec2 *positions, character_info *info) override;
 
         glyph_bitmap_type get_output_bitmap_type() const override {
             return monochrome_glyph_bitmap;

--- a/src/emu/services/include/services/fbs/adapter/linked_font_adapter.h
+++ b/src/emu/services/include/services/fbs/adapter/linked_font_adapter.h
@@ -21,6 +21,7 @@
 
 #include <services/fbs/adapter/font_adapter.h>
 
+#include <map>
 #include <unordered_map>
 #include <vector>
 
@@ -88,6 +89,17 @@ namespace eka2l1::epoc::adapter {
         // than nothing).
         std::size_t component_index_for(const std::uint32_t code, const std::uint32_t metric_identifier);
 
+        // Can this component draw into an atlas made for the canonical one?
+        // Only if it writes the same pixel format.
+        bool can_share_atlas(const std::size_t component_index);
+
+        // Group `codes` by the component that draws each of them, then hand
+        // every group to `handler` as one batch, along with where each entry
+        // came from in the caller's arrays.
+        template <typename F>
+        bool for_each_component_group(const int *codes, const std::size_t count,
+            const std::uint32_t metric_identifier, F handler);
+
     public:
         explicit linked_font_file_adapter(std::vector<component> components, const std::size_t canonical,
             const open_font_face_attrib &attrib);
@@ -112,10 +124,11 @@ namespace eka2l1::epoc::adapter {
         std::uint32_t get_glyph_advance(const std::size_t face_index, const std::uint32_t codepoint,
             const std::uint32_t metric_identifier, const bool vertical = false) override;
 
-        std::int32_t begin_get_atlas(std::uint8_t *atlas_ptr, const eka2l1::vec2 atlas_size) override;
-        bool get_glyph_atlas(const std::int32_t handle, const std::size_t idx, const char16_t start_code, int *unicode_point,
-            const char16_t num_code, const std::uint32_t metric_identifier, character_info *info) override;
-        void end_get_atlas(const std::int32_t handle) override;
+        bool measure_atlas_glyphs(const std::size_t idx, const int *codes, const std::size_t count,
+            const std::uint32_t metric_identifier, eka2l1::vec2 *sizes) override;
+        bool render_atlas_glyphs(const std::size_t idx, const int *codes, const std::size_t count,
+            const std::uint32_t metric_identifier, std::uint8_t *atlas, const eka2l1::vec2 atlas_size,
+            const eka2l1::vec2 *positions, character_info *info) override;
         std::uint8_t get_atlas_bitmap_bits_per_pixel() override;
 
         std::optional<open_font_metrics> get_metric_with_uid(const std::size_t face_index, const std::uint32_t uid,

--- a/src/emu/services/include/services/fbs/adapter/stb_font_adapter.h
+++ b/src/emu/services/include/services/fbs/adapter/stb_font_adapter.h
@@ -35,7 +35,6 @@ namespace eka2l1::epoc::adapter {
         std::map<int, stbtt_fontinfo> cache_info;
 
         stbtt_fontinfo info_;
-        common::identity_container<std::unique_ptr<stbtt_pack_context>> contexts_;
 
         std::size_t count_;
         std::uint8_t flags_;
@@ -70,12 +69,12 @@ namespace eka2l1::epoc::adapter {
 
         void free_glyph_bitmap(std::uint8_t *data) override;
 
-        std::int32_t begin_get_atlas(std::uint8_t *atlas_ptr, const eka2l1::vec2 atlas_size) override;
+        bool measure_atlas_glyphs(const std::size_t idx, const int *codes, const std::size_t count,
+            const std::uint32_t metric_identifier, eka2l1::vec2 *sizes) override;
 
-        bool get_glyph_atlas(const std::int32_t handle, const std::size_t idx, const char16_t start_code, int *unicode_point, const char16_t num_code,
-            const std::uint32_t metric_identifier, character_info *info) override;
-
-        void end_get_atlas(const std::int32_t handle) override;
+        bool render_atlas_glyphs(const std::size_t idx, const int *codes, const std::size_t count,
+            const std::uint32_t metric_identifier, std::uint8_t *atlas, const eka2l1::vec2 atlas_size,
+            const eka2l1::vec2 *positions, character_info *info) override;
 
         glyph_bitmap_type get_output_bitmap_type() const override {
             return antialised_glyph_bitmap;

--- a/src/emu/services/include/services/fbs/font_atlas.h
+++ b/src/emu/services/include/services/fbs/font_atlas.h
@@ -36,6 +36,10 @@ namespace eka2l1::drivers {
 namespace eka2l1::epoc {
 #define ESTIMATE_MAX_CHAR_IN_ATLAS_WIDTH 50
 
+    // The rectangle packer, kept out of this header so that including it does
+    // not drag stb in. Defined in font_atlas.cpp.
+    struct atlas_packing_state;
+
     /**
      * \brief Font atlas is a texture contains glyph bitmaps.
      * 
@@ -55,10 +59,30 @@ namespace eka2l1::epoc {
         std::unique_ptr<std::uint8_t[]> atlas_data_;
 
         std::size_t typeface_idx_;
-        std::int32_t pack_handle_;
+
+        // The atlas packs itself. An adapter only measures and draws glyphs --
+        // it cannot own the packing, because a linked typeface draws from
+        // several adapters into this one buffer and they would each lay it out
+        // from scratch, overwriting one another.
+        std::unique_ptr<atlas_packing_state> pack_state_;
+
+        // Every glyph is padded on all sides, so that filtering a glyph never
+        // samples the one packed next to it.
+        static constexpr int GLYPH_PADDING = 5;
+
+        // How many of the coldest characters a rebuild drops, to leave the
+        // refilled atlas some room to grow into.
+        static constexpr std::size_t EVICT_ON_REBUILD = 5;
+
+        bool begin_packing(const int width);
+        bool pack_glyphs(const std::vector<int> &codes, adapter::character_info *infos);
 
     public:
         explicit font_atlas();
+
+        // Out of line: pack_state_ points at a type this header only forward
+        // declares.
+        ~font_atlas();
 
         explicit font_atlas(adapter::font_file_adapter_base *adapter, const std::size_t typeface_idx, const char16_t initial_start,
             const char16_t initial_char_count, const int font_size, const std::uint32_t metric_identifier_);

--- a/src/emu/services/src/fbs/adapter/freetype_font_adapter.cpp
+++ b/src/emu/services/src/fbs/adapter/freetype_font_adapter.cpp
@@ -64,7 +64,11 @@ namespace eka2l1::epoc::adapter {
             currentMaxHeightInFontUnit = FT_MulFix(
                 boundingBoxHeightInFontUnit, aFace->size->metrics.y_scale );
         }
-        while ( currentMaxHeightInFontUnit > maxHeightInFontUnit )
+        // The lower bound is ours, not Symbian's: FT_Set_Pixel_Sizes fails at
+        // zero, which leaves currentMaxHeightInFontUnit unchanged and spins
+        // this loop forever. A caller asking for an unusably small height is
+        // enough to reach that.
+        while ( ( currentMaxHeightInFontUnit > maxHeightInFontUnit ) && ( designHeightInPixels > 1 ) )
         {
             designHeightInPixels--;
             FT_Set_Pixel_Sizes( aFace, designHeightInPixels, designHeightInPixels );
@@ -330,109 +334,98 @@ namespace eka2l1::epoc::adapter {
         }
     }
 
-    std::int32_t freetype_font_adapter::begin_get_atlas(std::uint8_t *atlas_ptr, const eka2l1::vec2 atlas_size) {
-        auto pack_state = std::make_unique<atlas_pack_state>();
-
-        pack_state->atlas_base_ = atlas_ptr;
-        pack_state->atlas_size_ = atlas_size;
-
-        pack_state->atlas_node_.resize(atlas_size.x);
-
-        stbrp_init_target(&pack_state->atlas_context_, atlas_size.x, atlas_size.y, pack_state->atlas_node_.data(),
-            static_cast<int>(pack_state->atlas_node_.size()));
-        std::memset(pack_state->atlas_base_, 0, atlas_size.x * atlas_size.y);
-
-        return static_cast<std::int32_t>(pack_states_.add(pack_state));
-    }
-
-    bool freetype_font_adapter::get_glyph_atlas(const std::int32_t handle, const std::size_t idx, const char16_t start_code, int *unicode_point, const char16_t num_code, const std::uint32_t metric_identifier, character_info *info) {
-        auto pack_state = pack_states_.get(handle);
-
-        if (!pack_state) {
+    bool freetype_font_adapter::measure_atlas_glyphs(const std::size_t idx, const int *codes, const std::size_t count,
+        const std::uint32_t metric_identifier, eka2l1::vec2 *sizes) {
+        if (idx >= faces_.size()) {
             return false;
         }
 
-        auto pack_state_ptr = pack_state->get();
         auto face = faces_[idx];
-
-        if (!face) {
-            return false;
-        }
 
         if (!set_font_size(idx, metric_identifier)) {
             return false;
         }
 
-        std::vector<stbrp_rect> pack_rects(num_code);
-
-        for (auto i = 0; i < num_code; i++) {
-            const char16_t char_code = unicode_point ? unicode_point[i] : static_cast<char16_t>(start_code + i);
-            auto err = FT_Load_Char(face, char_code, FT_LOAD_BITMAP_METRICS_ONLY);
+        for (std::size_t i = 0; i < count; i++) {
+            auto err = FT_Load_Char(face, static_cast<FT_ULong>(codes[i]), FT_LOAD_BITMAP_METRICS_ONLY);
 
             if (err) {
-                LOG_WARN(SERVICE_FBS, "Failed to load character code 0x{:X} for face to get glyph atlas, error: {}",
-                    static_cast<int>(char_code), FT_Error_String(err));
+                LOG_WARN(SERVICE_FBS, "Failed to load character code 0x{:X} for face to measure glyph atlas, error: {}",
+                    codes[i], FT_Error_String(err));
+
+                sizes[i] = eka2l1::vec2(0, 0);
+                continue;
             }
 
-            pack_rects[i].x = 0;
-            pack_rects[i].y = 0;
-            pack_rects[i].w = face->glyph->bitmap.width + 10;
-            pack_rects[i].h = face->glyph->bitmap.rows + 10;
+            // Metrics-only loading reports the plain (non-LCD) bitmap, while
+            // rendering goes through the LCD filter and is averaged back down
+            // by three. The two agree to within the filter's couple of pixels,
+            // which the caller's padding absorbs.
+            sizes[i] = eka2l1::vec2(static_cast<int>(face->glyph->bitmap.width),
+                static_cast<int>(face->glyph->bitmap.rows));
         }
 
-        if (!stbrp_pack_rects(&pack_state_ptr->atlas_context_, pack_rects.data(), static_cast<int>(pack_rects.size()))) {
-            LOG_ERROR(SERVICE_FBS, "Failed to pack rects for glyph atlas");
+        return true;
+    }
+
+    bool freetype_font_adapter::render_atlas_glyphs(const std::size_t idx, const int *codes, const std::size_t count,
+        const std::uint32_t metric_identifier, std::uint8_t *atlas, const eka2l1::vec2 atlas_size,
+        const eka2l1::vec2 *positions, character_info *info) {
+        if (idx >= faces_.size()) {
             return false;
         }
 
-        // Render and put bitmap to atlas
-        for (auto i = 0; i < num_code; i++) {
-            const char16_t char_code = unicode_point ? unicode_point[i] : static_cast<char16_t>(start_code + i);
-            auto err = FT_Load_Char(face, char_code, FT_LOAD_DEFAULT);
+        auto face = faces_[idx];
 
-            if (err) {
-                LOG_WARN(SERVICE_FBS, "Failed to load character code 0x{:X} for face to get glyph atlas, error: {}",
-                    static_cast<int>(char_code), FT_Error_String(err));
+        if (!set_font_size(idx, metric_identifier)) {
+            return false;
+        }
+
+        for (std::size_t i = 0; i < count; i++) {
+            auto err = FT_Load_Char(face, static_cast<FT_ULong>(codes[i]), FT_LOAD_DEFAULT);
+
+            if (!err) {
+                err = FT_Render_Glyph(face->glyph, FT_RENDER_MODE_LCD);
             }
 
-            err = FT_Render_Glyph(face->glyph, FT_RENDER_MODE_LCD);
             if (err) {
                 LOG_WARN(SERVICE_FBS, "Failed to render character code 0x{:X} for face to get glyph atlas, error: {}",
-                static_cast<int>(char_code), FT_Error_String(err));
+                    codes[i], FT_Error_String(err));
+
+                info[i] = character_info{};
+                continue;
             }
 
             auto glyph = face->glyph;
             auto bitmap = glyph->bitmap;
 
-            auto &rect = pack_rects[i];
-            auto dest = pack_state_ptr->atlas_base_ + (rect.x + 5) * 4 + (rect.y + 5) * pack_state_ptr->atlas_size_.x * 4;
+            std::uint8_t *dest = atlas + positions[i].x * 4 + positions[i].y * atlas_size.x * 4;
 
-            for (auto y = 0; y < bitmap.rows; y++) {
-                for (auto x = 0; x < bitmap.width / 3; x++) {
+            for (std::uint32_t y = 0; y < bitmap.rows; y++) {
+                for (std::uint32_t x = 0; x < bitmap.width / 3; x++) {
                     auto average = static_cast<float>(bitmap.buffer[x * 3 + y * bitmap.pitch] +
                         bitmap.buffer[x * 3 + y * bitmap.pitch + 1] +
                         bitmap.buffer[x * 3 + y * bitmap.pitch + 2]) / 3.0f;
 
                     eka2l1::vec4 color(bitmap.buffer[x * 3 + y * bitmap.pitch], bitmap.buffer[x * 3 + y * bitmap.pitch + 1],
-                       bitmap.buffer[x * 3 + y * bitmap.pitch +2], static_cast<std::uint8_t>(average));
+                       bitmap.buffer[x * 3 + y * bitmap.pitch + 2], static_cast<std::uint8_t>(average));
 
                     float max = (static_cast<float>(std::max({ color.x, color.y, color.z })) / 255.0f);
                     int min = std::min({ color.x, color.y, color.z });
 
                     color = color * max + eka2l1::vec4(color.x, color.y, color.z, min) * (1.0f - max);
 
-                    dest[x * 4 + y * pack_state_ptr->atlas_size_.x * 4 + 0] = color.x;
-                    dest[x * 4 + y * pack_state_ptr->atlas_size_.x * 4 + 1] = color.y;
-                    dest[x * 4 + y * pack_state_ptr->atlas_size_.x * 4 + 2] = color.z;
-                    dest[x * 4 + y * pack_state_ptr->atlas_size_.x * 4 + 3] = color.w;
-
+                    dest[x * 4 + y * atlas_size.x * 4 + 0] = color.x;
+                    dest[x * 4 + y * atlas_size.x * 4 + 1] = color.y;
+                    dest[x * 4 + y * atlas_size.x * 4 + 2] = color.z;
+                    dest[x * 4 + y * atlas_size.x * 4 + 3] = color.w;
                 }
             }
 
-            info[i].x0 = rect.x + 5;
-            info[i].y0 = rect.y + 5;
-            info[i].x1 = rect.x + 5 + bitmap.width / 3;
-            info[i].y1 = rect.y + 5 + bitmap.rows;
+            info[i].x0 = static_cast<std::uint16_t>(positions[i].x);
+            info[i].y0 = static_cast<std::uint16_t>(positions[i].y);
+            info[i].x1 = static_cast<std::uint16_t>(positions[i].x + bitmap.width / 3);
+            info[i].y1 = static_cast<std::uint16_t>(positions[i].y + bitmap.rows);
             info[i].xadv = ft_convention_to_float(glyph->metrics.horiAdvance);
             info[i].xoff = static_cast<float>(glyph->bitmap_left);
             info[i].yoff = static_cast<float>(-glyph->bitmap_top);
@@ -443,9 +436,6 @@ namespace eka2l1::epoc::adapter {
         return true;
     }
 
-    void freetype_font_adapter::end_get_atlas(const std::int32_t handle) {
-        pack_states_.remove(handle);
-    }
 
     bool freetype_font_adapter::does_glyph_exist(std::size_t idx, std::uint32_t code, const std::uint32_t metric_identifier) {
         if (idx >= faces_.size()) {

--- a/src/emu/services/src/fbs/adapter/gdr_font_adapter.cpp
+++ b/src/emu/services/src/fbs/adapter/gdr_font_adapter.cpp
@@ -21,20 +21,7 @@
 #include <common/log.h>
 #include <services/fbs/adapter/gdr_font_adapter.h>
 
-#define STB_RECT_PACK_IMPLEMENTATION
-#include <stb_rect_pack.h>
-
 namespace eka2l1::epoc::adapter {
-    static bool is_gdr_pack_context_free(gdr_font_atlas_pack_context &ctx) {
-        return (ctx.pack_dest_ == nullptr);
-    }
-
-    static void free_gdr_pack_context(gdr_font_atlas_pack_context &ctx) {
-        ctx.pack_nodes_.clear();
-        ctx.pack_context_.reset();
-        ctx.pack_dest_ = nullptr;
-    }
-
     static open_font_metrics build_of_metrics_from_font_bitmap(const loader::gdr::font_bitmap *target_bitmap) {
         open_font_metrics metrics;
 
@@ -55,8 +42,7 @@ namespace eka2l1::epoc::adapter {
         return metrics;
     }
 
-    gdr_font_file_adapter::gdr_font_file_adapter(std::vector<std::uint8_t> &data)
-        : pack_contexts_(is_gdr_pack_context_free, free_gdr_pack_context) {
+    gdr_font_file_adapter::gdr_font_file_adapter(std::vector<std::uint8_t> &data) {
         // Instantiate a read-only buffer stream
         buf_stream_ = std::make_unique<common::ro_buf_stream>(&data[0], data.size());
 
@@ -217,108 +203,69 @@ namespace eka2l1::epoc::adapter {
         }
     }
 
-    std::int32_t gdr_font_file_adapter::begin_get_atlas(std::uint8_t *atlas_ptr, const eka2l1::vec2 atlas_size) {
-        gdr_font_atlas_pack_context context;
-        context.pack_context_ = std::make_unique<stbrp_context>();
-        context.pack_nodes_.resize(atlas_size.y);
-
-        stbrp_init_target(context.pack_context_.get(), atlas_size.x, atlas_size.y, context.pack_nodes_.data(), static_cast<int>(context.pack_nodes_.size()));
-        context.pack_dest_ = atlas_ptr;
-        context.pack_size_ = atlas_size;
-
-        return static_cast<std::int32_t>(pack_contexts_.add(context));
-    }
-
-    static float calculate_scale_factor_of_font(const int target_size, const int font_general_height, const int char_height) {
-        return static_cast<float>(target_size) / ((char_height == 0) ? static_cast<float>(font_general_height) : static_cast<float>(char_height));
-    }
-
-    bool gdr_font_file_adapter::get_glyph_atlas(const std::int32_t handle, const std::size_t idx, const char16_t start_code, int *unicode_point, const char16_t num_code,
-        const std::uint32_t metric_identifier, character_info *info) {
-        gdr_font_atlas_pack_context *context = pack_contexts_.get(handle);
-
-        if (!context) {
-            return false;
-        }
-
-        std::vector<stbrp_rect> rect_build;
-        std::vector<const loader::gdr::character *> the_chars;
-        rect_build.resize(num_code);
-
-        for (char16_t i = 0; i < num_code; i++) {
-            const char16_t ucode = (unicode_point) ? static_cast<char16_t>(unicode_point[i]) : start_code + i;
-            const loader::gdr::character *c = get_character(idx, ucode, metric_identifier);
-
-            rect_build[i].x = 0;
-            rect_build[i].y = 0;
+    bool gdr_font_file_adapter::measure_atlas_glyphs(const std::size_t idx, const int *codes, const std::size_t count,
+        const std::uint32_t metric_identifier, eka2l1::vec2 *sizes) {
+        for (std::size_t i = 0; i < count; i++) {
+            const loader::gdr::character *c = get_character(idx, static_cast<std::uint32_t>(codes[i]), metric_identifier);
 
             if (!c) {
-                rect_build[i].w = 0;
-                rect_build[i].h = 0;
-            } else {
-                rect_build[i].w = static_cast<stbrp_coord>(c->metric_->move_in_pixels_ - c->metric_->left_adj_in_pixels_ - c->metric_->right_adjust_in_pixels_);
-                rect_build[i].h = c->metric_->height_in_pixels_;
+                sizes[i] = eka2l1::vec2(0, 0);
+                continue;
             }
 
-            the_chars.push_back(c);
+            sizes[i] = eka2l1::vec2(c->metric_->move_in_pixels_ - c->metric_->left_adj_in_pixels_
+                    - c->metric_->right_adjust_in_pixels_,
+                c->metric_->height_in_pixels_);
         }
 
-        if (stbrp_pack_rects(context->pack_context_.get(), rect_build.data(), num_code) == 0) {
-            return false;
-        }
+        return true;
+    }
 
-        for (char16_t i = 0; i < num_code; i++) {
-            if (the_chars[i]) {
-                // Copy those info to character infos
-                info[i].x0 = rect_build[i].x;
-                info[i].y0 = rect_build[i].y;
-                info[i].x1 = rect_build[i].x + rect_build[i].w;
-                info[i].y1 = rect_build[i].y + the_chars[i]->metric_->height_in_pixels_;
+    bool gdr_font_file_adapter::render_atlas_glyphs(const std::size_t idx, const int *codes, const std::size_t count,
+        const std::uint32_t metric_identifier, std::uint8_t *atlas, const eka2l1::vec2 atlas_size,
+        const eka2l1::vec2 *positions, character_info *info) {
+        for (std::size_t i = 0; i < count; i++) {
+            const loader::gdr::character *c = get_character(idx, static_cast<std::uint32_t>(codes[i]), metric_identifier);
 
-                const std::int16_t target_width = the_chars[i]->metric_->move_in_pixels_ - the_chars[i]->metric_->left_adj_in_pixels_ - the_chars[i]->metric_->right_adjust_in_pixels_;
+            if (!c) {
+                info[i] = character_info{};
+                continue;
+            }
 
-                info[i].xoff = the_chars[i]->metric_->left_adj_in_pixels_;
-                info[i].yoff = -(the_chars[i]->metric_->ascent_in_pixels_);
-                info[i].xoff2 = info[i].xoff + target_width;
-                info[i].yoff2 = info[i].yoff + (the_chars[i]->metric_->height_in_pixels_);
-                info[i].xadv = the_chars[i]->metric_->move_in_pixels_;
+            const std::int16_t target_width = c->metric_->move_in_pixels_ - c->metric_->left_adj_in_pixels_
+                - c->metric_->right_adjust_in_pixels_;
+            const std::int16_t target_height = c->metric_->height_in_pixels_;
 
-                const loader::gdr::bitmap &bmp = the_chars[i]->data_;
+            info[i].x0 = static_cast<std::uint16_t>(positions[i].x);
+            info[i].y0 = static_cast<std::uint16_t>(positions[i].y);
+            info[i].x1 = static_cast<std::uint16_t>(positions[i].x + target_width);
+            info[i].y1 = static_cast<std::uint16_t>(positions[i].y + target_height);
 
-                // UWU gonna copy data to you. Simple scaling algorithm WARNING!
-                for (int y = rect_build[i].y; y < rect_build[i].y + rect_build[i].h; y++) {
-                    for (int x = rect_build[i].x; x < rect_build[i].x + rect_build[i].w; x++) {
-                        const float y_in_rect = static_cast<float>(y - rect_build[i].y);
-                        const float x_in_rect = static_cast<float>(x - rect_build[i].x);
+            info[i].xoff = c->metric_->left_adj_in_pixels_;
+            info[i].yoff = -(c->metric_->ascent_in_pixels_);
+            info[i].xoff2 = info[i].xoff + target_width;
+            info[i].yoff2 = info[i].yoff + target_height;
+            info[i].xadv = c->metric_->move_in_pixels_;
 
-                        const std::uint32_t src_scale_loc = (static_cast<std::int16_t>(y_in_rect) * target_width + static_cast<std::int16_t>(x_in_rect));
-                        if (src_scale_loc >= static_cast<std::uint32_t>(target_width * the_chars[i]->metric_->height_in_pixels_)) {
-                            // Nothing, just black
-                            context->pack_dest_[context->pack_size_.x * y + x] = 0;
-                        } else {
-                            context->pack_dest_[context->pack_size_.x * y + x] = ((bmp[src_scale_loc >> 5] >> (src_scale_loc & 31)) & 1) * 0xFF;
-                        }
+            const loader::gdr::bitmap &bmp = c->data_;
+
+            for (std::int16_t y = 0; y < target_height; y++) {
+                for (std::int16_t x = 0; x < target_width; x++) {
+                    const std::uint32_t src_loc = static_cast<std::uint32_t>(y) * target_width + x;
+                    std::uint8_t *dest = atlas + (positions[i].y + y) * atlas_size.x + positions[i].x + x;
+
+                    if (src_loc >= static_cast<std::uint32_t>(target_width * target_height)) {
+                        *dest = 0;
+                    } else {
+                        *dest = static_cast<std::uint8_t>(((bmp[src_loc >> 5] >> (src_loc & 31)) & 1) * 0xFF);
                     }
                 }
-            } else {
-                info[i].xoff = 0;
-                info[i].xoff2 = 0;
-                info[i].yoff = 0;
-                info[i].yoff2 = 0;
-                info[i].xadv = 0;
-                info[i].x0 = 0;
-                info[i].y0 = 0;
-                info[i].x1 = 0;
-                info[i].y1 = 0;
             }
         }
 
         return true;
     }
 
-    void gdr_font_file_adapter::end_get_atlas(const std::int32_t handle) {
-        pack_contexts_.remove(handle);
-    }
     
     bool gdr_font_file_adapter::has_character(const std::size_t face_index, const std::int32_t codepoint, const std::uint32_t metric_identifier) {
         return (get_character(face_index, codepoint, metric_identifier) != nullptr);

--- a/src/emu/services/src/fbs/adapter/linked_font_adapter.cpp
+++ b/src/emu/services/src/fbs/adapter/linked_font_adapter.cpp
@@ -210,21 +210,89 @@ namespace eka2l1::epoc::adapter {
             metric_for(index, metric_identifier), vertical);
     }
 
-    std::int32_t linked_font_file_adapter::begin_get_atlas(std::uint8_t *atlas_ptr, const eka2l1::vec2 atlas_size) {
-        // The packing state belongs to one adapter, so an atlas can only be
-        // built from the canonical component. Nothing in the font store uses
-        // this path (only the Qt button-map overlay does, with its own font).
-        return canonical().adapter_->begin_get_atlas(atlas_ptr, atlas_size);
+    bool linked_font_file_adapter::can_share_atlas(const std::size_t component_index) {
+        // Every component draws into the one buffer the caller uploads as a
+        // single texture, in whatever format it writes. Only those writing the
+        // format the atlas was made in -- the canonical's -- can take part; a
+        // gdr face backed by an imported TrueType font is the case that cares.
+        return components_[component_index].adapter_->get_atlas_bitmap_bits_per_pixel()
+            == components_[canonical_].adapter_->get_atlas_bitmap_bits_per_pixel();
     }
 
-    bool linked_font_file_adapter::get_glyph_atlas(const std::int32_t handle, const std::size_t idx, const char16_t start_code,
-        int *unicode_point, const char16_t num_code, const std::uint32_t metric_identifier, character_info *info) {
-        return canonical().adapter_->get_glyph_atlas(handle, canonical().face_index_, start_code, unicode_point, num_code,
-            metric_identifier, info);
+    // Sort `codes` by the component that draws them and run `handler` once per
+    // component, so a component still sees its glyphs as one batch. `slots`
+    // maps each entry of the group back to its index in the caller's arrays.
+    template <typename F>
+    bool linked_font_file_adapter::for_each_component_group(const int *codes, const std::size_t count,
+        const std::uint32_t metric_identifier, F handler) {
+        std::map<std::size_t, std::pair<std::vector<int>, std::vector<std::size_t>>> groups;
+
+        for (std::size_t i = 0; i < count; i++) {
+            const std::size_t chosen = component_index_for(static_cast<std::uint32_t>(codes[i]), metric_identifier);
+
+            auto &group = groups[can_share_atlas(chosen) ? chosen : canonical_];
+
+            group.first.push_back(codes[i]);
+            group.second.push_back(i);
+        }
+
+        for (auto &group : groups) {
+            if (!handler(components_[group.first], group.first, group.second.first, group.second.second)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
-    void linked_font_file_adapter::end_get_atlas(const std::int32_t handle) {
-        canonical().adapter_->end_get_atlas(handle);
+    // The atlas belongs to the caller, which packs it and tells each component
+    // where to draw, so these two only have to route a codepoint to the
+    // component that can draw it -- exactly as get_glyph_bitmap() does.
+    bool linked_font_file_adapter::measure_atlas_glyphs(const std::size_t idx, const int *codes, const std::size_t count,
+        const std::uint32_t metric_identifier, eka2l1::vec2 *sizes) {
+        return for_each_component_group(codes, count, metric_identifier,
+            [&](const component &comp, const std::size_t component_index, const std::vector<int> &group,
+                const std::vector<std::size_t> &slots) {
+                std::vector<eka2l1::vec2> measured(group.size());
+
+                if (!comp.adapter_->measure_atlas_glyphs(comp.face_index_, group.data(), group.size(),
+                        metric_for(component_index, metric_identifier), measured.data())) {
+                    return false;
+                }
+
+                for (std::size_t i = 0; i < group.size(); i++) {
+                    sizes[slots[i]] = measured[i];
+                }
+
+                return true;
+            });
+    }
+
+    bool linked_font_file_adapter::render_atlas_glyphs(const std::size_t idx, const int *codes, const std::size_t count,
+        const std::uint32_t metric_identifier, std::uint8_t *atlas, const eka2l1::vec2 atlas_size,
+        const eka2l1::vec2 *positions, character_info *info) {
+        return for_each_component_group(codes, count, metric_identifier,
+            [&](const component &comp, const std::size_t component_index, const std::vector<int> &group,
+                const std::vector<std::size_t> &slots) {
+                std::vector<eka2l1::vec2> where(group.size());
+                std::vector<character_info> drawn(group.size());
+
+                for (std::size_t i = 0; i < group.size(); i++) {
+                    where[i] = positions[slots[i]];
+                }
+
+                if (!comp.adapter_->render_atlas_glyphs(comp.face_index_, group.data(), group.size(),
+                        metric_for(component_index, metric_identifier), atlas, atlas_size, where.data(),
+                        drawn.data())) {
+                    return false;
+                }
+
+                for (std::size_t i = 0; i < group.size(); i++) {
+                    info[slots[i]] = drawn[i];
+                }
+
+                return true;
+            });
     }
 
     std::uint8_t linked_font_file_adapter::get_atlas_bitmap_bits_per_pixel() {
@@ -250,14 +318,30 @@ namespace eka2l1::epoc::adapter {
         // is still to hand: the per-glyph calls only ever see the canonical's
         // identifier, and handing a gdr bitmap index to FreeType as a pixel
         // size renders the glyph at a couple of pixels tall.
+        //
+        // What they are asked for is the size the canonical actually settled
+        // on, not the one the client asked for. A linked typeface has to look
+        // like one face, and a bitmap canonical only stocks a few sizes, so it
+        // routinely lands somewhere other than the request. Where the request
+        // is itself unusable -- S60v2 clients have been seen asking for two
+        // pixels while the canonical renders at thirteen -- passing it on
+        // shrinks every fallback glyph to nothing.
+        const std::uint16_t settled_size = (metrics->max_height > 0)
+            ? static_cast<std::uint16_t>(metrics->max_height)
+            : targeted_font_size;
+
         std::vector<std::uint32_t> &identifiers = metric_identifiers_[canonical_identifier];
         identifiers.assign(components_.size(), canonical_identifier);
 
         for (std::size_t i = 0; i < components_.size(); i++) {
+            if (i == canonical_) {
+                continue;
+            }
+
             std::uint32_t component_identifier = canonical_identifier;
 
-            if (components_[i].adapter_->get_nearest_supported_metric(components_[i].face_index_, targeted_font_size,
-                    &component_identifier, is_design_font_size)) {
+            if (components_[i].adapter_->get_nearest_supported_metric(components_[i].face_index_, settled_size,
+                    &component_identifier, false)) {
                 identifiers[i] = component_identifier;
             }
         }

--- a/src/emu/services/src/fbs/adapter/stb_font_adapter.cpp
+++ b/src/emu/services/src/fbs/adapter/stb_font_adapter.cpp
@@ -23,20 +23,12 @@
 #define STB_TRUETYPE_IMPLEMENTATION
 #include <stb_truetype.h>
 
+#include <cstring>
+
 namespace eka2l1::epoc::adapter {
-    static void free_stb_pack_context(std::unique_ptr<stbtt_pack_context> &ctx) {
-        stbtt_PackEnd(ctx.get());
-        ctx.reset();
-    }
-
-    static bool is_stb_pack_context_free(std::unique_ptr<stbtt_pack_context> &ctx) {
-        return (ctx == nullptr);
-    }
-
     stb_font_file_adapter::stb_font_file_adapter(std::vector<std::uint8_t> &data_)
         : data_(data_)
-        , flags_(0)
-        , contexts_(is_stb_pack_context_free, free_stb_pack_context) {
+        , flags_(0) {
         count_ = stbtt_GetNumberOfFonts(&data_[0]);
 
         if (count_ > 0) {
@@ -295,46 +287,103 @@ namespace eka2l1::epoc::adapter {
         stbtt_FreeBitmap(data, nullptr);
     }
 
-    std::int32_t stb_font_file_adapter::begin_get_atlas(std::uint8_t *atlas_ptr, const eka2l1::vec2 atlas_size) {
-        std::unique_ptr<stbtt_pack_context> context = std::make_unique<stbtt_pack_context>();
-        if (stbtt_PackBegin(context.get(), atlas_ptr, atlas_size.x, atlas_size.y, 0, 1, nullptr) == 0) {
-            return -1;
-        }
+    // stb_truetype's packer normally gathers, packs and renders in one call.
+    // The atlas does its own packing, so the two halves are driven separately
+    // here: a pack context is built per call purely to carry the oversampling
+    // settings and, when rendering, the destination buffer. Padding is left at
+    // zero so a rectangle's position is the position stb draws at.
+    bool stb_font_file_adapter::measure_atlas_glyphs(const std::size_t idx, const int *codes, const std::size_t count,
+        const std::uint32_t metric_identifier, eka2l1::vec2 *sizes) {
+        int off = 0;
+        stbtt_fontinfo *font_info = get_or_create_info(static_cast<int>(idx), &off);
 
-        return static_cast<std::int32_t>(contexts_.add(context));
-    }
-
-    void stb_font_file_adapter::end_get_atlas(const std::int32_t handle) {
-        contexts_.remove(static_cast<std::size_t>(handle));
-    }
-
-    bool stb_font_file_adapter::get_glyph_atlas(const std::int32_t handle, const std::size_t idx, const char16_t start_code, int *unicode_point,
-        const char16_t num_code, const std::uint32_t font_size, character_info *info) {
-        auto character_infos = std::make_unique<stbtt_packedchar[]>(num_code);
-        std::unique_ptr<stbtt_pack_context> *context_ptr = contexts_.get(handle);
-
-        if (!context_ptr) {
+        if (!font_info) {
             return false;
         }
 
-        stbtt_pack_context *context = context_ptr->get();
-        stbtt_PackSetOversampling(context, 2, 2);
+        std::vector<int> codepoints(codes, codes + count);
+        auto packed = std::make_unique<stbtt_packedchar[]>(count);
+        auto rects = std::make_unique<stbrp_rect[]>(count);
+
+        stbtt_pack_context context;
+
+        if (!stbtt_PackBegin(&context, nullptr, 1, 1, 0, 0, nullptr)) {
+            return false;
+        }
+
+        stbtt_PackSetOversampling(&context, 2, 2);
 
         stbtt_pack_range range;
-        range.array_of_unicode_codepoints = unicode_point;
-        range.chardata_for_range = character_infos.get();
-        range.font_size = static_cast<float>(font_size);
-        range.num_chars = num_code;
-        range.first_unicode_codepoint_in_range = start_code;
+        range.array_of_unicode_codepoints = codepoints.data();
+        range.chardata_for_range = packed.get();
+        range.font_size = static_cast<float>(metric_identifier);
+        range.num_chars = static_cast<int>(count);
+        range.first_unicode_codepoint_in_range = 0;
 
-        if (!stbtt_PackFontRanges(context, data_.data(), static_cast<int>(idx), &range, 1)) {
+        const int gathered = stbtt_PackFontRangesGatherRects(&context, font_info, &range, 1, rects.get());
+        stbtt_PackEnd(&context);
+
+        if (gathered != static_cast<int>(count)) {
             return false;
         }
 
-        if (info) {
-            std::memcpy(info, character_infos.get(), num_code * sizeof(character_info));
+        for (std::size_t i = 0; i < count; i++) {
+            sizes[i] = eka2l1::vec2(rects[i].w, rects[i].h);
         }
 
+        return true;
+    }
+
+    bool stb_font_file_adapter::render_atlas_glyphs(const std::size_t idx, const int *codes, const std::size_t count,
+        const std::uint32_t metric_identifier, std::uint8_t *atlas, const eka2l1::vec2 atlas_size,
+        const eka2l1::vec2 *positions, character_info *info) {
+        int off = 0;
+        stbtt_fontinfo *font_info = get_or_create_info(static_cast<int>(idx), &off);
+
+        if (!font_info) {
+            return false;
+        }
+
+        std::vector<int> codepoints(codes, codes + count);
+        auto packed = std::make_unique<stbtt_packedchar[]>(count);
+        auto rects = std::make_unique<stbrp_rect[]>(count);
+
+        stbtt_pack_context context;
+
+        if (!stbtt_PackBegin(&context, atlas, atlas_size.x, atlas_size.y, atlas_size.x, 0, nullptr)) {
+            return false;
+        }
+
+        stbtt_PackSetOversampling(&context, 2, 2);
+
+        stbtt_pack_range range;
+        range.array_of_unicode_codepoints = codepoints.data();
+        range.chardata_for_range = packed.get();
+        range.font_size = static_cast<float>(metric_identifier);
+        range.num_chars = static_cast<int>(count);
+        range.first_unicode_codepoint_in_range = 0;
+
+        if (stbtt_PackFontRangesGatherRects(&context, font_info, &range, 1, rects.get()) != static_cast<int>(count)) {
+            stbtt_PackEnd(&context);
+            return false;
+        }
+
+        // Hand stb the placement the atlas decided on, in the form its renderer
+        // expects from a packer that has run.
+        for (std::size_t i = 0; i < count; i++) {
+            rects[i].x = static_cast<stbrp_coord>(positions[i].x);
+            rects[i].y = static_cast<stbrp_coord>(positions[i].y);
+            rects[i].was_packed = 1;
+        }
+
+        const int rendered = stbtt_PackFontRangesRenderIntoRects(&context, font_info, &range, 1, rects.get());
+        stbtt_PackEnd(&context);
+
+        if (!rendered) {
+            return false;
+        }
+
+        std::memcpy(info, packed.get(), count * sizeof(character_info));
         return true;
     }
 

--- a/src/emu/services/src/fbs/font_atlas.cpp
+++ b/src/emu/services/src/fbs/font_atlas.cpp
@@ -18,14 +18,26 @@
 #include <drivers/graphics/graphics.h>
 #include <services/fbs/font_atlas.h>
 
+#define STB_RECT_PACK_IMPLEMENTATION
+#include <stb_rect_pack.h>
+
 #include <common/algorithm.h>
 #include <common/time.h>
 
+#include <cstring>
+
 namespace eka2l1::epoc {
+    struct atlas_packing_state {
+        std::vector<stbrp_node> nodes_;
+        stbrp_context context_;
+        int width_;
+    };
+
+    font_atlas::~font_atlas() = default;
+
     font_atlas::font_atlas()
         : atlas_handle_(0)
-        , atlas_data_(nullptr)
-        , pack_handle_(0) {
+        , atlas_data_(nullptr) {
     }
 
     font_atlas::font_atlas(adapter::font_file_adapter_base *adapter, const std::size_t typeface_idx, const char16_t initial_start,
@@ -36,8 +48,7 @@ namespace eka2l1::epoc {
         , size_(font_size)
         , initial_range_(initial_start, initial_char_count)
         , typeface_idx_(typeface_idx)
-        , atlas_data_(nullptr)
-        , pack_handle_(0) {
+        , atlas_data_(nullptr) {
     }
 
     void font_atlas::init(adapter::font_file_adapter_base *adapter, const std::size_t typeface_idx, const char16_t initial_start,
@@ -48,7 +59,7 @@ namespace eka2l1::epoc {
         size_ = font_size;
         initial_range_ = { initial_start, initial_char_count };
         typeface_idx_ = typeface_idx;
-        pack_handle_ = 0;
+        pack_state_.reset();
 
         atlas_data_.reset();
     }
@@ -65,9 +76,7 @@ namespace eka2l1::epoc {
             atlas_data_.reset();
         }
 
-        if (pack_handle_) {
-            adapter_->end_get_atlas(pack_handle_);
-        }
+        pack_state_.reset();
 
         last_use_.clear();
         characters_.clear();
@@ -75,6 +84,57 @@ namespace eka2l1::epoc {
 
     int font_atlas::get_atlas_width() const {
         return common::align(ESTIMATE_MAX_CHAR_IN_ATLAS_WIDTH * size_, 1024);
+    }
+
+    bool font_atlas::begin_packing(const int width) {
+        if (!pack_state_) {
+            pack_state_ = std::make_unique<atlas_packing_state>();
+        }
+
+        // stb wants one node per atlas column to place rectangles precisely.
+        pack_state_->nodes_.resize(width);
+        pack_state_->width_ = width;
+
+        stbrp_init_target(&pack_state_->context_, width, width, pack_state_->nodes_.data(),
+            static_cast<int>(pack_state_->nodes_.size()));
+
+        return true;
+    }
+
+    bool font_atlas::pack_glyphs(const std::vector<int> &codes, adapter::character_info *infos) {
+        if (!pack_state_ || codes.empty()) {
+            return (pack_state_ != nullptr);
+        }
+
+        std::vector<eka2l1::vec2> sizes(codes.size());
+
+        if (!adapter_->measure_atlas_glyphs(typeface_idx_, codes.data(), codes.size(), metric_identifier_,
+                sizes.data())) {
+            return false;
+        }
+
+        std::vector<stbrp_rect> rects(codes.size());
+
+        for (std::size_t i = 0; i < codes.size(); i++) {
+            rects[i].x = 0;
+            rects[i].y = 0;
+            rects[i].w = static_cast<stbrp_coord>(sizes[i].x + GLYPH_PADDING * 2);
+            rects[i].h = static_cast<stbrp_coord>(sizes[i].y + GLYPH_PADDING * 2);
+        }
+
+        if (!stbrp_pack_rects(&pack_state_->context_, rects.data(), static_cast<int>(rects.size()))) {
+            // Out of room. The caller decides whether to rebuild the atlas.
+            return false;
+        }
+
+        std::vector<eka2l1::vec2> positions(codes.size());
+
+        for (std::size_t i = 0; i < codes.size(); i++) {
+            positions[i] = eka2l1::vec2(rects[i].x + GLYPH_PADDING, rects[i].y + GLYPH_PADDING);
+        }
+
+        return adapter_->render_atlas_glyphs(typeface_idx_, codes.data(), codes.size(), metric_identifier_,
+            atlas_data_.get(), { pack_state_->width_, pack_state_->width_ }, positions.data(), infos);
     }
 
     bool font_atlas::draw_text(const std::u16string &text, const eka2l1::rect &text_box, const epoc::text_alignment alignment, drivers::graphics_driver *driver, drivers::graphics_command_builder &builder, const eka2l1::vec2f scale_vector) {
@@ -89,23 +149,25 @@ namespace eka2l1::epoc {
 
         if (!atlas_data_) {
             atlas_data_ = std::make_unique<std::uint8_t[]>(width * width * adapter_->get_atlas_bitmap_bits_per_pixel() / 8);
-            auto cinfos = std::make_unique<adapter::character_info[]>(initial_range_.second);
 
-            pack_handle_ = adapter_->begin_get_atlas(atlas_data_.get(), { width, width });
+            std::vector<int> initial_codes(initial_range_.second);
 
-            if (pack_handle_ == -1) {
-                return false;
+            for (char16_t i = 0; i < initial_range_.second; i++) {
+                initial_codes[i] = initial_range_.first + i;
             }
 
-            if (!adapter_->get_glyph_atlas(pack_handle_, typeface_idx_, initial_range_.first, nullptr, initial_range_.second,
-                    metric_identifier_, cinfos.get())) {
+            std::vector<adapter::character_info> cinfos(initial_codes.size());
+
+            begin_packing(width);
+
+            if (!pack_glyphs(initial_codes, cinfos.data())) {
                 return false;
             }
 
             // initialize the last used list and character map
-            for (char16_t i = 0; i < initial_range_.second; i++) {
-                last_use_.push_back(initial_range_.first + i);
-                characters_.emplace(initial_range_.first + i, cinfos[i]);
+            for (std::size_t i = 0; i < initial_codes.size(); i++) {
+                last_use_.push_back(initial_codes[i]);
+                characters_.emplace(static_cast<char16_t>(initial_codes[i]), cinfos[i]);
             }
 
             // Submit the bitmap through another queue, in case the command list above never got submitted
@@ -138,36 +200,48 @@ namespace eka2l1::epoc {
         last_use_.erase(last_use_.end() - unique_char.size(), last_use_.end());
 
         if (!to_rast.empty()) {
-            // Try to rasterize these
-            auto cinfos = std::make_unique<adapter::character_info[]>(to_rast.size());
+            std::vector<adapter::character_info> cinfos(to_rast.size());
 
-            if (!adapter_->get_glyph_atlas(pack_handle_, typeface_idx_, 0, to_rast.data(), static_cast<char16_t>(to_rast.size()), metric_identifier_,
-                    cinfos.get())) {
-                // Try to redo the atlas, getting latest use characters.
-                adapter_->end_get_atlas(pack_handle_);
-                pack_handle_ = adapter_->begin_get_atlas(atlas_data_.get(), { width, width });
-
-                if (pack_handle_ == -1) {
-                    return false;
-                }
-
-                if (!adapter_->get_glyph_atlas(pack_handle_, typeface_idx_, 0, &last_use_[0], static_cast<char16_t>(characters_.size() - 5),
-                        metric_identifier_, cinfos.get())) {
-                    return false;
-                }
-
-                for (std::size_t i = 0; i < characters_.size() - 5; i++) {
-                    characters_[last_use_[i]] = cinfos[i];
+            if (pack_glyphs(to_rast, cinfos.data())) {
+                for (std::size_t i = 0; i < to_rast.size(); i++) {
+                    characters_.emplace(static_cast<char16_t>(to_rast[i]), cinfos[i]);
                 }
             } else {
-                // Update the characters
-                for (char16_t i = 0; i < static_cast<char16_t>(to_rast.size()); i++) {
-                    characters_.emplace(to_rast[i], cinfos[i]);
+                // Out of room: rebuild the atlas from the characters used most
+                // recently, plus the ones that did not fit. `last_use_` has the
+                // hottest first, so dropping its tail evicts the coldest.
+                std::vector<int> rebuild(last_use_.begin(),
+                    last_use_.begin() + common::min<std::size_t>(last_use_.size(), characters_.size()));
+
+                rebuild.erase(std::remove_if(rebuild.begin(), rebuild.end(), [&](const int code) {
+                    return characters_.find(static_cast<char16_t>(code)) == characters_.end();
+                }), rebuild.end());
+
+                if (rebuild.size() > EVICT_ON_REBUILD) {
+                    rebuild.resize(rebuild.size() - EVICT_ON_REBUILD);
                 }
 
-                upload_builder.update_bitmap(atlas_handle_, reinterpret_cast<const char *>(atlas_data_.get()),
-                    width * width * adapter_->get_atlas_bitmap_bits_per_pixel() / 8, { 0, 0 }, { width, width });
+                rebuild.insert(rebuild.end(), to_rast.begin(), to_rast.end());
+
+                std::vector<adapter::character_info> rebuilt(rebuild.size());
+
+                std::memset(atlas_data_.get(), 0,
+                    width * width * adapter_->get_atlas_bitmap_bits_per_pixel() / 8);
+                begin_packing(width);
+
+                if (!pack_glyphs(rebuild, rebuilt.data())) {
+                    return false;
+                }
+
+                characters_.clear();
+
+                for (std::size_t i = 0; i < rebuild.size(); i++) {
+                    characters_[static_cast<char16_t>(rebuild[i])] = rebuilt[i];
+                }
             }
+
+            upload_builder.update_bitmap(atlas_handle_, reinterpret_cast<const char *>(atlas_data_.get()),
+                width * width * adapter_->get_atlas_bitmap_bits_per_pixel() / 8, { 0, 0 }, { width, width });
         }
 
         eka2l1::vec2 cur_pos = text_box.top;

--- a/src/tests/epoc/services/fbs/linkedfont.cpp
+++ b/src/tests/epoc/services/fbs/linkedfont.cpp
@@ -23,6 +23,7 @@
 #include <services/fbs/linked_font_config.h>
 
 #include <set>
+#include <vector>
 
 using namespace eka2l1;
 
@@ -172,16 +173,39 @@ namespace {
             return advance_;
         }
 
-        std::int32_t begin_get_atlas(std::uint8_t *atlas_ptr, const eka2l1::vec2 atlas_size) override {
-            return 0;
-        }
+        std::vector<int> measured_codes_;
+        std::vector<int> rendered_codes_;
+        std::uint32_t last_atlas_metric_identifier_ = 0xFFFFFFFF;
 
-        bool get_glyph_atlas(const std::int32_t handle, const std::size_t idx, const char16_t start_code, int *unicode_point,
-            const char16_t num_code, const std::uint32_t metric_identifier, epoc::adapter::character_info *info) override {
+        bool measure_atlas_glyphs(const std::size_t idx, const int *codes, const std::size_t count,
+            const std::uint32_t metric_identifier, eka2l1::vec2 *sizes) override {
+            last_atlas_metric_identifier_ = metric_identifier;
+
+            for (std::size_t i = 0; i < count; i++) {
+                measured_codes_.push_back(codes[i]);
+                sizes[i] = codepoints_.count(codes[i]) ? eka2l1::vec2(4, 6) : eka2l1::vec2(0, 0);
+            }
+
             return true;
         }
 
-        void end_get_atlas(const std::int32_t handle) override {
+        bool render_atlas_glyphs(const std::size_t idx, const int *codes, const std::size_t count,
+            const std::uint32_t metric_identifier, std::uint8_t *atlas, const eka2l1::vec2 atlas_size,
+            const eka2l1::vec2 *positions, epoc::adapter::character_info *info) override {
+            last_atlas_metric_identifier_ = metric_identifier;
+
+            for (std::size_t i = 0; i < count; i++) {
+                rendered_codes_.push_back(codes[i]);
+
+                info[i] = {};
+                info[i].x0 = static_cast<std::uint16_t>(positions[i].x);
+                info[i].y0 = static_cast<std::uint16_t>(positions[i].y);
+                info[i].x1 = static_cast<std::uint16_t>(positions[i].x + 4);
+                info[i].y1 = static_cast<std::uint16_t>(positions[i].y + 6);
+                info[i].xadv = static_cast<float>(advance_);
+            }
+
+            return true;
         }
 
         std::optional<epoc::open_font_metrics> get_metric_with_uid(const std::size_t face_index, const std::uint32_t uid,
@@ -189,10 +213,15 @@ namespace {
             return std::nullopt;
         }
 
+        // Non-zero when this face renders at a fixed height whatever is asked
+        // for, the way a bitmap face does.
+        std::int16_t settled_height_ = 0;
+
         std::optional<epoc::open_font_metrics> get_nearest_supported_metric(const std::size_t face_index,
             const std::uint16_t targeted_font_size, std::uint32_t *metric_identifier, bool is_design_font_size) override {
             epoc::open_font_metrics metrics{};
             metrics.design_height = static_cast<std::int16_t>(targeted_font_size);
+            metrics.max_height = settled_height_ ? settled_height_ : static_cast<std::int16_t>(targeted_font_size);
 
             if (metric_identifier) {
                 *metric_identifier = targeted_font_size;
@@ -211,6 +240,7 @@ namespace {
             const std::uint16_t targeted_font_size, std::uint32_t *metric_identifier, bool is_design_font_size) override {
             epoc::open_font_metrics metrics{};
             metrics.design_height = static_cast<std::int16_t>(targeted_font_size);
+            metrics.max_height = settled_height_ ? settled_height_ : static_cast<std::int16_t>(targeted_font_size);
 
             // Whatever the size, this face only has two bitmaps.
             if (metric_identifier) {
@@ -387,6 +417,64 @@ TEST_CASE("linked_font_adapter_translates_metric_identifiers", "fbs") {
     // ...while the other component is addressed the way it expects, by size.
     REQUIRE(linked.get_glyph_advance(0, CJK_CODE, metric_identifier, false) == 13);
     REQUIRE(cjk.last_metric_identifier_ == 17);
+}
+
+TEST_CASE("linked_font_adapter_packs_each_glyph_from_the_component_that_has_it", "fbs") {
+    // The atlas is how S60 UI text actually reaches the screen, so a component
+    // whose glyphs never enter it is of no use for anything the canonical face
+    // lacks -- which is every character the typeface was linked together for.
+    fake_font_adapter latin({ LATIN_CODE }, 7);
+    fake_font_adapter cjk({ CJK_CODE }, 13);
+
+    epoc::adapter::linked_font_file_adapter linked({ { &latin, 0 }, { &cjk, 0 } }, 0, {});
+
+    const int codes[] = { LATIN_CODE, CJK_CODE };
+    eka2l1::vec2 sizes[2] = {};
+
+    REQUIRE(linked.measure_atlas_glyphs(0, codes, 2, 0, sizes));
+
+    // Each component is asked only about what it can draw, and both glyphs
+    // come back with a size.
+    REQUIRE(latin.measured_codes_ == std::vector<int>{ LATIN_CODE });
+    REQUIRE(cjk.measured_codes_ == std::vector<int>{ CJK_CODE });
+    REQUIRE(sizes[0].x > 0);
+    REQUIRE(sizes[1].x > 0);
+
+    std::vector<std::uint8_t> atlas(64 * 64, 0);
+    const eka2l1::vec2 positions[] = { { 1, 2 }, { 20, 30 } };
+    epoc::adapter::character_info info[2] = {};
+
+    REQUIRE(linked.render_atlas_glyphs(0, codes, 2, 0, atlas.data(), { 64, 64 }, positions, info));
+
+    REQUIRE(latin.rendered_codes_ == std::vector<int>{ LATIN_CODE });
+    REQUIRE(cjk.rendered_codes_ == std::vector<int>{ CJK_CODE });
+
+    // Placement is reported back in the caller's order, not the order the
+    // components happened to be consulted in.
+    REQUIRE(info[0].x0 == 1);
+    REQUIRE(info[0].y0 == 2);
+    REQUIRE(info[1].x0 == 20);
+    REQUIRE(info[1].y0 == 30);
+}
+
+TEST_CASE("linked_font_adapter_sizes_fallbacks_off_the_canonical", "fbs") {
+    // A bitmap canonical stocks a handful of sizes and takes the nearest, so a
+    // request it cannot honour costs it nothing. A scalable fallback handed
+    // that same request renders to it exactly -- at two pixels the glyphs come
+    // out one pixel square. What keeps a linked typeface looking like one face
+    // is sizing the fallback off what the canonical settled on.
+    indexed_font_adapter device({ LATIN_CODE }, 7);
+    device.settled_height_ = 13;
+
+    fake_font_adapter cjk({ CJK_CODE }, 13);
+
+    epoc::adapter::linked_font_file_adapter linked({ { &device, 0 }, { &cjk, 0 } }, 0, {});
+
+    std::uint32_t metric_identifier = 0;
+    REQUIRE(linked.get_nearest_supported_metric(0, 2, &metric_identifier, false).has_value());
+
+    REQUIRE(linked.get_glyph_advance(0, CJK_CODE, metric_identifier, false) == 13);
+    REQUIRE(cjk.last_metric_identifier_ == 13);
 }
 
 TEST_CASE("linked_font_adapter_asks_components_for_the_face_format", "fbs") {


### PR DESCRIPTION
Three defects in linked typefaces, all of which surface the same way: glyphs
the canonical component cannot supply simply do not appear.

## The atlas could only ever be filled by one adapter

S60 UI text is painted host-side through `font_atlas`, and
`linked_font_file_adapter` forwarded `begin_get_atlas` / `get_glyph_atlas` /
`end_get_atlas` straight to its canonical component. A fallback's glyphs could
never enter the atlas, so anything the canonical face lacks drew as `.notdef`.
The guest-side rasterize path dispatched per codepoint all along, which is what
made this confusing to chase: the server returns perfectly good bitmaps for
characters that never reach the screen.

The packing was in the wrong place. Those three calls keep the rectangle packer
inside the adapter, and the packers cannot be shared — FreeType and gdr keep an
`stbrp_context`, stb a `stbtt_pack_context` wrapped around one. So the interface
is now two calls that ask an adapter only for what it alone knows:

```cpp
measure_atlas_glyphs(idx, codes, count, metric_id, sizes);
render_atlas_glyphs(idx, codes, count, metric_id, atlas, atlas_size, positions, info);
```

`font_atlas` owns the packer, measures what it is about to add, packs in one
pass and tells each component where to draw. The linked adapter reduces to the
same per-codepoint dispatch `get_glyph_bitmap()` was already using. All three
adapters already worked in these two phases internally, so each was a matter of
splitting an existing function — stb_truetype even publishes
`PackFontRangesGatherRects` / `PackFontRangesRenderIntoRects` around the packing
step precisely so a caller can substitute its own.

Components writing a different pixel format stay out of the atlas: a gdr face
backed by an imported TrueType one would otherwise scribble 32bpp over an 8bpp
buffer.

## Fallbacks were sized off the request, not off the canonical

`get_nearest_supported_metric()` had every component translate the size the
*client* asked for. A bitmap canonical stocks a handful of fixed sizes and takes
the nearest, so a request it cannot honour costs it nothing — X-Plore on an N70
asks for a height of 2 while the canonical renders its bitmap font at 13 — but a
scalable fallback handed that same request obliges exactly, and its glyphs come
out one pixel square.

Fallbacks now translate the size the canonical settled on. A linked typeface has
to look like one face.

## `derive_design_height_from_max_height()` can hang

Ported from Symbian's `FTRAST2.CPP`, it walks its height down in a loop with no
lower bound. `FT_Set_Pixel_Sizes` fails at zero and leaves the loop variable
unchanged, so an unusably small request spins forever. It stops at one pixel now.

## Also fixed while rewriting the atlas

- The rebuild path (taken when the atlas fills up) wrote `characters_.size() - 5`
  entries into an array sized `to_rast.size()` — an overflow whenever more
  characters were cached than were being added — and never added the characters
  that triggered the rebuild in the first place.
- Glyph padding was per-adapter and inconsistent (5 pixels in FreeType, 1 in stb,
  none in gdr). It belongs to whoever packs, so it is uniform now.

## Testing

Two new cases in `linkedfont.cpp`, both of which fail if the corresponding fix is
reverted:

- each component is asked only for the glyphs it can draw, and placement comes
  back in the caller's order rather than the order components were consulted in;
- a fallback is sized off the canonical rather than off the request (reverting
  gives `2 == 13`, the N70 numbers).

`ekatests` is green (182 cases, 3330 assertions). The existing `fake_font_adapter`
needed updating for the new interface, which is where the coverage came from.

Verified in the emulator on a Chinese N95 (ZipManager and Calculator), a 6680 for
the gdr path, and X-Plore switched to Chinese on both an N-Gage QD and an N70 —
the last two being the case that exposed the sizing bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Y5HxNrqcezzvc4nNshJw7