### PR TITLE
Fix the EKA1 CameraServer viewfinder: stop capturing a photo per frame, and deliver frames the right way up

### DIFF
--- a/src/emu/android/app/src/main/cpp/src/launcher.cpp
+++ b/src/emu/android/app/src/main/cpp/src/launcher.cpp
@@ -21,6 +21,8 @@
 #include <android/launcher.h>
 #include <android/state.h>
 
+#include <drivers/camera/camera_collection.h>
+
 #include <package/manager.h>
 #include <system/devices.h>
 
@@ -581,6 +583,15 @@ namespace eka2l1::android {
 
         if (scr) {
             auto &crr_mode = scr->current_mode();
+
+            // A camera is bolted to the device body, so a guest needs its frames
+            // rotated into the picture it composes for. Only the guest term is
+            // known here; the host interface's own rotation is added by the
+            // backend, which reads the display rotation directly (see
+            // EmulatorCamera.receiveViewfinderFeed).
+            const eka2l1::epoc::config::screen_mode *natural_mode = scr->mode_info(0);
+            drivers::camera::set_frame_rotation(crr_mode.rotation
+                - (natural_mode ? natural_mode->rotation : 0));
 
             eka2l1::vec2 size = crr_mode.size;
             src.size = size;

--- a/src/emu/android/app/src/main/cpp/src/native-lib.cpp
+++ b/src/emu/android/app/src/main/cpp/src/native-lib.cpp
@@ -382,6 +382,12 @@ Java_com_github_eka2l1_emu_EmulatorCamera_onFrameViewfinderDelivered(JNIEnv *env
     }
 }
 extern "C"
+JNIEXPORT jint JNICALL
+Java_com_github_eka2l1_emu_EmulatorCamera_guestFrameRotation(JNIEnv *env, jclass clazz) {
+    return eka2l1::drivers::camera::frame_rotation();
+}
+
+extern "C"
 JNIEXPORT jboolean JNICALL
 Java_com_github_eka2l1_emu_EmulatorCamera_doesCameraAllowNewFrame(JNIEnv *env, jclass clazz,
                                                                   jint index) {

--- a/src/emu/android/app/src/main/java/com/github/eka2l1/emu/EmulatorCamera.java
+++ b/src/emu/android/app/src/main/java/com/github/eka2l1/emu/EmulatorCamera.java
@@ -12,6 +12,7 @@ import android.hardware.camera2.params.StreamConfigurationMap;
 import android.os.Looper;
 import android.util.Log;
 import android.util.Size;
+import android.view.Surface;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
@@ -411,6 +412,22 @@ public class EmulatorCamera {
         }
     }
 
+    // How far, counter-clockwise, a frame that is upright in the device's natural
+    // orientation still has to turn to be upright in the guest's picture.
+    //
+    // Display.getRotation() reports how far the screen has turned counter-
+    // clockwise from natural; the interface counter-rotates by the same amount to
+    // stay upright for the viewer, while the camera keeps looking out of the
+    // device body -- so it enters with the display's sign. The native side
+    // contributes the guest term alone (see launcher.cpp), because only the
+    // backend can see the host display.
+    private int frameRotationDegrees() {
+        final int display_rotation =
+            applicationActivity.getWindowManager().getDefaultDisplay().getRotation() * 90;
+
+        return ((guestFrameRotation() + display_rotation) % 360 + 360) % 360;
+    }
+
     private int getTargetCaptureRotation() {
         int rotation = applicationActivity.getWindowManager().getDefaultDisplay().getRotation() * 90;
         int cameraOrientation = characteristics.get(CameraCharacteristics.SENSOR_ORIENTATION);
@@ -445,13 +462,18 @@ public class EmulatorCamera {
         applicationActivity.runOnUiThread(() -> {
             Size sizeFinned = new Size(width, height);
 
+            // Pin the target to the device's natural orientation so that the
+            // per-image rotation degrees always mean "rotate by this to be upright
+            // in the natural orientation", whatever the display was doing when the
+            // use case got bound. The display's own rotation is folded back in per
+            // frame, together with the guest's, in frameRotationDegrees().
             currentAnalysis = new ImageAnalysis.Builder()
                     .setTargetResolution(sizeFinned)
+                    .setTargetRotation(Surface.ROTATION_0)
                     .setOutputImageFormat(ImageAnalysis.OUTPUT_IMAGE_FORMAT_RGBA_8888)
                     .build();
 
             camera = cameraProvider.bindToLifecycle(applicationActivity, getCameraSelector(), currentAnalysis);
-            currentAnalysis.getTargetRotation();
 
             currentAnalysis.setAnalyzer(cameraExecutor,
                     image -> {
@@ -463,7 +485,14 @@ public class EmulatorCamera {
                         ByteBuffer imageBuffer = image.getPlanes()[0].getBuffer();
 
                         Size sizeRotatedReceived = new Size(image.getWidth(), image.getHeight());
-                        int rotationGivenByImage = image.getImageInfo().getRotationDegrees();
+
+                        // getRotationDegrees() turns the raw frame upright in the
+                        // device's natural orientation (the target is pinned to it
+                        // above); frameRotationDegrees() carries it the rest of the
+                        // way into the guest's picture. postRotate turns clockwise,
+                        // so the counter-clockwise remainder is subtracted.
+                        int rotationGivenByImage = ((image.getImageInfo().getRotationDegrees()
+                                - frameRotationDegrees()) % 360 + 360) % 360;
 
                         Bitmap finalBitmap = null;
                         int stride = image.getPlanes()[0].getRowStride();
@@ -786,6 +815,11 @@ public class EmulatorCamera {
 
         return buffer;
     }
+
+    // The rotation, counter-clockwise, that the guest's picture sits at from the
+    // emulated device's natural orientation. Read per frame: an app switches
+    // screen mode while the camera runs.
+    private static native int guestFrameRotation();
 
     private static native boolean doesCameraAllowNewFrame(int index);
     private static native void onCaptureImageDelivered(int index, byte[] rawData, int errorCode);

--- a/src/emu/drivers/include/drivers/camera/backend/ios/camera_pixel_ios.h
+++ b/src/emu/drivers/include/drivers/camera/backend/ios/camera_pixel_ios.h
@@ -33,7 +33,7 @@ namespace eka2l1::drivers::camera {
 
     // Formats the backend can produce from a BGRA source. Mirrors the Android
     // backend's advertised set.
-    extern const frame_format IOS_SUPPORTED_FORMATS[7];
+    extern const frame_format IOS_SUPPORTED_FORMATS[8];
 
     bool ios_is_supported_format(const frame_format format);
 

--- a/src/emu/drivers/include/drivers/camera/backend/ios/camera_pixel_ios.h
+++ b/src/emu/drivers/include/drivers/camera/backend/ios/camera_pixel_ios.h
@@ -45,9 +45,23 @@ namespace eka2l1::drivers::camera {
         const int width, const int height, const frame_format format,
         std::vector<std::uint8_t> &dest);
 
-    // Draw a CGImage scaled into a top-down BGRX buffer of exactly dw x dh.
+    // Draw a CGImage into a top-down BGRX buffer of exactly dw x dh, rotated
+    // counter-clockwise by rotation_ccw_deg (a multiple of 90) on the way.
+    //
+    // The destination is filled edge to edge, so a source whose rotated extents
+    // have a different aspect ratio is stretched rather than letterboxed. That
+    // is deliberate: a guest scales the frame over its own window, and the two
+    // stretches largely cancel -- the way they do on the hardware, whose sensor
+    // buffer has a fixed shape whatever the screen is.
     bool ios_render_cgimage_to_bgra(CGImageRef image, const int dw, const int dh,
-        std::vector<std::uint8_t> &out);
+        const int rotation_ccw_deg, std::vector<std::uint8_t> &out);
+
+    // The angle, counter-clockwise, that a raw capture buffer must be rotated by
+    // to be upright in the guest's picture. Built-in cameras output landscape
+    // frames whatever the interface is doing, so a fixed offset takes them to
+    // the host's natural orientation, and camera::frame_rotation() takes them
+    // the rest of the way (see camera_collection.h).
+    int ios_frame_rotation_ccw();
 
     // Wrap a top-down BGRX buffer as a CGImage. The buffer must outlive the image.
     CGImageRef ios_create_cgimage_from_bgra(const std::uint8_t *base, const std::size_t stride,

--- a/src/emu/drivers/include/drivers/camera/camera_collection.h
+++ b/src/emu/drivers/include/drivers/camera/camera_collection.h
@@ -36,4 +36,26 @@ namespace eka2l1::drivers::camera {
     };
 
     collection *get_collection();
+
+    // How far, counter-clockwise, a frame that is already upright in the host
+    // device's natural orientation still has to turn to be upright in the guest's
+    // picture. A backend owns the raw-readout-to-natural step, which is its own
+    // business, and adds this on top. The presenter keeps the value current: a
+    // guest switches screen mode, and the host interface rotates, while a camera
+    // runs.
+    //
+    // Close to the accelerometer's angle, but not the same one, and the difference
+    // is easy to miss because it vanishes in the orientation most testing happens
+    // in:
+    //
+    //   camera        = (mode.rotation - panel_mount) - host_interface_rotation
+    //   accelerometer = (mode.rotation - panel_mount) + host_interface_rotation
+    //
+    // The host terms have opposite signs. Turning the phone counter-clockwise
+    // spins the scene clockwise inside a sensor buffer, while the interface
+    // counter-rotates the picture to keep it upright for the viewer. The guest
+    // terms match: an app that composes for a rotated panel has already laid the
+    // frame out for that panel.
+    void set_frame_rotation(const int degrees);
+    int frame_rotation();
 }

--- a/src/emu/drivers/src/camera/backend/ios/camera_ios.mm
+++ b/src/emu/drivers/src/camera/backend/ios/camera_ios.mm
@@ -232,17 +232,22 @@ using eka2l1::drivers::camera::instance_ios;
         return;
     }
 
-    // Deliver upright (portrait) pixels, matching what the Android backend
-    // produces after rotating by the Camera2-reported rotation degrees.
+    // Pin the connection to the cameras' native landscape-right readout instead
+    // of asking AVFoundation to rotate. A guest needs frames upright in *its*
+    // picture, which depends on the emulated screen mode and on the host
+    // interface orientation, so the whole rotation is done in the pixel path
+    // (ios_frame_rotation_ccw) where it costs nothing on top of the rescale
+    // that already happens. Pinning also keeps the buffer geometry fixed, so
+    // the delegate can reason about it without querying the connection back.
     if (@available(iOS 17.0, *)) {
-        if ([connection isVideoRotationAngleSupported:90.0]) {
-            connection.videoRotationAngle = 90.0;
+        if ([connection isVideoRotationAngleSupported:0.0]) {
+            connection.videoRotationAngle = 0.0;
         }
     } else {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         if (connection.supportsVideoOrientation) {
-            connection.videoOrientation = AVCaptureVideoOrientationPortrait;
+            connection.videoOrientation = AVCaptureVideoOrientationLandscapeRight;
         }
 #pragma clang diagnostic pop
     }
@@ -457,10 +462,12 @@ using eka2l1::drivers::camera::instance_ios;
     const int source_width = static_cast<int>(CVPixelBufferGetWidth(pixel_buffer));
     const int source_height = static_cast<int>(CVPixelBufferGetHeight(pixel_buffer));
 
+    const int rotation = eka2l1::drivers::camera::ios_frame_rotation_ccw();
+
     std::vector<std::uint8_t> converted;
     bool converted_ok = false;
 
-    if ((source_width == _viewfinderWidth) && (source_height == _viewfinderHeight)) {
+    if ((rotation == 0) && (source_width == _viewfinderWidth) && (source_height == _viewfinderHeight)) {
         converted_ok = eka2l1::drivers::camera::ios_convert_bgra_to_guest(base, stride,
             _viewfinderWidth, _viewfinderHeight, _viewfinderFormat, converted);
     } else {
@@ -470,7 +477,7 @@ using eka2l1::drivers::camera::instance_ios;
         if (source_image) {
             std::vector<std::uint8_t> scaled;
             if (eka2l1::drivers::camera::ios_render_cgimage_to_bgra(source_image, _viewfinderWidth,
-                _viewfinderHeight, scaled)) {
+                _viewfinderHeight, rotation, scaled)) {
                 converted_ok = eka2l1::drivers::camera::ios_convert_bgra_to_guest(scaled.data(),
                     static_cast<std::size_t>(_viewfinderWidth) * 4, _viewfinderWidth,
                     _viewfinderHeight, _viewfinderFormat, converted);
@@ -542,9 +549,13 @@ using eka2l1::drivers::camera::instance_ios;
 
     const eka2l1::drivers::camera::frame_format format = _captureFormat;
 
+    // A still is bolted to the device the same way a viewfinder frame is: a
+    // guest saving it expects the picture the right way up for its own screen.
+    const int rotation = eka2l1::drivers::camera::ios_frame_rotation_ccw();
+
     if ((format == eka2l1::drivers::camera::FRAME_FORMAT_JPEG) ||
         (format == eka2l1::drivers::camera::FRAME_FORMAT_EXIF)) {
-        if ((image_width == _captureWidth) && (image_height == _captureHeight)) {
+        if ((rotation == 0) && (image_width == _captureWidth) && (image_height == _captureHeight)) {
             CGImageRelease(image);
             [self deliverCaptureBytes:jpeg_data.bytes size:jpeg_data.length error:0];
             return;
@@ -554,7 +565,7 @@ using eka2l1::drivers::camera::instance_ios;
         // the sensor output size differs from the requested one.
         std::vector<std::uint8_t> scaled;
         bool ok = eka2l1::drivers::camera::ios_render_cgimage_to_bgra(image, _captureWidth,
-            _captureHeight, scaled);
+            _captureHeight, rotation, scaled);
         CGImageRelease(image);
 
         CGImageRef scaled_image = nullptr;
@@ -596,7 +607,7 @@ using eka2l1::drivers::camera::instance_ios;
 
     std::vector<std::uint8_t> bgra;
     const bool render_ok = eka2l1::drivers::camera::ios_render_cgimage_to_bgra(image, _captureWidth,
-        _captureHeight, bgra);
+        _captureHeight, rotation, bgra);
     CGImageRelease(image);
 
     std::vector<std::uint8_t> converted;

--- a/src/emu/drivers/src/camera/backend/ios/camera_pixel_ios.mm
+++ b/src/emu/drivers/src/camera/backend/ios/camera_pixel_ios.mm
@@ -22,6 +22,7 @@
 #import <ImageIO/ImageIO.h>
 
 #include <drivers/camera/backend/ios/camera_pixel_ios.h>
+#include <drivers/camera/camera_collection.h>
 
 namespace eka2l1::drivers::camera {
     // Formats the backend can synthesize from a BGRA source. Mirrors the
@@ -148,9 +149,19 @@ namespace eka2l1::drivers::camera {
         return false;
     }
 
-    // Draw a CGImage scaled into a top-down BGRX buffer of exactly dw x dh.
+    // Every built-in iOS camera reads out landscape-right, so a raw buffer sits
+    // 90 degrees counter-clockwise from upright in the host's natural (portrait)
+    // orientation. The capture connection is pinned to that native readout, so
+    // this offset is a constant rather than something to query per frame.
+    static constexpr int IOS_SENSOR_CCW_FROM_NATURAL = 90;
+
+    int ios_frame_rotation_ccw() {
+        const int total = frame_rotation() - IOS_SENSOR_CCW_FROM_NATURAL;
+        return ((total % 360) + 360) % 360;
+    }
+
     bool ios_render_cgimage_to_bgra(CGImageRef image, const int dw, const int dh,
-        std::vector<std::uint8_t> &out) {
+        const int rotation_ccw_deg, std::vector<std::uint8_t> &out) {
         out.resize(static_cast<std::size_t>(dw) * 4 * dh);
 
         CGColorSpaceRef color_space = CGColorSpaceCreateDeviceRGB();
@@ -164,7 +175,35 @@ namespace eka2l1::drivers::camera {
         }
 
         CGContextSetInterpolationQuality(context, kCGInterpolationLow);
-        CGContextDrawImage(context, CGRectMake(0, 0, dw, dh), image);
+
+        const int rotation = ((rotation_ccw_deg % 360) + 360) % 360;
+
+        if (rotation == 0) {
+            CGContextDrawImage(context, CGRectMake(0, 0, dw, dh), image);
+            CGContextRelease(context);
+
+            return true;
+        }
+
+        // A bitmap context puts row 0 at the top and +Y upwards, so the user
+        // space is upright and a positive CGContext rotation is counter-
+        // clockwise in the picture too.
+        const double source_width = static_cast<double>(CGImageGetWidth(image));
+        const double source_height = static_cast<double>(CGImageGetHeight(image));
+        const bool extents_swapped = ((rotation % 180) != 0);
+        const double rotated_width = extents_swapped ? source_height : source_width;
+        const double rotated_height = extents_swapped ? source_width : source_height;
+
+        if ((source_width <= 0.0) || (source_height <= 0.0)) {
+            CGContextRelease(context);
+            return false;
+        }
+
+        CGContextTranslateCTM(context, dw * 0.5, dh * 0.5);
+        CGContextRotateCTM(context, rotation * M_PI / 180.0);
+        CGContextScaleCTM(context, dw / rotated_width, dh / rotated_height);
+        CGContextDrawImage(context, CGRectMake(-source_width * 0.5, -source_height * 0.5,
+            source_width, source_height), image);
         CGContextRelease(context);
 
         return true;

--- a/src/emu/drivers/src/camera/backend/ios/camera_pixel_ios.mm
+++ b/src/emu/drivers/src/camera/backend/ios/camera_pixel_ios.mm
@@ -26,9 +26,9 @@
 namespace eka2l1::drivers::camera {
     // Formats the backend can synthesize from a BGRA source. Mirrors the
     // Android backend's advertised set.
-    const frame_format IOS_SUPPORTED_FORMATS[7] = {
+    const frame_format IOS_SUPPORTED_FORMATS[8] = {
         FRAME_FORMAT_ARGB8888, FRAME_FORMAT_JPEG, FRAME_FORMAT_RGB565,
-        FRAME_FORMAT_FBSBMP_COLOR64K, FRAME_FORMAT_FBSBMP_COLOR16M,
+        FRAME_FORMAT_FBSBMP_COLOR4K, FRAME_FORMAT_FBSBMP_COLOR64K, FRAME_FORMAT_FBSBMP_COLOR16M,
         FRAME_FORMAT_FBSBMP_COLOR16MU, FRAME_FORMAT_EXIF
     };
 
@@ -105,9 +105,12 @@ namespace eka2l1::drivers::camera {
             return true;
         }
 
+        case FRAME_FORMAT_FBSBMP_COLOR4K:
         case FRAME_FORMAT_FBSBMP_COLOR64K:
         case FRAME_FORMAT_RGB565: {
-            const std::size_t dest_stride = (format == FRAME_FORMAT_FBSBMP_COLOR64K)
+            const bool is_fbs = (format == FRAME_FORMAT_FBSBMP_COLOR4K)
+                || (format == FRAME_FORMAT_FBSBMP_COLOR64K);
+            const std::size_t dest_stride = is_fbs
                 ? (static_cast<std::size_t>(width) * 2 + 3) / 4 * 4
                 : static_cast<std::size_t>(width) * 2;
             dest.resize(dest_stride * height);
@@ -117,10 +120,18 @@ namespace eka2l1::drivers::camera {
                 std::uint8_t *dest_row = dest.data() + y * dest_stride;
 
                 for (int x = 0; x < width; x++) {
-                    const std::uint16_t pixel = static_cast<std::uint16_t>(
-                        ((src_row[x * 4 + 0] & 0xF8) >> 3) |
-                        ((src_row[x * 4 + 1] & 0xFC) << 3) |
-                        ((src_row[x * 4 + 2] & 0xF8) << 8));
+                    std::uint16_t pixel = 0;
+                    if (format == FRAME_FORMAT_FBSBMP_COLOR4K) {
+                        pixel = static_cast<std::uint16_t>(
+                            (src_row[x * 4 + 0] >> 4)
+                            | (src_row[x * 4 + 1] & 0xF0)
+                            | ((src_row[x * 4 + 2] & 0xF0) << 4));
+                    } else {
+                        pixel = static_cast<std::uint16_t>(
+                            ((src_row[x * 4 + 0] & 0xF8) >> 3)
+                            | ((src_row[x * 4 + 1] & 0xFC) << 3)
+                            | ((src_row[x * 4 + 2] & 0xF8) << 8));
+                    }
 
                     dest_row[x * 2 + 0] = static_cast<std::uint8_t>(pixel & 0xFF);
                     dest_row[x * 2 + 1] = static_cast<std::uint8_t>(pixel >> 8);

--- a/src/emu/drivers/src/camera/backend/ios/camera_simulator.mm
+++ b/src/emu/drivers/src/camera/backend/ios/camera_simulator.mm
@@ -22,6 +22,7 @@
 
 #include <drivers/camera/backend/ios/camera_pixel_ios.h>
 #include <drivers/camera/backend/ios/camera_simulator.h>
+#include <drivers/camera/camera_collection.h>
 
 #include <common/log.h>
 
@@ -129,8 +130,39 @@ namespace eka2l1::drivers::camera {
 
     static bool encode_pattern(const int width, const int height, const std::uint32_t frame_index,
         const bool front_facing, const frame_format format, std::vector<std::uint8_t> &out) {
+        // The pattern stands in for a raw sensor readout, in the landscape shape
+        // and with the same orientation a built-in camera hands over, and then
+        // goes through the exact rotate-and-stretch the device backend applies.
+        // Generating straight at the requested size skipped the orientation path
+        // altogether, which is what left the simulator blind to frames arriving
+        // sideways on hardware.
+        const int sensor_width = std::max(width, height);
+        const int sensor_height = std::min(width, height);
+        const int rotation = ios_frame_rotation_ccw();
+
+        std::vector<std::uint8_t> sensor_bgra;
+        synthesize_test_pattern_bgra(sensor_width, sensor_height, frame_index, front_facing,
+            sensor_bgra);
+
         std::vector<std::uint8_t> bgra;
-        synthesize_test_pattern_bgra(width, height, frame_index, front_facing, bgra);
+
+        if ((rotation == 0) && (sensor_width == width) && (sensor_height == height)) {
+            bgra = std::move(sensor_bgra);
+        } else {
+            CGImageRef sensor_image = ios_create_cgimage_from_bgra(sensor_bgra.data(),
+                static_cast<std::size_t>(sensor_width) * 4, sensor_width, sensor_height);
+            if (!sensor_image) {
+                return false;
+            }
+
+            const bool rendered = ios_render_cgimage_to_bgra(sensor_image, width, height,
+                rotation, bgra);
+            CGImageRelease(sensor_image);
+
+            if (!rendered) {
+                return false;
+            }
+        }
 
         if ((format == FRAME_FORMAT_JPEG) || (format == FRAME_FORMAT_EXIF)) {
             return ios_encode_bgra_to_jpeg(bgra.data(), width, height, out);

--- a/src/emu/drivers/src/camera/camera_collection.cpp
+++ b/src/emu/drivers/src/camera/camera_collection.cpp
@@ -3,6 +3,7 @@
 
 #include <common/platform.h>
 
+#include <atomic>
 #include <type_traits>
 
 #if EKA2L1_PLATFORM(ANDROID)
@@ -24,6 +25,18 @@ namespace eka2l1::drivers::camera {
         "camera::collection is owned polymorphically and must be destroyed polymorphically");
 
     std::unique_ptr<collection> collection_detail = nullptr;
+
+    // Written by the presenter thread, read on whichever thread a backend converts
+    // a frame on.
+    static std::atomic<int> frame_rotation_deg = 0;
+
+    void set_frame_rotation(const int degrees) {
+        frame_rotation_deg.store(((degrees % 360) + 360) % 360, std::memory_order_relaxed);
+    }
+
+    int frame_rotation() {
+        return frame_rotation_deg.load(std::memory_order_relaxed);
+    }
 
     collection *get_collection() {
         if (collection_detail == nullptr) {

--- a/src/emu/ios/Bridge/IosEmulator.mm
+++ b/src/emu/ios/Bridge/IosEmulator.mm
@@ -46,6 +46,7 @@
 #include <drivers/input/common.h>
 #include <drivers/itc.h>
 #include <drivers/hwrm/vibration.h>
+#include <drivers/camera/camera_collection.h>
 #include <drivers/sensor/sensor.h>
 #include <services/window/screen.h>
 #include <kernel/kernel.h>
@@ -685,11 +686,24 @@ namespace eka2l1::ios {
         // rot=270), unlike Symbian^3 (rot=0). Refreshing here tracks both
         // guest screen-mode switches and host rotations (a host rotation
         // re-attaches the surface, which re-presents even a static screen).
-        if (state->sensor_driver) {
+        {
             const eka2l1::epoc::config::screen_mode *natural_mode = scr->mode_info(0);
             const int panel_mount = natural_mode ? natural_mode->rotation : 0;
-            state->sensor_driver->set_motion_rotation(mode.rotation - panel_mount
-                + state->host_interface_rotation_deg.load(std::memory_order_relaxed));
+            const int picture_rotation = mode.rotation - panel_mount
+                + state->host_interface_rotation_deg.load(std::memory_order_relaxed);
+
+            if (state->sensor_driver) {
+                state->sensor_driver->set_motion_rotation(picture_rotation);
+            }
+
+            // A camera is bolted to the device body, so it needs the mirror of the
+            // accelerometer's angle for the host term: turning the phone counter-
+            // clockwise spins the scene clockwise inside the sensor buffer, while
+            // the interface counter-rotates the picture to stay upright for the
+            // viewer. The guest term keeps its sign -- an app that composes for a
+            // rotated panel already lays the frame out for it.
+            eka2l1::drivers::camera::set_frame_rotation(mode.rotation - panel_mount
+                - state->host_interface_rotation_deg.load(std::memory_order_relaxed));
         }
         eka2l1::rect src;
         src.size = mode.size;

--- a/src/emu/services/include/services/camera/camera.h
+++ b/src/emu/services/include/services/camera/camera.h
@@ -13,6 +13,9 @@
 
 #include <services/framework.h>
 
+#include <common/vecx.h>
+
+#include <cstdint>
 #include <memory>
 
 namespace eka2l1 {
@@ -22,14 +25,27 @@ namespace eka2l1 {
 
     class camera_session : public service::typical_session {
         struct capture_state;
+        struct feed_state;
 
         bool low_quality_;
         bool night_mode_;
         std::unique_ptr<drivers::camera::instance> camera_;
         std::shared_ptr<capture_state> pending_capture_;
+        std::shared_ptr<feed_state> feed_;
+        eka2l1::vec2 feed_size_;
+        std::uint32_t feed_format_;
 
         int turn_on(system *sys);
         void turn_off();
+
+        // Both run with the kernel lock held, and start_feed() drops it around the
+        // driver call because a failing driver invokes the callback synchronously.
+        bool start_feed(system *sys, const eka2l1::vec2 &size, const std::uint32_t format,
+            const std::shared_ptr<capture_state> &first_request);
+        void stop_feed();
+
+        static void deliver_frame(const std::shared_ptr<capture_state> &state, const void *buffer,
+            const std::size_t buffer_size, const int error);
 
     public:
         camera_session(service::typical_server *server, kernel::uid client_session_uid,

--- a/src/emu/services/src/camera/camera.cpp
+++ b/src/emu/services/src/camera/camera.cpp
@@ -21,7 +21,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cstring>
-#include <limits>
+#include <vector>
 
 namespace eka2l1 {
     namespace {
@@ -53,11 +53,26 @@ namespace eka2l1 {
         std::atomic<bool> done{ false };
     };
 
+    // Frames arrive on a driver thread for as long as the feed runs, so the state
+    // the callback touches outlives the session it was started from.
+    struct camera_session::feed_state {
+        system *sys;
+
+        // Only read/written with the kernel lock held.
+        std::shared_ptr<capture_state> pending;
+
+        std::atomic<bool> wants_frame{ false };
+        std::atomic<bool> stopped{ false };
+        std::atomic<bool> failed{ false };
+    };
+
     camera_session::camera_session(service::typical_server *server, const kernel::uid client_session_uid,
         const epoc::version client_version)
         : service::typical_session(server, client_session_uid, client_version)
         , low_quality_(false)
-        , night_mode_(false) {
+        , night_mode_(false)
+        , feed_size_(0, 0)
+        , feed_format_(0) {
     }
 
     camera_session::~camera_session() {
@@ -96,6 +111,8 @@ namespace eka2l1 {
     }
 
     void camera_session::turn_off() {
+        stop_feed();
+
         if (pending_capture_) {
             const std::shared_ptr<capture_state> state = pending_capture_;
             state->cancelled.store(true);
@@ -122,6 +139,164 @@ namespace eka2l1 {
         }
     }
 
+    void camera_session::stop_feed() {
+        if (!feed_) {
+            return;
+        }
+
+        // Retire the shared state before the driver so that a frame already in
+        // flight on the driver thread finds the feed stopped and does nothing.
+        feed_->stopped.store(true);
+        feed_->wants_frame.store(false);
+        feed_->pending.reset();
+        feed_.reset();
+
+        feed_size_ = eka2l1::vec2(0, 0);
+        feed_format_ = 0;
+
+        if (camera_) {
+            camera_->stop_viewfinder_feed();
+        }
+
+        LOG_TRACE(HLE_CAMERA, "Camera frame feed stopped");
+    }
+
+    bool camera_session::start_feed(system *sys, const eka2l1::vec2 &size, const std::uint32_t format,
+        const std::shared_ptr<capture_state> &first_request) {
+        std::shared_ptr<feed_state> feed = std::make_shared<feed_state>();
+        feed->sys = sys;
+        feed->pending = first_request;
+        feed->wants_frame.store(true);
+
+        feed_ = feed;
+        feed_size_ = size;
+        feed_format_ = format;
+
+        kernel_system *kern = sys->get_kernel_system();
+
+        // Drivers normally deliver on their own thread, but a feed that fails to
+        // start reports it through the same callback, synchronously. Let that call
+        // take the kernel lock instead of deadlocking against this thread.
+        kern->unlock();
+        camera_->receive_viewfinder_feed(size, static_cast<drivers::camera::frame_format>(format),
+            [feed]() {
+                return feed->wants_frame.load() && !feed->stopped.load();
+            },
+            [feed](const void *buffer, const std::size_t buffer_size, const int error) {
+                if (feed->stopped.load() || !feed->wants_frame.load()) {
+                    return;
+                }
+
+                kernel_system *kern = feed->sys->get_kernel_system();
+                kernel_lock guard(kern);
+
+                if (feed->stopped.load() || kern->is_wiping()) {
+                    return;
+                }
+
+                if (error < 0) {
+                    feed->failed.store(true);
+                }
+
+                const std::shared_ptr<capture_state> state = feed->pending;
+                feed->pending.reset();
+                feed->wants_frame.store(false);
+
+                if (state) {
+                    deliver_frame(state, buffer, buffer_size, error);
+                }
+            });
+        kern->lock();
+
+        // A feed that cannot start reports it through the same callback, which has
+        // already completed the request by now. Tear the dead feed down so that the
+        // next request tries again instead of waiting forever.
+        if (feed->failed.load()) {
+            LOG_ERROR(HLE_CAMERA, "Unable to start the camera frame feed!");
+            stop_feed();
+            return false;
+        }
+
+        LOG_TRACE(HLE_CAMERA, "Camera frame feed started at {}x{}, format 0x{:X}",
+            size.x, size.y, format);
+        return true;
+    }
+
+    void camera_session::deliver_frame(const std::shared_ptr<capture_state> &state, const void *buffer,
+        const std::size_t buffer_size, const int error) {
+        kernel_system *kern = state->sys->get_kernel_system();
+
+        if (state->cancelled.load() || state->done.exchange(true)) {
+            return;
+        }
+
+        if (!kern->is_thread_alive(state->notify.requester)) {
+            if (state->owns_bitmap && state->bitmap && (state->bitmap->count == 0)) {
+                state->fbs->remove(state->bitmap);
+                state->bitmap = nullptr;
+            }
+
+            return;
+        }
+
+        int result = epoc::error_none;
+        fbs_server *fbs = state->fbs;
+        fbsbitmap *bitmap = fbs ? fbs->get<fbsbitmap>(state->bitmap_handle) : nullptr;
+
+        if ((error < 0) || !buffer) {
+            result = epoc::error_general;
+        } else if (!bitmap || (bitmap->kind != fbsobj_kind::bitmap)) {
+            result = epoc::error_bad_handle;
+        } else {
+            epoc::display_mode mode = bitmap->bitmap_->settings_.current_display_mode();
+            if (mode == epoc::display_mode::none) {
+                mode = bitmap->bitmap_->settings_.initial_display_mode();
+            }
+
+            const std::size_t source_bytes = static_cast<std::size_t>(state->source_stride)
+                * state->source_size.y;
+            const std::size_t target_bytes = static_cast<std::size_t>(state->target_stride)
+                * state->target_size.y;
+
+            if ((bitmap->bitmap_->header_.size_pixels != state->target_size)
+                || (mode != state->target_mode)
+                || (bitmap->bitmap_->data_size() < target_bytes)
+                || (buffer_size < source_bytes)) {
+                result = epoc::error_underflow;
+            } else {
+                const std::uint8_t *source = reinterpret_cast<const std::uint8_t *>(buffer);
+                std::uint8_t *target = bitmap->bitmap_->data_pointer(fbs);
+
+                if ((state->source_size == state->target_size)
+                    && (state->source_stride == state->target_stride)) {
+                    std::memcpy(target, source, target_bytes);
+                } else {
+                    std::memset(target, 0, target_bytes);
+
+                    for (int y = 0; y < state->target_size.y; y++) {
+                        const int source_y = y * state->source_size.y / state->target_size.y;
+                        for (int x = 0; x < state->target_size.x; x++) {
+                            const int source_x = x * state->source_size.x / state->target_size.x;
+                            std::memcpy(target + static_cast<std::size_t>(y) * state->target_stride
+                                    + static_cast<std::size_t>(x) * state->bytes_per_pixel,
+                                source + static_cast<std::size_t>(source_y) * state->source_stride
+                                    + static_cast<std::size_t>(source_x) * state->bytes_per_pixel,
+                                state->bytes_per_pixel);
+                        }
+                    }
+                }
+            }
+        }
+
+        if ((result != epoc::error_none) && state->owns_bitmap
+            && state->bitmap && (state->bitmap->count == 0)) {
+            state->fbs->remove(state->bitmap);
+            state->bitmap = nullptr;
+        }
+
+        state->notify.complete(result);
+    }
+
     void camera_session::fetch(service::ipc_context *ctx) {
         switch (ctx->msg->function) {
         case camera_turn_on:
@@ -141,6 +316,7 @@ namespace eka2l1 {
             }
 
             night_mode_ = (*lighting == 1);
+            LOG_TRACE(HLE_CAMERA, "Camera night mode set to {}", night_mode_);
             if (camera_) {
                 camera_->set_parameter(drivers::camera::PARAMETER_KEY_EXPOSURE,
                     night_mode_ ? drivers::camera::EXPOSURE_MODE_NIGHT : drivers::camera::EXPOSURE_MODE_AUTO);
@@ -158,6 +334,7 @@ namespace eka2l1 {
             }
 
             low_quality_ = (*quality == 1);
+            LOG_TRACE(HLE_CAMERA, "Camera low quality mode set to {}", low_quality_);
             ctx->complete(epoc::error_none);
             break;
         }
@@ -219,29 +396,17 @@ namespace eka2l1 {
             const std::uint32_t bits_per_pixel = low_quality_ ? 12 : 24;
             const std::uint32_t bytes_per_pixel = low_quality_ ? 2 : 3;
 
-            const std::vector<eka2l1::vec2> sizes = camera_->supported_output_image_sizes(format);
-            if (sizes.empty()) {
+            // Frames come from the viewfinder feed, which delivers exactly the
+            // requested size in the requested guest format. A driver that does not
+            // know the format would drop the feed request without reporting it, so
+            // reject it here rather than leaving the client waiting forever.
+            const std::vector<drivers::camera::frame_format> formats = camera_->supported_frame_formats();
+            if (std::find(formats.begin(), formats.end(), format) == formats.end()) {
                 ctx->complete(epoc::error_not_supported);
                 break;
             }
 
-            std::size_t size_index = 0;
-            std::uint64_t best_distance = std::numeric_limits<std::uint64_t>::max();
-            for (std::size_t i = 0; i < sizes.size(); i++) {
-                const std::int64_t dx = static_cast<std::int64_t>(sizes[i].x) - expected_size.x;
-                const std::int64_t dy = static_cast<std::int64_t>(sizes[i].y) - expected_size.y;
-                const std::uint64_t distance = static_cast<std::uint64_t>(dx * dx + dy * dy);
-                if (distance < best_distance) {
-                    best_distance = distance;
-                    size_index = i;
-                }
-            }
-
-            const eka2l1::vec2 source_size = sizes[size_index];
-            if ((source_size.x <= 0) || (source_size.y <= 0)) {
-                ctx->complete(epoc::error_not_supported);
-                break;
-            }
+            const eka2l1::vec2 source_size = expected_size;
 
             if (!bitmap) {
                 bool support_current_display_mode = true;
@@ -306,82 +471,25 @@ namespace eka2l1 {
             state->bytes_per_pixel = bytes_per_pixel;
             pending_capture_ = state;
 
-            // Backends normally complete on their capture queue, but request
-            // setup failures may invoke the callback synchronously. Let that
-            // callback take the kernel lock instead of deadlocking here.
-            kern->unlock();
-            camera_->capture_image(static_cast<std::uint32_t>(size_index), format,
-                [state](const void *buffer, const std::size_t buffer_size, const int error) {
-                    if (state->cancelled.load()) {
-                        return;
-                    }
+            // GetImage is how this protocol implements a viewfinder: apps poll it
+            // frame after frame. Serving each poll with a still capture makes the
+            // host run its whole photo pipeline (and, on iOS, the shutter sound)
+            // per frame, so take frames from the viewfinder feed and leave it
+            // running between requests instead.
+            if (feed_ && (feed_->failed.load() || (feed_size_ != expected_size)
+                || (feed_format_ != static_cast<std::uint32_t>(format)))) {
+                // A feed that reported an error stays dead, and the quality
+                // setting can change the size and format between requests.
+                stop_feed();
+            }
 
-                    kernel_system *kern = state->sys->get_kernel_system();
-                    kernel_lock guard(kern);
+            if (feed_) {
+                feed_->pending = state;
+                feed_->wants_frame.store(true);
+            } else {
+                start_feed(ctx->sys, expected_size, static_cast<std::uint32_t>(format), state);
+            }
 
-                    if (state->cancelled.load() || kern->is_wiping() || state->done.exchange(true)) {
-                        return;
-                    }
-
-                    if (!kern->is_thread_alive(state->notify.requester)) {
-                        if (state->owns_bitmap && state->bitmap && (state->bitmap->count == 0)) {
-                            state->fbs->remove(state->bitmap);
-                            state->bitmap = nullptr;
-                        }
-                        return;
-                    }
-
-                    int result = epoc::error_none;
-                    fbs_server *fbs = state->fbs;
-                    fbsbitmap *bitmap = fbs ? fbs->get<fbsbitmap>(state->bitmap_handle) : nullptr;
-
-                    if ((error < 0) || !buffer) {
-                        result = epoc::error_general;
-                    } else if (!bitmap || (bitmap->kind != fbsobj_kind::bitmap)) {
-                        result = epoc::error_bad_handle;
-                    } else {
-                        epoc::display_mode mode = bitmap->bitmap_->settings_.current_display_mode();
-                        if (mode == epoc::display_mode::none) {
-                            mode = bitmap->bitmap_->settings_.initial_display_mode();
-                        }
-
-                        const std::size_t source_bytes = static_cast<std::size_t>(state->source_stride)
-                            * state->source_size.y;
-                        const std::size_t target_bytes = static_cast<std::size_t>(state->target_stride)
-                            * state->target_size.y;
-                        if ((bitmap->bitmap_->header_.size_pixels != state->target_size)
-                            || (mode != state->target_mode)
-                            || (bitmap->bitmap_->data_size() < target_bytes)
-                            || (buffer_size < source_bytes)) {
-                            result = epoc::error_underflow;
-                        } else {
-                            const std::uint8_t *source = reinterpret_cast<const std::uint8_t *>(buffer);
-                            std::uint8_t *target = bitmap->bitmap_->data_pointer(fbs);
-                            std::memset(target, 0, target_bytes);
-
-                            for (int y = 0; y < state->target_size.y; y++) {
-                                const int source_y = y * state->source_size.y / state->target_size.y;
-                                for (int x = 0; x < state->target_size.x; x++) {
-                                    const int source_x = x * state->source_size.x / state->target_size.x;
-                                    std::memcpy(target + static_cast<std::size_t>(y) * state->target_stride
-                                            + static_cast<std::size_t>(x) * state->bytes_per_pixel,
-                                        source + static_cast<std::size_t>(source_y) * state->source_stride
-                                            + static_cast<std::size_t>(source_x) * state->bytes_per_pixel,
-                                        state->bytes_per_pixel);
-                                }
-                            }
-                        }
-                    }
-
-                    if ((result != epoc::error_none) && state->owns_bitmap
-                        && state->bitmap && (state->bitmap->count == 0)) {
-                        state->fbs->remove(state->bitmap);
-                        state->bitmap = nullptr;
-                    }
-
-                    state->notify.complete(result);
-                });
-            kern->lock();
             break;
         }
 


### PR DESCRIPTION
Two problems on the EKA1 `CameraServer` path, both reproduced on hardware on iOS and Android. Found while looking at *Attack of the Killer Virus* on the N70 (`nem-4`), but neither is app-specific.

## 1. GetImage was served with a still photo capture

`GetImage` is how this protocol implements a viewfinder — the game polls it about **fifteen times a second**, continuously (`Service.Track` logs `Calling service: CameraServer, id: 4` at that rate). The server answered every poll with `instance::capture_image()`.

So every displayed frame ran a full host photo pipeline:

- **iOS**: `AVCapturePhotoOutput` — start the session, shoot at the sensor's full photo resolution, encode JPEG, decode, rescale, stop the session again. Plus the system shutter sound, which apps cannot suppress, once per frame.
- **Android**: `ImageCapture.takePicture` followed by a JPEG decode and scale.

Frames now come from the viewfinder feed, which stays running between requests. Both backends already deliver at exactly the requested size with FBS-style 4-byte-aligned scanlines — the same thing `epoc::get_byte_width()` computes for the target bitmap — so the copy is a straight `memcpy` and the resolution-ladder search is gone.

The still-capture path is untouched for the ECam dispatch path, where a guest asking for a photo really does want one.

## 2. Frames arrived sideways

Measured on hardware, with `D` = the scene's "up" as displayed (counter-clockwise from screen-up) and `φ` = how far the phone itself was turned counter-clockwise:

| app | φ = 0 | φ = +90 | φ = −90 |
|---|---|---|---|
| Killer Virus (`nem-4`, portrait guest) | D = +90 | D = 0 | — |
| Camera (`rm-409`, landscape guest) | D = 0 | D = −90 | D = +90 |

Same slope in `φ` in both rows: the frame was bolted to the phone and ignored the guest picture entirely. The rows differ by a constant that the wsini files explain — `rm-409` declares `SCR_ROTATION2 90` for its 320x240 landscape mode, `nem-4` declares no `SCR_*` at all, and a presenter probe confirmed the camera app switching to `mode.rotation=90` against Killer Virus sitting at `0`.

That fits `D = 90 + hir − (mode.rotation − panel_mount)` on all five observations. The leading 90 is a raw landscape-right sensor readout that was never corrected: `orientConnection` asked AVFoundation for portrait delivery and, on hardware, that request did not take.

`camera::set_frame_rotation()` now carries how far a frame that is already upright in the host's natural orientation still has to turn to be upright in the guest's picture. **It is close to the accelerometer's angle but not the same one**, and the difference is easy to miss:

```
camera        = (mode.rotation - panel_mount) - host_interface_rotation
accelerometer = (mode.rotation - panel_mount) + host_interface_rotation
```

The host terms have opposite signs — turning the phone counter-clockwise spins the scene clockwise inside a sensor buffer, while the interface counter-rotates the picture to keep it upright for the viewer. The guest terms match. That difference vanishes in portrait, which is how a sign error here survives testing; it did, twice, before the landscape case caught it.

Backends own the raw-readout-to-natural step and add the shared angle on top:

- **iOS** pins the capture connection to the cameras' native landscape-right readout rather than asking for a rotation hardware ignored, and folds the whole angle into the `CGContext` pass that was already rescaling the frame — so the rotation costs nothing. Stills take the same angle.
- **Android** pins `ImageAnalysis` to `Surface.ROTATION_0`, so `getRotationDegrees()` always means "upright in the natural orientation" instead of depending on what the display was doing when the use case was bound, then subtracts the guest angle. Only the backend can see the host display there, so it folds the display rotation in itself and the presenter contributes the guest term alone.

The simulator's mock camera synthesized its pattern straight at the requested size, so it never entered the rotate-and-scale path — blind to this class of bug by construction. It now synthesizes in the landscape shape and orientation a real sensor reads out in and goes through the identical path.

## Deliberately unchanged

**The stretch.** A guest scales the frame over its own window, and on hardware the sensor buffer has a fixed shape whatever the screen is, so the two stretches largely cancel. Killer Virus lands ~13% wide; aspect-preserving crop would leave it ~37% *squashed* and throw away 44% of the field of view.

**Android stills.** That path reads `getRotationDegrees()` only to compute an output size and never rotates anything — a pre-existing gap, left alone rather than restructured without a device to test on.

## Testing

- iOS Simulator, Release, both paths: `rm-409` camera app (`mode.rotation=90` → net rotation 0, pattern upright) and `nem-4` Killer Virus (`mode.rotation=0` → net −90, pattern turned 90° clockwise) — both match the formula, and the poll rate now equals the frame rate rather than limiting it.
- Verified on this branch's own build against `master`, not only on the branch it was developed on.
- **Not verified on hardware**: the device I have was not reachable while finishing this. The angles come from the five hardware observations above. **Android is untested** — I have no way to build or run it here, so that half deserves a careful look.

The first commit (`EColor4K` on the iOS backend) is a prerequisite: the EKA1 `CameraServer` asks for that format on its low-quality setting, the Android backend already produced it, and the iOS one did not advertise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USdxEKAwgcQyEmno5B2Nax