### PR TITLE
fix(window): keep the ROM's 12-bit display mode on EKA1 panels

### DIFF
--- a/src/emu/services/src/window/window.cpp
+++ b/src/emu/services/src/window/window.cpp
@@ -1392,15 +1392,6 @@ namespace eka2l1 {
                 if (conv_res != epoc::display_mode::color_last) {
                     scr_mode_global = conv_res;
                     use_in_ini = false;
-
-                    // A 4K-colour panel is driven through a 16-bit framebuffer: two bytes
-                    // per pixel with the top four unused. Reporting EColor4K makes apps
-                    // that map a display mode to a *byte* stride come up with zero bytes
-                    // per pixel, so they allocate nothing and then blit 16bpp over the
-                    // heap (X-Plore on the N-Gage panics with USER 44 that way).
-                    if (scr_mode_global == epoc::display_mode::color4k) {
-                        scr_mode_global = epoc::display_mode::color64k;
-                    }
                 }
             }
 


### PR DESCRIPTION
Follow-up to #658 / the EKA1 DSA framebuffer-depth work: that PR landed the measurement machinery but left the older global `EColor4K` → `EColor64K` remap in `parse_wsini()` in place, so `master` currently carries both.

### Symptom

Cybersaurus on the classic N-Gage (`nem-4`) renders its 3D levels with a severe cyan/green cast. The palette should be red, orange, brown and green.

### Root cause

`parse_wsini()` derives the EPOC6 screen mode from the ROM header and then rewrites a 12-bit result into `EColor64K`. Both modes store two bytes per pixel, so the remap looks free — but the layouts are different: `EColor4K` is XRGB4444, `EColor64K` is RGB565. Symbian's own screen driver draws the same distinction (12 HAL bits → `EColor4K`, 16 → `EColor64K`), so storage width alone cannot select the mode. Cybersaurus writes native XRGB4444 words into the panel; reading them back as RGB565 moves every channel's width and position.

### Why the remap existed, and why it should go

It was added for X-Plore, which computes a **byte** stride from the display mode, gets zero bytes per pixel for `EColor4K`, allocates a zero-byte surface and then blits 16-bit pixels over the heap until an unrelated `RHeap::Free()` panics with `USER 44`.

That is a bug in X-Plore's own 12-bit surface table. Paying for it by changing the hardware pixel format of every application on the device fixes one file manager and miscolours the games — a per-application compatibility setting is where a workaround for it belongs.

### What this does not change

Removing the remap does not resurrect the EKA1 direct screen access problem it got tangled up with. `WINDOWMODE` is still narrowed to 16 bits for DSA independently in the `dsa_mode_global` path immediately below, and widened again by `screen::promote_dsa_depth_if_deep_pixels_written()` once a guest proves it writes deeper pixels. The `conv_res != color_last` sentinel check is untouched.

The branch only applies to `epocver <= epoc6`, so nothing on 8.1a/EKA2 devices is affected.

### Verification

Per application on the N-Gage ROM — the only way to cover this, since the automated suites are all EKA2:

| Title | Before | After |
|---|---|---|
| Cybersaurus | 3D level renders with a cyan/green cast | expected red/orange/brown/green palette; survives new-game cleanup |
| Bowling Master | reaches the lane | unchanged |
| Killer Virus | reaches combat | unchanged |
| Jungle King | reaches its playable scene | unchanged |
| X-Plore | reaches its file browser | **regresses** to the `USER 44` heap panic described above |

The X-Plore regression is the known and intended cost of the revert.