### PR TITLE
qt: return to the application list when a game exits

### DIFF
--- a/src/emu/common/src/watcher_unix.cpp
+++ b/src/emu/common/src/watcher_unix.cpp
@@ -20,17 +20,32 @@
 #include "watcher_unix.h"
 #include <common/log.h>
 
+#include <cerrno>
+#include <poll.h>
+#include <sys/eventfd.h>
 #include <sys/inotify.h>
 
 namespace eka2l1::common {
     static constexpr std::size_t EVENT_MAX_SIZE = sizeof(struct inotify_event) + 16;
 
     directory_watcher_impl::directory_watcher_impl()
-        : should_stop(false) {
+        : stop_event_(-1)
+        , should_stop(false) {
         instance_ = inotify_init();
 
         if (instance_ == -1) {
             LOG_ERROR(COMMON, "Error creating INotify instance!");
+            return;
+        }
+
+        stop_event_ = eventfd(0, EFD_CLOEXEC);
+
+        if (stop_event_ == -1) {
+            LOG_ERROR(COMMON, "Error creating the watcher stop event!");
+
+            close(instance_);
+            instance_ = -1;
+
             return;
         }
 
@@ -53,11 +68,43 @@ namespace eka2l1::common {
             };
 
             while (!should_stop) {
+                struct pollfd waits[2];
+
+                waits[0].fd = instance_;
+                waits[0].events = POLLIN;
+                waits[0].revents = 0;
+                waits[1].fd = stop_event_;
+                waits[1].events = POLLIN;
+                waits[1].revents = 0;
+
+                if (poll(waits, 2, -1) == -1) {
+                    if (errno == EINTR) {
+                        continue;
+                    }
+
+                    LOG_ERROR(COMMON, "Error waiting for notify event!");
+                    break;
+                }
+
+                // The destructor asked us to leave. Check this before draining inotify so
+                // that a folder still being touched can not keep the thread here.
+                if (waits[1].revents & POLLIN) {
+                    break;
+                }
+
+                if (!(waits[0].revents & POLLIN)) {
+                    continue;
+                }
+
                 const ssize_t length = read(instance_, &events_[0], events_.size());
 
-                if (length == -1) {
+                if (length <= 0) {
+                    if ((length == -1) && ((errno == EINTR) || (errno == EAGAIN))) {
+                        continue;
+                    }
+
                     LOG_ERROR(COMMON, "Error reading notify event!");
-                    should_stop = true;
+                    break;
                 }
 
                 std::size_t i = 0;
@@ -65,7 +112,7 @@ namespace eka2l1::common {
                 int last_wd = -1;
 
                 // Parse all event
-                while (i < length) {
+                while (i < static_cast<std::size_t>(length)) {
                     struct inotify_event *evt = reinterpret_cast<struct inotify_event *>(&events_[i]);
 
                     directory_change change;
@@ -118,13 +165,29 @@ namespace eka2l1::common {
     }
 
     directory_watcher_impl::~directory_watcher_impl() {
+        if (instance_ == -1) {
+            return;
+        }
+
         for (auto &wd : container_) {
             inotify_rm_watch(instance_, wd);
         }
 
         should_stop = true;
-        wait_thread_->join();
 
+        // Kick the watch thread out of poll(). Without this it stays blocked until some
+        // watched folder happens to change, and the join below never returns: emulator
+        // shutdown runs this destructor, so the whole process hangs on exit.
+        const std::uint64_t wake = 1;
+        if (write(stop_event_, &wake, sizeof(wake)) != static_cast<ssize_t>(sizeof(wake))) {
+            LOG_ERROR(COMMON, "Error waking the watch thread up for shutdown!");
+        }
+
+        if (wait_thread_) {
+            wait_thread_->join();
+        }
+
+        close(stop_event_);
         close(instance_);
     }
 

--- a/src/emu/common/src/watcher_unix.h
+++ b/src/emu/common/src/watcher_unix.h
@@ -40,6 +40,10 @@ namespace eka2l1::common {
 
         int instance_;
 
+        // Written to by the destructor so the watch thread wakes up from its poll instead
+        // of sitting in inotify's read() forever.
+        int stop_event_;
+
         std::atomic<bool> should_stop;
 
         std::vector<int> container_;

--- a/src/emu/qt/include/qt/mainwindow.h
+++ b/src/emu/qt/include/qt/mainwindow.h
@@ -210,7 +210,7 @@ private slots:
     void on_btnet_friends_dialog_requested_from_conf();
     void on_action_stretch_to_fill_toggled(bool checked);
     void on_question_dialog_open_request();
-    void on_app_exited(eka2l1::kernel::process *proc);
+    void on_app_exited(const int exit_type, const int exit_reason, const QString exit_category);
 
 signals:
     void progress_dialog_change(const std::size_t now, const std::size_t total);
@@ -225,7 +225,7 @@ signals:
     void input_dialog_close_request();
     void install_ngage_game_name_available(QString name);
     void question_dialog_open_request();
-    void app_exited(eka2l1::kernel::process *proc);
+    void app_exited(const int exit_type, const int exit_reason, const QString exit_category);
 
 public:
     main_window(QApplication &app, QWidget *parent, eka2l1::desktop::emulator &emulator_state);

--- a/src/emu/qt/src/mainwindow.cpp
+++ b/src/emu/qt/src/mainwindow.cpp
@@ -1083,21 +1083,22 @@ void main_window::switch_to_game_display_mode() {
     on_fullscreen_toogled(ui_->action_fullscreen->isChecked());
 }
 
-void main_window::on_app_exited(eka2l1::kernel::process *target_proc) {
+void main_window::on_app_exited(const int exit_type, const int exit_reason, const QString exit_category) {
+    const eka2l1::kernel::entity_exit_type exit_type_enum = static_cast<eka2l1::kernel::entity_exit_type>(exit_type);
     bool shown_msg = false;
 
-    if (target_proc->get_exit_type() == eka2l1::kernel::entity_exit_type::kill) {
-        if ((target_proc->get_exit_reason() == 0) || (target_proc->get_exit_category() == u"None")) {
+    if (exit_type_enum == eka2l1::kernel::entity_exit_type::kill) {
+        if ((exit_reason == 0) || (exit_category == QStringLiteral("None"))) {
             tray_icon_->showMessage(tr("Application exited"), tr("The application exited normally"), emu_icon_, 1500);
             shown_msg = true;
         }
     }
 
     if (!shown_msg) {
-        QString category_exit = QString::fromStdU16String(target_proc->get_exit_category());
-        int reason_exit = target_proc->get_exit_reason();
+        const QString &category_exit = exit_category;
+        const int reason_exit = exit_reason;
 
-        switch (target_proc->get_exit_type()) {
+        switch (exit_type_enum) {
         case eka2l1::kernel::entity_exit_type::kill:
             tray_icon_->showMessage(tr("Application exited"), tr("The application was killed with code: %1/%2").arg(category_exit).arg(reason_exit), emu_icon_, 1500);
             break;
@@ -1123,7 +1124,15 @@ void main_window::on_app_exited(eka2l1::kernel::process *target_proc) {
 }
 
 std::function<void(eka2l1::kernel::process *)> main_window::get_process_exit_callback() {
-    return [this](eka2l1::kernel::process *proc) { emit app_exited(proc); };
+    // Snapshot the exit details here rather than handing the GUI thread a process pointer.
+    // The callback runs from process::kill on the emulator thread and the process is torn
+    // down as soon as it returns, so by the time the queued slot runs the pointer is stale.
+    // Qt also refuses to queue an unregistered pointer type, which used to drop the signal
+    // entirely and leave the window stuck on the dead app instead of the application list.
+    return [this](eka2l1::kernel::process *proc) {
+        emit app_exited(static_cast<int>(proc->get_exit_type()), proc->get_exit_reason(),
+            QString::fromStdU16String(proc->get_exit_category()));
+    };
 }
 
 void main_window::set_discord_presence_current_playing(const std::string &name) {


### PR DESCRIPTION
Quitting a game from inside the game leaves the emulator on a black screen instead of the application list. Closing the window from there sometimes fails to end the process as well.

Two independent defects on the same path.

## The exit notification never reaches the GUI thread

**Symptom.** Quit Snakes on a 5320 (Quit → Yes). The emulated screen goes black, the frontend keeps drawing it at full frame rate, and the application list never comes back.

**Root cause.** `main_window` learns about a guest process exiting through a `kernel::process` logon callback, which runs on the emulator thread inside `process::kill`. It forwards that to the GUI thread as `emit app_exited(proc)` over a `Qt::QueuedConnection`. Queueing a call means copying its arguments, and Qt has no metatype for `eka2l1::kernel::process *`, so it discards the call instead of delivering it:

```
qt.core.qobject.connect: QObject::connect: Cannot queue arguments of type 'eka2l1::kernel::process*'
(Make sure 'eka2l1::kernel::process*' is registered using qRegisterMetaType().)
```

One line per game exit. `on_app_exited` is the only caller of `on_restart_requested()`, which resets the system and rebuilds the application list, so none of that runs.

**Fix.** Registering the pointer type would be the small fix and the wrong one — the process is torn down as soon as the callback returns, so a queued slot would dereference a stale pointer, and `on_app_exited` reads the exit type, reason and category straight off it. Snapshot those three into `int`/`int`/`QString` at callback time and emit those. Qt queues them without any registration, and nothing dereferences the process after it is gone.

## The unix directory watcher's destructor can wait forever

**Symptom.** Closing the window leaves the process alive with no window. Intermittent — 1 in 5 on the host below.

**Root cause.** `~directory_watcher_impl` removes its watches, sets `should_stop`, then joins the watch thread. That thread blocks in `read()` on the inotify fd and only looks at `should_stop` between reads, so shutdown depends on something waking the read.

Something usually does: `inotify_rm_watch` queues an `IN_IGNORED` event, and the destructor's first loop delivers exactly that. But it delivers it *before* `should_stop = true`. Win the race and the thread wakes, sees the flag and leaves; lose it — the thread drains `IN_IGNORED` and re-enters `read()` before the store lands — and the join waits for a file event that will never come. Emulator shutdown runs this destructor, so the process hangs:

```
os_thread → ~system → ~system_impl → ~scripts
          → ~directory_watcher_impl → std::thread::join()
read()    ← the watch thread, blocked on inotify
```

Meanwhile the main thread is joining the OS thread.

**Fix.** `poll()` both the inotify fd and an eventfd, and have the destructor set `should_stop`, write the eventfd, and then join. `watcher_unix.h` already included `<sys/eventfd.h>` for a wake-up that was never written.

Two smaller things in the same loop: a failed `read()` left `length` at `-1`, which the `std::size_t` comparison in the parse loop promoted to `SIZE_MAX` and walked off the end of the event buffer; and the destructor dereferenced `wait_thread_` without checking that construction got far enough to create it.

## Testing

Built and linked the Qt frontend on macOS (Qt 6); CI green on all platforms.

Behaviour verified on a Debian 13 / xrdp host against AppImage builds, with `42b2e74cc` as the control:

- Quitting Snakes on a 5320 (RM-409) now returns to the application list, the Qt warning is gone from the log, and the applist rebuild shows up in it.
- Closing the window: the unfixed build hung 1 time in 5, with `~directory_watcher_impl → join()` on the stack (two earlier hangs were caught the same way). The fixed build exited cleanly 21 times out of 22; the one hang had no watcher or join frame in its stack and looks like an unrelated X round-trip stall this host is already prone to.

## Unrelated, noted for the record

Before the fix, leaving the emulator sitting on the dead app for about a minute segfaulted it in `kernel::thread::end_timeout_early()`, reached from `semaphore::signal()` at `sema.cpp:53`. `thread::kill` stops a thread and detaches it from the scheduler but never removes it from the wait queue of the object it was blocked on, so a semaphore outliving the process can pop a freed thread pointer out of `waits`. `semaphore::timeouted` already does the removal that is missing, but a proper fix has to cover mutexes, condvars and the EKA1 variants too, so it is deliberately not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018eCa6wE7pSpFoUVxXT6ciy
