### PR TITLE
qt: Fix the update check, and let every desktop use it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -475,6 +475,8 @@ jobs:
       with:
         name: "eka2l1-${{ steps.git_short_sha.outputs.value }}-ios-device"
 
+    # get_platform_release_filename() in src/emu/qt/src/update_dialog.cpp looks
+    # the asset up by this exact name, so renaming one means renaming both.
     - name: Rename artifacts for release
       run: |
         (cd windows-files && zip -r ../EKA2L1-Windows-x86_64.zip .)

--- a/src/emu/qt/include/qt/update_dialog.h
+++ b/src/emu/qt/include/qt/update_dialog.h
@@ -41,6 +41,7 @@ private:
 
     std::string new_commit_hash_;
     QString download_url_;
+    QString release_page_url_;
     QNetworkReply *download_reply_;
     QFile *downloaded_file_;
 

--- a/src/emu/qt/src/update_dialog.cpp
+++ b/src/emu/qt/src/update_dialog.cpp
@@ -61,13 +61,15 @@ static const char *UPDATE_FILE_STORE_PATH = "staging\\update.zip";
 static const char *INVALID_JSON_ERR_STR = "Invalid response from GitHub about newest update! Please check your internet connection!";
 static const char *NO_AUTO_CHECK_UPDATE_SETTING = "noAutoCheckUpdate";
 
+// These have to match the names the "roll-release" job of .github/workflows/build.yml
+// uploads to the rolling release, or the updater will never find anything to download.
 static QString get_platform_release_filename() {
 #if EKA2L1_PLATFORM(WIN32)
-    return QString("windows-latest.zip");
+    return QString("EKA2L1-Windows-x86_64.zip");
 #elif EKA2L1_PLATFORM(UNIX)
-    return QString("ubuntu-latest.zip");
+    return QString("EKA2L1-Linux-x86_64.AppImage");
 #else
-    return QString("macos-latest.zip");
+    return QString("EKA2L1-MacOS-arm64.dmg");
 #endif
 }
 
@@ -76,7 +78,8 @@ update_dialog::update_dialog(QWidget *parent)
     , ui_(new Ui::update_dialog)
     , access_manager_(new QNetworkAccessManager(this))
     , download_reply_(nullptr)
-    , downloaded_file_(nullptr) {
+    , downloaded_file_(nullptr)
+    , explicit_up_(false) {
     ui_->setupUi(this);
     ui_->cancel_button->hide();
     ui_->download_progress_bar->hide();
@@ -102,16 +105,29 @@ update_dialog::~update_dialog() {
     delete access_manager_;
 }
 
+// Both of these end the update check, so they also close the dialog: an
+// automatic check keeps it hidden, and a hidden dialog that is never closed is
+// never deleted either (WA_DeleteOnClose).
 void update_dialog::report_info(const QString &info_string) {
+    LOG_INFO(eka2l1::FRONTEND_UI, "Update check: {}", info_string.toStdString());
+
     if (explicit_up_) {
         QMessageBox::information(this, tr("Update success"), info_string);
     }
+
+    close();
 }
 
 void update_dialog::report_error(const QString &info_string) {
+    // An automatic check shows nothing, so the log is the only trace of why it
+    // gave up.
+    LOG_ERROR(eka2l1::FRONTEND_UI, "Update check failed: {}", info_string.toStdString());
+
     if (explicit_up_) {
         QMessageBox::critical(this, tr("Update failed"), info_string);
     }
+
+    close();
 }
 
 void update_dialog::on_tag_request_complete(QNetworkReply *reply) {
@@ -140,7 +156,6 @@ void update_dialog::on_tag_request_complete(QNetworkReply *reply) {
                         tag_download_link_request();
                     } else {
                         report_info(tr("The emulator is already updated to lastest version!"));
-                        close();
                     }
 
                     found = true;

--- a/src/emu/qt/src/update_dialog.cpp
+++ b/src/emu/qt/src/update_dialog.cpp
@@ -27,6 +27,8 @@
 #include <QtCore/QJsonArray>
 #include <QtCore/QJsonObject>
 #include <QMessageBox>
+#include <QDesktopServices>
+#include <QUrl>
 
 #include <common/algorithm.h>
 #include <common/configure.h>
@@ -44,19 +46,39 @@
 #include <QProcess>
 #include <QSettings>
 
+// Installing an update in place is Windows-only: it hands the downloaded zip to
+// updater.exe, a separate program the build only produces for Windows, and that
+// program overwrites an install made of loose files. The other desktops ship one
+// AppImage and an ad-hoc signed .app inside a DMG, neither of which that
+// mechanism can unpack over an existing install.
 #if EKA2L1_PLATFORM(WIN32) && BUILD_FOR_USER
 #define ENABLE_UPDATER 1
 #else
 #define ENABLE_UPDATER 0
 #endif
 
+// Checking, however, is three GitHub requests and nothing platform specific, so
+// every desktop can tell the user a new build exists and hand them the download.
+// Android is __unix__ too, and ships through its own store, so it is excluded.
+#if (EKA2L1_PLATFORM(WIN32) || EKA2L1_PLATFORM(MACOS) || (EKA2L1_PLATFORM(UNIX) && !EKA2L1_PLATFORM(ANDROID))) && BUILD_FOR_USER
+#define ENABLE_UPDATE_CHECK 1
+#else
+#define ENABLE_UPDATE_CHECK 0
+#endif
+
 // Code takes many reference from DuckStation!
-static const char *TAG_REQUEST_GET_URL = "https://api.github.com/repos/eka2l1/eka2l1/tags";
 static const char *TAG_RELEASE_INFO_REQUEST_GET_URL = "https://api.github.com/repos/eka2l1/eka2l1/releases/tags/%1";
 static const char *COMMITS_COMPARE_REQUEST_GET_URL = "https://api.github.com/repos/eka2l1/eka2l1/compare/%1...%2";
 static const char *UPDATE_TAG_NAME = "continous";
+
+#if ENABLE_UPDATE_CHECK
+static const char *TAG_REQUEST_GET_URL = "https://api.github.com/repos/eka2l1/eka2l1/tags";
+#endif
+
+#if ENABLE_UPDATER
 static const char *UPDATE_FILE_STORE_FOLDER = "staging";
 static const char *UPDATE_FILE_STORE_PATH = "staging\\update.zip";
+#endif
 
 static const char *INVALID_JSON_ERR_STR = "Invalid response from GitHub about newest update! Please check your internet connection!";
 static const char *NO_AUTO_CHECK_UPDATE_SETTING = "noAutoCheckUpdate";
@@ -188,21 +210,25 @@ void update_dialog::on_tag_download_link_request_complete(QNetworkReply *reply) 
             QJsonArray asset_array = doc["assets"].toArray();
             const QString platform_asset_name = get_platform_release_filename();
 
-            bool found_plat = false;
+            release_page_url_ = doc["html_url"].toString();
 
             for (const QJsonValue &asset: asset_array) {
                 if (asset["name"].toString() == platform_asset_name) {
                     download_url_ = asset["browser_download_url"].toString();
-                    found_plat = true;
-
-                    changelog_request();
-
                     break;
                 }
             }
 
-            if (!found_plat) {
+            // The installer needs the file itself, so a missing asset is fatal
+            // there. A platform that only opens the download can fall back to the
+            // release page instead, which keeps a future rename from silencing
+            // the check outright.
+            const bool can_fall_back_to_page = !ENABLE_UPDATER && !release_page_url_.isEmpty();
+
+            if (download_url_.isEmpty() && !can_fall_back_to_page) {
                 report_error(tr("Can't find the download link of newest update for your platform!"));
+            } else {
+                changelog_request();
             }
         } else {
             report_error(tr(INVALID_JSON_ERR_STR));
@@ -269,12 +295,15 @@ void update_dialog::changelog_request() {
 }
 
 void update_dialog::check_for_update(const bool explicit_request) {
-#if !ENABLE_UPDATER
+#if !ENABLE_UPDATE_CHECK
     if (explicit_request) {
         QMessageBox::information(this, tr("Updater unsupported"), tr("The updater is not yet supported on your platform!"));
-        close();
-        return;
     }
+
+    // Unconditional: an automatic check used to return here without closing,
+    // and a dialog that never closes is never deleted (WA_DeleteOnClose).
+    close();
+    return;
 #else
     if (strcmp(GIT_COMMIT_HASH, "Stable") == 0) {
         close();
@@ -312,6 +341,12 @@ void update_dialog::on_new_update_download_progress_report(quint64 received, qui
 }
 
 void update_dialog::on_update_button_clicked() {
+#if !ENABLE_UPDATER
+    // Nothing here can install over an AppImage or a mounted DMG, so open the
+    // download and let the user install it the way they installed the emulator.
+    QDesktopServices::openUrl(QUrl(download_url_.isEmpty() ? release_page_url_ : download_url_));
+    close();
+#else
     QDir().mkdir(UPDATE_FILE_STORE_FOLDER);
     downloaded_file_ = new QFile(UPDATE_FILE_STORE_PATH);
     if (!downloaded_file_->open(QIODevice::WriteOnly)) {
@@ -333,6 +368,7 @@ void update_dialog::on_update_button_clicked() {
 
     connect(download_reply_, &QNetworkReply::downloadProgress, this, &update_dialog::on_new_update_download_progress_report);
     connect(download_reply_, &QNetworkReply::readyRead, this, &update_dialog::on_new_update_download_read_ready);
+#endif
 }
 
 void update_dialog::on_ignore_button_clicked() {
@@ -360,7 +396,9 @@ void update_dialog::on_cancel_button_clicked() {
         downloaded_file_ = nullptr;
     }
 
+#if ENABLE_UPDATER
     QDir().remove(UPDATE_FILE_STORE_PATH);
+#endif
 
     revert_ui_to_update_wait();
     close();


### PR DESCRIPTION
Two commits: the first fixes an update check that has been silently broken since April 2024, the second makes it reachable on the desktops where it was compiled out.

## 1. The check has not found an update since April 2024

`get_platform_release_filename()` asks the `continous` release for an asset called `windows-latest.zip`, but [76a4696a4 "ci: Rename artifacts"](https://github.com/EKA2L1/EKA2L1/commit/76a4696a4) renamed the published assets to `EKA2L1-Windows-x86_64.zip` and friends without touching the emulator side. The asset scan never matches, and the check stops one step before the download link. Against the live release, all three names it looks for (`windows-latest.zip`, `ubuntu-latest.zip`, `macos-latest.zip`) are absent.

It fails invisibly, because an automatic check reports nothing — the dialog stays hidden, no message box appears, nothing is logged. It also leaks: none of the six error paths closed the dialog, and one that is never closed is never deleted under `WA_DeleteOnClose`.

- Name the assets the way the `roll-release` job names them, with a comment on each side pointing at the other.
- Log why the check gave up, so an automatic one leaves a trace.
- Close the dialog from `report_info()` / `report_error()`, the two ways the check ends.
- Initialise `explicit_up_`, which `check_for_update()` leaves untouched when the updater is compiled out and both reporters read.

## 2. Only the Windows branch of that function was ever reachable

`ENABLE_UPDATER` is `EKA2L1_PLATFORM(WIN32) && BUILD_FOR_USER`, and it gates the entire check. On macOS and Linux `check_for_update()` answers *"the updater is not yet supported on your platform"* and stops, so the other two branches never named anything.

That guard conflates two things:

| | what it needs |
| --- | --- |
| checking | three GitHub requests, nothing platform specific |
| installing | `updater.exe`, built only under `if (WIN32)`, overwriting an install made of loose files |

Installing is the genuinely Windows-only half. Linux ships one AppImage and macOS an ad-hoc signed `.app` inside a DMG (`macdeployqt -dmg -codesign=-`); neither can be unpacked over an existing install by that mechanism.

So the guard is split. `ENABLE_UPDATE_CHECK` covers every desktop — Android is `__unix__` too and ships through its own store, so it is excluded — while `ENABLE_UPDATER` keeps meaning *can install in place*. Where it cannot, the update button opens the download in the browser and the user installs it the way they installed the emulator. macOS and Linux users now learn a new build exists and see the changelog, instead of being told the updater does not support them.

The asset lookup also remembers the release's `html_url`. The installer needs the file itself, so a missing asset stays fatal there, but a platform that only opens a link falls back to the release page — had that existed, the rename fixed above would have degraded instead of going silent.

### Not in scope

**Automatic in-place installation on macOS and Linux.** Replacing a running AppImage, or mounting a DMG and swapping an ad-hoc signed `.app` under Gatekeeper and quarantine, are each a mechanism of their own, and destructive if wrong. I would rather not land file-replacement code I cannot verify on those platforms. Opening the download is the honest intermediate step, and `on_new_update_download_finished()`'s non-Windows path — which would have emitted `exit_for_update_request()` and closed the emulator having installed nothing — is now unreachable rather than merely unused.

## Verification

The request chain was replayed against the live release. All three platforms resolve to a real `browser_download_url`: Windows installs in place, Linux and macOS open the AppImage and the DMG.

The macOS one is worth a note. It was replayed twice. The first time the release still carried `EKA2L1-MacOS-x86_64.zip`, because the DMG rename in 5128e4282 had not rolled out — its `roll-release` could not move the tag, having been overtaken by another workflow-touching merge a minute later. macOS took the release-page fallback then, which is exactly the degradation it exists for. The next master run rolled successfully and `EKA2L1-MacOS-arm64.dmg` now exists, so the exact-name path is what runs today.

`update_dialog.cpp` was compiled in all three macro shapes, warning-clean under `-Wall`:

| | `ENABLE_UPDATE_CHECK` | `ENABLE_UPDATER` | |
| --- | --- | --- | --- |
| local desktop build | 0 | 0 | ✅ |
| CI macOS / Linux | 1 | 0 | ✅ |
| Windows | 1 | 1 | ✅ |

No `tr()` strings were added or changed, so the translations are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016b2tiDhKzfizAX3DDUkWUc
