### PR TITLE
ci: ship the macOS DMG itself, under its real architecture

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -249,7 +249,15 @@ jobs:
       with:
         name: eka2l1-${{ steps.git_short_sha.outputs.value }}-${{ matrix.label }}
         path: build/bin
-      if: matrix.label != 'linux'
+      if: matrix.label == 'windows'
+
+    # The bundle left in build/bin is what macdeployqt packed into the DMG, not
+    # a second deliverable, and the DMG is what people install from.
+    - uses: actions/upload-artifact@v4
+      with:
+        name: eka2l1-${{ steps.git_short_sha.outputs.value }}-${{ matrix.label }}
+        path: build/bin/EKA2L1.dmg
+      if: matrix.label == 'macos'
 
     - uses: actions/upload-artifact@v4
       with:
@@ -470,7 +478,7 @@ jobs:
     - name: Rename artifacts for release
       run: |
         (cd windows-files && zip -r ../EKA2L1-Windows-x86_64.zip .)
-        (cd mac-files && zip -r ../EKA2L1-MacOS-x86_64.zip .)
+        mv mac-files/EKA2L1.dmg EKA2L1-MacOS-arm64.dmg
         mv eka2l1-qt-x64.AppImage EKA2L1-Linux-x86_64.AppImage
         mv eka2l1-${{ steps.git_short_sha.outputs.value }}.apk EKA2L1-Android.apk
 
@@ -489,7 +497,7 @@ jobs:
         prerelease: false
         files: |
           EKA2L1-Windows-x86_64.zip
-          EKA2L1-MacOS-x86_64.zip
+          EKA2L1-MacOS-arm64.dmg
           EKA2L1-Linux-x86_64.AppImage
           EKA2L1-Android.apk
           EKA2L1-iOS-unsigned.ipa

--- a/src/emu/qt/CMakeLists.txt
+++ b/src/emu/qt/CMakeLists.txt
@@ -353,9 +353,6 @@ if(APPLE)
                 -dmg
                 -always-overwrite
                 -codesign=-)
-
-        add_custom_command(TARGET eka2l1_qt POST_BUILD
-            COMMAND rm -rf "${CMAKE_BINARY_DIR}/bin/EKA2L1.app")
     endif()
 endif()
 


### PR DESCRIPTION
Three things are wrong with the macOS half of the rolling release, and they share a cause. (This PR started as a one-line rename; investigating why the zip also contained a hollow `.app` turned up the other two.)

### 1. It is not x86_64

The asset is called `EKA2L1-MacOS-x86_64.zip`, but the job has not produced an x86_64 binary since the runner moved to Apple silicon:

```
$ lipo -info EKA2L1.app/Contents/MacOS/EKA2L1     # from the current continous release
Non-fat file: EKA2L1.app/Contents/MacOS/EKA2L1 is architecture: arm64
```

Nor could it be anything else: `src/external/CMakeLists.txt` links the arm64-only ffmpeg set whenever `CMAKE_SYSTEM_PROCESSOR` is `arm64`, and nothing sets `CMAKE_OSX_ARCHITECTURES`, so the build is thin by construction. The universal binaries you can find inside the bundle — `QtCore`, `SDL2`, `libqcocoa` — are Qt's own prebuilt frameworks and say nothing about what we compiled.

The name is not merely stale: it sends Intel users to a download that will not launch on their machine.

### 2. The zip ships a hollow app next to the DMG

```
EKA2L1-MacOS-x86_64.zip
├── EKA2L1.dmg
├── EKA2L1.app/Contents/Info.plist      <- and three empty directories, nothing else
└── patch/                              <- already inside the DMG's bundle
```

CMake writes a bundle's `Info.plist` and directory skeleton during **generate**, not as a build-graph output (`ninja -t query bin/EKA2L1.app/Contents/Info.plist` → `unknown target`). Delete `bin/EKA2L1.app`, re-run `cmake` without building, and the skeleton is back. The `POST_BUILD` `rm -rf bin/EKA2L1.app` then deletes the whole bundle, and a later regenerate puts the skeleton back — into an artifact that was supposed to contain only the DMG.

### 3. That rm breaks incremental builds

The `Info.plist` it takes with it is never restored by any build rule, so the *next* local build of an already-deployed tree dies:

```
-- Fixing up application bundle: .../bin/EKA2L1.app
CMake Error at cmake/DolphinPostprocessBundle.cmake:40 (_message):
  error: fixup_bundle: not a valid bundle
```

CI never hits this because it always configures a fresh tree; developers do.

### The change

Drop the rm, upload `build/bin/EKA2L1.dmg` rather than all of `build/bin`, and publish that DMG directly instead of zipping a directory that was only ever a build tree. macOS users get the disk image they would mount anyway, named for the architecture it actually is: **`EKA2L1-MacOS-arm64.dmg`**.

Nothing is lost by dropping the top-level `patch/`: the DMG's bundle already carries all 14 patch DLLs in `Contents/MacOS/patch`.

### Verification

On arm64 with the job's own generator and flags (Unix Makefiles — CI's default, not Ninja — Release, `MACOSX_DEPLOYMENT_TARGET=12.0`):

- **before**: clean configure + `cmake --build --target eka2l1_qt ekatests` + `ctest` reproduces the hollow bundle exactly, matching the published zip
- **after**: `build/bin` holds a complete `EKA2L1.app` and `EKA2L1.dmg`
- a second incremental build succeeds instead of failing in `fixup_bundle`
- re-running `macdeployqt` over the already-deployed bundle is idempotent: DMG size stable across three passes (71,505,455 → 71,508,411 bytes), no nested `Frameworks`

Windows and Linux are named correctly and are untouched.

### Two notes for maintainers

- `softprops/action-gh-release` does not prune assets it no longer uploads, so the old `EKA2L1-MacOS-x86_64.zip` will sit next to the new DMG until someone runs `gh release delete-asset continous EKA2L1-MacOS-x86_64.zip`.
- The in-app updater is unaffected, because it is already broken independently of this: `update_dialog.cpp:64-71` looks for `macos-latest.zip` / `windows-latest.zip` / `ubuntu-latest.zip`, and no asset by any of those names has been published for a long time — every platform hits "Can't find the download link of newest update for your platform!". Worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TqCyftG2ebMo4TDN2AuNBb