### PR TITLE
ci: stop building macOS without the scripting subsystem

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,7 +188,7 @@ jobs:
       if: matrix.label == 'windows'
 
     - name: CMake configure (macOS)
-      run: cmake -B build -DCI=ON -DEKA2L1_ENABLE_SCRIPTING_ABILITY=OFF -DEKA2L1_DEPLOY_DMG=ON -DEKA2L1_ENABLE_UNEXPECTED_EXCEPTION_HANDLER=ON -DEKA2L1_ENABLE_DISCORD_RICH_PRESENCE=ON -DCMAKE_PREFIX_PATH=${{ env.QT_ROOT_DIR }} -DCMAKE_BUILD_TYPE=${{ env.config }}
+      run: cmake -B build -DCI=ON -DEKA2L1_DEPLOY_DMG=ON -DEKA2L1_ENABLE_UNEXPECTED_EXCEPTION_HANDLER=ON -DEKA2L1_ENABLE_DISCORD_RICH_PRESENCE=ON -DCMAKE_PREFIX_PATH=${{ env.QT_ROOT_DIR }} -DCMAKE_BUILD_TYPE=${{ env.config }}
       if: matrix.label == 'macos'
 
     - name: CMake configure (Windows)


### PR DESCRIPTION
The macOS job has configured with `EKA2L1_ENABLE_SCRIPTING_ABILITY=OFF` since c11a459 (2021), when LuaJIT would not build there. Every other desktop target leaves the option at its `ON` default, so the shipped compatibility patches under `scripts/` only ever ran on Windows and Linux.

Nothing about the DMG hints at that. `src/emu/qt/CMakeLists.txt` stages `src/scripts/` into the bundle unconditionally, and `main.cpp` copies it on to the user data directory on every launch, so the `.lua` files are present and look installed — but `ENABLE_SCRIPTING` is undefined, `system::get_scripts()` returns `nullptr`, and no breakpoint or IPC hook is ever registered. A patch that works on Linux silently does nothing on macOS. That is how this was found: #637's `s60v3_empty_avkon_menu_fix` took effect on Linux and iOS and not on the macOS build of the same commit.

LuaJIT builds and runs fine on macOS today: v2.1 ROLLING maps its generated code with `MAP_JIT` and flips `pthread_jit_write_protect_np`, the same thing the dynarmic backend already does on Apple silicon, and the ad-hoc signature `macdeployqt -codesign=-` applies does not enable the hardened runtime that would refuse it.

### Verification

Local macOS arm64, with the job's own flags (`-DCI=ON -DCMAKE_BUILD_TYPE=Release`, `MACOSX_DEPLOYMENT_TARGET=12.0`):

- `libluajit` compiles from a clean build directory
- `eka2l1_qt` links it through the `-force_load` of `libscripting`
- `ctest` passes
- the ad-hoc signed bundle loads all six shipped modules at startup:

```
[Scripting]: Module s3_driver_patch loaded!
[Scripting]: Module wh40k_slow_load_fix loaded!
[Scripting]: Module hero_of_sparta_crash_fix loaded!
[Scripting]: Module s60v3_empty_avkon_menu_fix loaded!
[Scripting]: Module eternal_legacy_crash_fix loaded!
[Scripting]: Module aq_crash_fix loaded!
```

Each of those modules registers its hooks by handing a Lua closure to a C function pointer, i.e. through an FFI callback, so reaching "loaded" is also proof the write-execute path works at runtime and not just at build time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TqCyftG2ebMo4TDN2AuNBb