### PR TITLE
fix(netplay): make Bluetooth netplay reach a peer, and survive teardown

### DIFF
--- a/src/emu/services/CMakeLists.txt
+++ b/src/emu/services/CMakeLists.txt
@@ -99,6 +99,7 @@ add_library(epocservs
         include/services/msv/msv.h
         include/services/msv/store.h
         include/services/notifier/notifier.h
+        include/services/notifier/bluetooth.h
         include/services/notifier/queries.h
         include/services/posix/op.h
         include/services/posix/posix.h
@@ -252,6 +253,7 @@ add_library(epocservs
         src/msv/registry.cpp
         src/msv/store.cpp
         src/notifier/notifier.cpp
+        src/notifier/bluetooth.cpp
         src/notifier/queries.cpp
         src/posix/posix.cpp
         src/redir/redir.cpp

--- a/src/emu/services/include/services/bluetooth/protocols/asker_inet.h
+++ b/src/emu/services/include/services/bluetooth/protocols/asker_inet.h
@@ -24,6 +24,7 @@
 #include <common/sync.h>
 #include <uvlooper/uvlooper.h>
 
+#include <atomic>
 #include <memory>
 #include <optional>
 #include <vector>
@@ -63,8 +64,7 @@ namespace eka2l1::epoc::bt {
 
         bool in_transfer_data_callback_;
         std::uint32_t asker_id_;
-
-        epoc::socket::saddress dest_addr_;
+        std::shared_ptr<std::atomic<bool>> alive_;
 
         void keep_sending_data();
         void handle_request_failure();
@@ -77,6 +77,15 @@ namespace eka2l1::epoc::bt {
     public:
         explicit asker_inet(midman_inet *midman);
         ~asker_inet();
+
+        /**
+         * @brief Close the libuv handles so they stop calling back into this object.
+         *
+         * Must be run on the loop thread. Idempotent. The owner has to call this before
+         * anything the response callback refers to is destroyed, since the retry timer
+         * keeps firing until the handle is actually closed.
+         */
+        void shutdown_handles();
 
         bool check_is_real_port_mapped(const epoc::socket::saddress &addr, const std::uint32_t real_port);
         std::optional<device_address> get_device_address(const epoc::socket::saddress &dest_friend);

--- a/src/emu/services/include/services/bluetooth/protocols/base_inet.h
+++ b/src/emu/services/include/services/bluetooth/protocols/base_inet.h
@@ -48,6 +48,9 @@ namespace eka2l1::epoc::bt {
         explicit btinet_socket(btlink_inet_protocol *protocol, std::unique_ptr<epoc::socket::socket> &inet_socket);
         virtual ~btinet_socket() override;
 
+        bool set_option(const std::uint32_t option_id, const std::uint32_t option_family,
+            std::uint8_t *buffer, const std::size_t avail_size) override;
+
         void bind(const epoc::socket::saddress &addr, epoc::notify_info &info) override;
         void accept(std::unique_ptr<epoc::socket::socket> *pending_sock, epoc::notify_info &complete_info) override;
         void send(const std::uint8_t *data, const std::uint32_t data_size, std::uint32_t *sent_size, const epoc::socket::saddress *addr, std::uint32_t flags, epoc::notify_info &complete_info) override;

--- a/src/emu/services/include/services/bluetooth/protocols/btlink/btlink_inet.h
+++ b/src/emu/services/include/services/bluetooth/protocols/btlink/btlink_inet.h
@@ -120,10 +120,8 @@ namespace eka2l1::epoc::bt {
             return epoc::socket::byte_order_little_endian;
         }
 
-        virtual std::unique_ptr<epoc::socket::socket> make_socket(const std::uint32_t family_id, const std::uint32_t protocol_id, const socket::socket_type sock_type) override {
-            // L2CAP will be the one handling this. This stack is currently only used for managing links.
-            return nullptr;
-        }
+        virtual std::unique_ptr<epoc::socket::socket> make_socket(const std::uint32_t family_id,
+            const std::uint32_t protocol_id, const socket::socket_type sock_type) override;
 
         virtual std::unique_ptr<epoc::socket::socket> make_empty_base_link_socket() {
             return nullptr;

--- a/src/emu/services/include/services/bluetooth/protocols/btmidman_inet.h
+++ b/src/emu/services/include/services/bluetooth/protocols/btmidman_inet.h
@@ -39,6 +39,25 @@ typedef struct uv_timer_s uv_timer_t;
 typedef struct uv_buf_t uv_buf_t;
 
 namespace eka2l1::epoc::bt {
+    /**
+     * @brief Disconnect and close a libuv handle. Must be called on the loop thread.
+     *
+     * A uvw handle keeps a self-reference alive inside libuv from init() until close(),
+     * so releasing the owning shared_ptr does not stop it: it keeps dispatching events
+     * into listeners that captured a `this` which is about to be freed. Owners have to
+     * drop the listeners and close the handle before they go away.
+     */
+    template <typename T>
+    inline void shutdown_uv_handle(std::shared_ptr<T> &handle) {
+        if (!handle) {
+            return;
+        }
+
+        handle->reset();
+        handle->close();
+        handle.reset();
+    }
+
     static constexpr std::uint32_t TIMEOUT_HEARING_STRANGER_MS = 2000;
     static constexpr std::uint16_t CENTRAL_SERVER_STANDARD_PORT = 27138;
     static constexpr std::uint16_t HARBOUR_PORT = 35689;
@@ -81,6 +100,11 @@ namespace eka2l1::epoc::bt {
         std::vector<friend_info> friends_;
         common::bitmap_allocator allocated_ports_;
         std::array<std::uint16_t, MAX_PORT> port_refs_;
+        // Host ports we actually asked the router to forward. A port ref is not
+        // proof of a mapping (accept() refs a port that was never published),
+        // so unmapping must follow this instead, or we delete a stranger's
+        // mapping on the same router.
+        std::array<bool, MAX_PORT> port_upnp_mapped_;
         std::uint32_t port_offset_;
         bool enable_upnp_;
 
@@ -88,6 +112,7 @@ namespace eka2l1::epoc::bt {
 
         std::shared_ptr<uvw::udp_handle> lan_discovery_call_listener_socket_;
         std::shared_ptr<uvw::tcp_handle> matching_server_socket_;
+        std::vector<char> matching_server_receive_buffer_;
 
         std::shared_ptr<uvw::udp_handle> bluetooth_queries_server_socket_;
         std::shared_ptr<uvw::timer_handle> hearing_timeout_timer_;
@@ -126,7 +151,7 @@ namespace eka2l1::epoc::bt {
         void handle_matching_server_msg(std::int64_t nread, const char *buf_ptr);
         void send_login();
         void send_logout(const bool close_and_reset = true);
-        void read_and_add_friend(const char *buf, char &buf_pointer);
+        void read_and_add_friend(const char *buf, std::int64_t nread, std::int64_t &buf_pointer);
         void add_friend(epoc::bt::friend_info &info);
         void on_timeout_friend_search();
 

--- a/src/emu/services/include/services/bluetooth/protocols/common.h
+++ b/src/emu/services/include/services/bluetooth/protocols/common.h
@@ -43,6 +43,9 @@ namespace eka2l1::epoc::bt {
         SOL_BT_LINK_MANAGER = 0x1011,
         SOL_BT_L2CAP = 0x1012,
         SOL_BT_RFCOMM = 0x1013,
+        SOL_BT_SAP_BASE = 0x2020,
+
+        BT_SET_NO_SECURITY_REQUIRED = 0x0997,
 
         HCI_READ_SCAN_ENABLE = 14,
         HCI_WRITE_SCAN_ENABLE = 15,

--- a/src/emu/services/include/services/bluetooth/protocols/common_inet.h
+++ b/src/emu/services/include/services/bluetooth/protocols/common_inet.h
@@ -14,6 +14,7 @@ namespace eka2l1::epoc::bt {
 
         QUERY_OPCODE_SERVER_LOGIN,
         QUERY_OPCODE_SERVER_LOGOUT,
+        QUERY_OPCODE_SERVER_PORT_EXTENSION,
         QUERY_OPCODE_RESULT_START = 100
     };
 }

--- a/src/emu/services/include/services/notifier/bluetooth.h
+++ b/src/emu/services/include/services/notifier/bluetooth.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#pragma once
+
+#include <services/bluetooth/protocols/btmidman_inet.h>
+#include <services/notifier/plugin.h>
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+
+namespace eka2l1::epoc::notifier {
+    class bluetooth_device_selection_plugin : public plugin_base, public epoc::bt::inet_stranger_call_observer {
+        struct request_state {
+            explicit request_state(kernel_system *kern)
+                : kern(kern) {
+            }
+
+            kernel_system *kern;
+            std::mutex lock;
+            epoc::bt::midman_inet *midman = nullptr;
+            epoc::des8 *response = nullptr;
+            epoc::notify_info complete_info{};
+            std::atomic<std::uint64_t> generation{ 0 };
+        };
+
+        std::shared_ptr<request_state> request_state_;
+        static void finish_request(const std::shared_ptr<request_state> &state, std::uint64_t generation);
+
+    public:
+        explicit bluetooth_device_selection_plugin(kernel_system *kern)
+            : plugin_base(kern)
+            , request_state_(std::make_shared<request_state>(kern)) {
+        }
+
+        ~bluetooth_device_selection_plugin() override;
+
+        epoc::uid unique_id() const override {
+            return 0x100069D1;
+        }
+
+        void handle(epoc::desc8 *request, epoc::des8 *response, epoc::notify_info &complete_info) override;
+        void cancel() override;
+
+        void on_stranger_call(epoc::socket::saddress &addr, std::uint32_t index_in_list) override;
+        void on_no_more_strangers() override;
+    };
+}

--- a/src/emu/services/src/bluetooth/protocols/asker_inet.cpp
+++ b/src/emu/services/src/bluetooth/protocols/asker_inet.cpp
@@ -36,11 +36,37 @@ namespace eka2l1::epoc::bt {
         , retry_times_(0)
         , callback_(nullptr)
         , in_transfer_data_callback_(true)
-        , asker_id_(midman->new_asker_id()) {
+        , asker_id_(midman->new_asker_id())
+        , alive_(std::make_shared<std::atomic<bool>>(true)) {
         request_done_evt_.set();
     }
     
+    void asker_inet::shutdown_handles() {
+        shutdown_uv_handle(asker_);
+        shutdown_uv_handle(asker_retry_timer_);
+    }
+
     asker_inet::~asker_inet() {
+        // A posted uvlooper task owns a separate uv_async handle and can run after
+        // our shared_ptr to the task is released. Make queued callbacks harmless
+        // before ordering handle teardown on the loop thread.
+        alive_->store(false, std::memory_order_release);
+
+        if (!libuv::default_looper->started()) {
+            return;
+        }
+
+        // RSocket::Close runs while the Symbian thread holds the kernel lock. The
+        // shared libuv loop can simultaneously be waiting for that lock in an inet
+        // callback, so waiting here would deadlock. The callbacks already reject work
+        // through alive_; transfer handle ownership to the loop and return immediately.
+        auto asker = std::move(asker_);
+        auto retry_timer = std::move(asker_retry_timer_);
+
+        libuv::default_looper->one_shot([asker = std::move(asker), retry_timer = std::move(retry_timer)]() mutable {
+            shutdown_uv_handle(asker);
+            shutdown_uv_handle(retry_timer);
+        });
     }
 
     void asker_inet::handle_request_failure() {
@@ -56,7 +82,11 @@ namespace eka2l1::epoc::bt {
     }
 
     void asker_inet::listen_to_data() {
-        asker_->on<uvw::udp_data_event>([this](const uvw::udp_data_event &event, uvw::udp_handle &handle) {
+        asker_->on<uvw::udp_data_event>([this, alive = alive_](const uvw::udp_data_event &event, uvw::udp_handle &handle) {
+            if (!alive->load(std::memory_order_acquire)) {
+                return;
+            }
+
             if (event.length < 4) {
                 return;
             }
@@ -80,7 +110,11 @@ namespace eka2l1::epoc::bt {
             }
         });
 
-        asker_->on<uvw::error_event>([this](const uvw::error_event &event, uvw::udp_handle &handle) {
+        asker_->on<uvw::error_event>([this, alive = alive_](const uvw::error_event &event, uvw::udp_handle &handle) {
+            if (!alive->load(std::memory_order_acquire)) {
+                return;
+            }
+
             handle_request_failure();
         });
 
@@ -94,7 +128,11 @@ namespace eka2l1::epoc::bt {
         if (asker_->send(*reinterpret_cast<const sockaddr *>(&dest_), buffer_.data(), static_cast<std::uint32_t>(buffer_.size())) < 0) {
             handle_request_failure();
         } else {
-            asker_retry_timer_->on<uvw::timer_event>([this](const uvw::timer_event &event, uvw::timer_handle &handle) {
+            asker_retry_timer_->on<uvw::timer_event>([this, alive = alive_](const uvw::timer_event &event, uvw::timer_handle &handle) {
+                if (!alive->load(std::memory_order_acquire)) {
+                    return;
+                }
+
                 handle_request_failure();
             });
 
@@ -113,8 +151,15 @@ namespace eka2l1::epoc::bt {
         GUEST_TO_BSD_ADDR(addr, addr_host);
 
         if (addr_host == nullptr) {
-            callback_(nullptr, BT_COMM_INET_INVALID_ADDR);
+            response_cb(nullptr, BT_COMM_INET_INVALID_ADDR);
             return;
+        }
+
+        if (addr_host->sa_family == AF_INET) {
+            std::memset(&dest_, 0, sizeof(dest_));
+            std::memcpy(&dest_, addr_host, sizeof(sockaddr_in));
+        } else {
+            std::memcpy(&dest_, addr_host, sizeof(sockaddr_in6));
         }
 
         request_done_evt_.reset();
@@ -122,16 +167,16 @@ namespace eka2l1::epoc::bt {
 
         retry_times_ = 0;
         callback_ = response_cb;
-        dest_addr_ = addr;
 
         buffer_.clear();
         buffer_.insert(buffer_.begin(), reinterpret_cast<char*>(&asker_id_), reinterpret_cast<char*>(&asker_id_ + 1));
         buffer_.insert(buffer_.end(), request, request + request_size);
 
         if (!send_data_task_) {
-            send_data_task_ = libuv::create_task([this]() {
-                sockaddr *addr_host = nullptr;
-                GUEST_TO_BSD_ADDR(dest_addr_, addr_host);
+            send_data_task_ = libuv::create_task([this, alive = alive_]() {
+                if (!alive->load(std::memory_order_acquire)) {
+                    return;
+                }
 
                 auto default_loop = uvw::loop::get_default();
 
@@ -147,12 +192,6 @@ namespace eka2l1::epoc::bt {
 
                 if (!asker_retry_timer_) {
                     asker_retry_timer_ = default_loop->resource<uvw::timer_handle>();
-                }
-
-                if (addr_host->sa_family == AF_INET) {
-                    std::memcpy(&dest_, addr_host, sizeof(sockaddr_in));
-                } else {
-                    std::memcpy(&dest_, addr_host, sizeof(sockaddr_in6));
                 }
 
                 listen_to_data();

--- a/src/emu/services/src/bluetooth/protocols/base_inet.cpp
+++ b/src/emu/services/src/bluetooth/protocols/base_inet.cpp
@@ -85,6 +85,19 @@ namespace eka2l1::epoc::bt {
         }
     }
 
+    bool btinet_socket::set_option(const std::uint32_t option_id, const std::uint32_t option_family,
+        std::uint8_t *buffer, const std::size_t avail_size) {
+        // KBTSetNoSecurityRequired is handled by Symbian's common
+        // CBluetoothSAP before protocol-specific options. Inet netplay has no
+        // Bluetooth security manager to configure, so accepting it represents
+        // the requested no-security policy for every emulated Bluetooth SAP.
+        if ((option_family == SOL_BT_SAP_BASE) && (option_id == BT_SET_NO_SECURITY_REQUIRED)) {
+            return true;
+        }
+
+        return socket::set_option(option_id, option_family, buffer, avail_size);
+    }
+
     void btinet_socket::bind(const epoc::socket::saddress &addr, epoc::notify_info &info) {
         if (addr.port_ > midman::MAX_PORT) {
             LOG_ERROR(SERVICE_BLUETOOTH, "Bluetooth bind port is only allowed to be from 1 to 60!");

--- a/src/emu/services/src/bluetooth/protocols/btlink/resolver_inet.cpp
+++ b/src/emu/services/src/bluetooth/protocols/btlink/resolver_inet.cpp
@@ -19,6 +19,7 @@
 
 #include <common/log.h>
 #include <services/bluetooth/btmidman.h>
+#include <services/bluetooth/protocols/base_inet.h>
 #include <services/bluetooth/protocols/btlink/btlink_inet.h>
 #include <services/bluetooth/protocols/btmidman_inet.h>
 #include <services/bluetooth/protocols/common.h>
@@ -31,6 +32,43 @@
 #include <utils/err.h>
 
 namespace eka2l1::epoc::bt {
+    namespace {
+        constexpr std::uint32_t K_UNDEFINED_PROTOCOL_OPTION_LEVEL = 0xFFFFFFFE;
+
+        class btlink_control_inet_socket final : public btinet_socket {
+        public:
+            btlink_control_inet_socket(btlink_inet_protocol *protocol,
+                std::unique_ptr<epoc::socket::socket> &inet_socket)
+                : btinet_socket(protocol, inet_socket) {
+            }
+
+            bool set_option(const std::uint32_t option_id, const std::uint32_t option_family,
+                std::uint8_t *buffer, const std::size_t avail_size) override {
+                // Symbian 8.1 Bluetooth opens the raw link-manager control
+                // socket with an undefined protocol level, then enables the
+                // provider with option 1. There is no host-side data path to
+                // configure; accepting it makes the existing HCI/LM controls
+                // available to the client.
+                if ((option_family == K_UNDEFINED_PROTOCOL_OPTION_LEVEL) && (option_id == 1)) {
+                    return true;
+                }
+
+                return btinet_socket::set_option(option_id, option_family, buffer, avail_size);
+            }
+        };
+    }
+
+    std::unique_ptr<epoc::socket::socket> btlink_inet_protocol::make_socket(const std::uint32_t family_id,
+        const std::uint32_t protocol_id, const socket::socket_type sock_type) {
+        // Link-manager sockets do not carry user data. They are nevertheless
+        // opened as raw sockets by Bluetooth clients to issue HCI/link-manager
+        // ioctls (for example, to change the scan mode). Reuse the common
+        // Bluetooth socket implementation without a backing TCP socket so
+        // those control operations remain available.
+        std::unique_ptr<epoc::socket::socket> empty_socket;
+        return std::make_unique<btlink_control_inet_socket>(this, empty_socket);
+    }
+
     btlink_inet_host_resolver::btlink_inet_host_resolver(btlink_inet_protocol *papa)
         : papa_(papa)
         , friend_name_entry_(nullptr)

--- a/src/emu/services/src/bluetooth/protocols/btmidman_inet.cpp
+++ b/src/emu/services/src/bluetooth/protocols/btmidman_inet.cpp
@@ -55,11 +55,12 @@ namespace eka2l1::epoc::bt {
             return;
         }
 
-        if (discovery_mode_ != DISCOVERY_MODE_DIRECT_IP) {
+        if (discovery_mode_ == DISCOVERY_MODE_LAN) {
             port_ = HARBOUR_PORT;
         }
 
         std::fill(port_refs_.begin(), port_refs_.end(), 0);
+        std::fill(port_upnp_mapped_.begin(), port_upnp_mapped_.end(), false);
 
         std::vector<std::uint64_t> errs;
         update_friend_list(conf.friend_addresses, errs);
@@ -102,7 +103,11 @@ namespace eka2l1::epoc::bt {
             addr_bind.sin6_family = (discovery_mode_ == DISCOVERY_MODE_LAN) ? AF_INET : AF_INET6;
             addr_bind.sin6_port = htons(static_cast<std::uint16_t>(port_));
 
-            bluetooth_queries_server_socket_->bind(*reinterpret_cast<sockaddr*>(&addr_bind));
+            // Nothing else reports on this socket, so an unchecked failure here
+            // leaves the whole discovery side dead with nothing in the log.
+            if (const int bind_err = bluetooth_queries_server_socket_->bind(*reinterpret_cast<sockaddr*>(&addr_bind)); bind_err < 0) {
+                LOG_ERROR(SERVICE_BLUETOOTH, "Can't bind the Bluetooth queries socket to port {}! Libuv error code={}", port_, bind_err);
+            }
 
             if (should_upnp_apply_to_port()) {
                 UPnP::TryPortmapping(static_cast<std::uint16_t>(port_), true);
@@ -117,8 +122,8 @@ namespace eka2l1::epoc::bt {
                 handle_queries_request(reinterpret_cast<sockaddr*>(&sender_ced.value()), event.data.get(), event.length);
             });
 
-            bluetooth_queries_server_socket_->on<uvw::error_event>([this](const uvw::error_event &event, uvw::udp_handle &handle) {
-                handle_queries_request(nullptr, nullptr, event.code());
+            bluetooth_queries_server_socket_->on<uvw::error_event>([](const uvw::error_event &event, uvw::udp_handle &handle) {
+                LOG_ERROR(SERVICE_BLUETOOTH, "Error on the Bluetooth queries socket! Libuv error code={}", event.code());
             });
 
             bluetooth_queries_server_socket_->recv();
@@ -133,8 +138,8 @@ namespace eka2l1::epoc::bt {
         if (should_upnp_apply_to_port()) {
             UPnP::StopPortmapping(static_cast<std::uint16_t>(port_), true);
 
-            for (std::size_t i = 0; i < port_refs_.size(); i++) {
-                if (port_refs_[i] != 0) {
+            for (std::size_t i = 0; i < port_upnp_mapped_.size(); i++) {
+                if (port_upnp_mapped_[i]) {
                     UPnP::StopPortmapping(static_cast<std::uint16_t>(port_offset_ + i), false);
                 }
             }
@@ -142,12 +147,30 @@ namespace eka2l1::epoc::bt {
 
         send_logout(true);
 
-        auto lan_discovery_call_listener_socket_copy = lan_discovery_call_listener_socket_;
-        auto bluetooth_queries_server_socket_copy = bluetooth_queries_server_socket_;
-        auto hearing_timeout_timer_copy = hearing_timeout_timer_;
+        if (!libuv::default_looper->started()) {
+            return;
+        }
 
-        libuv::default_looper->one_shot([lan_discovery_call_listener_socket_copy, bluetooth_queries_server_socket_copy, hearing_timeout_timer_copy]() {
+        // Every handle below dispatches into a listener that captured this, and stays
+        // alive on its own until closed, so this object may not go away until the loop
+        // thread has torn them all down. Blocking is safe: the default looper is started
+        // once and never stopped, so the task is always picked up.
+        common::event teardown_done;
+
+        libuv::default_looper->one_shot([this, &teardown_done]() {
+            // The asker goes first: its retry timer completes requests through a callback
+            // that reaches back into this object, which is already half torn down.
+            device_addr_asker_.shutdown_handles();
+
+            shutdown_uv_handle(lan_discovery_call_listener_socket_);
+            shutdown_uv_handle(bluetooth_queries_server_socket_);
+            shutdown_uv_handle(matching_server_socket_);
+            shutdown_uv_handle(hearing_timeout_timer_);
+
+            teardown_done.set();
         });
+
+        teardown_done.wait();
     }
 
     void midman_inet::on_timeout_friend_search() {
@@ -194,9 +217,44 @@ namespace eka2l1::epoc::bt {
     }
 
     void midman_inet::handle_queries_request(const sockaddr *sender, const char *buf, std::int64_t nread) {
-        const std::uint32_t asker_id = *reinterpret_cast<const std::uint32_t*>(buf);
+        // The datagram comes from the network, so it may be truncated or hostile. Every
+        // opcode below needs the asker ID plus the opcode byte before anything else.
+        static constexpr std::int64_t QUERY_HEADER_SIZE = 5;
+
+        if (!sender || !buf || (nread < QUERY_HEADER_SIZE)) {
+            return;
+        }
+
+        std::uint32_t asker_id = 0;
+        std::memcpy(&asker_id, buf, sizeof(asker_id));
+
         query_opcode opcode = static_cast<query_opcode>(buf[4]);
         char opcode_result_signature = QUERY_OPCODE_RESULT_START + opcode;
+
+        std::int64_t payload_size_needed = 0;
+
+        switch (opcode) {
+        case QUERY_OPCODE_GET_NAME:
+        case QUERY_OPCODE_GET_VIRTUAL_BLUETOOTH_ADDRESS:
+            break;
+
+        case QUERY_OPCODE_IS_REAL_PORT_MAPPED_TO_VIRTUAL_PORT:
+            payload_size_needed = 4;
+            break;
+
+        case QUERY_OPCODE_GET_REAL_PORT_FROM_VIRTUAL_PORT:
+            payload_size_needed = 2;
+            break;
+
+        default:
+            LOG_ERROR(SERVICE_BLUETOOTH, "Unhandeled query opcode: {}", static_cast<int>(opcode));
+            return;
+        }
+
+        if (nread < QUERY_HEADER_SIZE + payload_size_needed) {
+            LOG_ERROR(SERVICE_BLUETOOTH, "Query request with opcode {} is truncated (got {} bytes)", static_cast<int>(opcode), nread);
+            return;
+        }
 
         switch (opcode) {
         case QUERY_OPCODE_GET_NAME: {
@@ -255,7 +313,6 @@ namespace eka2l1::epoc::bt {
         }
 
         default:
-            LOG_ERROR(SERVICE_BLUETOOTH, "Unhandeled query opcode: {}", static_cast<int>(opcode));
             break;
         }
     }
@@ -294,23 +351,51 @@ namespace eka2l1::epoc::bt {
         current_active_observer_->on_stranger_call(info.real_addr_, static_cast<std::uint32_t>(friends_.size() - 1));
     }
 
-    void midman_inet::read_and_add_friend(const char *buf, char &buf_pointer) {
+    void midman_inet::read_and_add_friend(const char *buf, std::int64_t nread, std::int64_t &buf_pointer) {
         epoc::bt::friend_info info;
+        std::memset(&info.real_addr_, 0, sizeof(epoc::socket::saddress));
         info.dvc_addr_.padding_ = 0;
 
-        char is_ipv4 = buf[buf_pointer++];
-        if (is_ipv4) {
-            info.real_addr_.family_ = epoc::internet::INET_ADDRESS_FAMILY;
+        if (buf_pointer >= nread) {
+            LOG_ERROR(SERVICE_BLUETOOTH, "Player list from the matching server is truncated (got {} bytes)", nread);
 
-            *static_cast<epoc::internet::sinet_address &>(info.real_addr_).addr_long() = *reinterpret_cast<const std::uint32_t *>(buf);
-            buf_pointer += sizeof(std::uint32_t);
-        } else {info.real_addr_.family_ = epoc::internet::INET6_ADDRESS_FAMILY;
-
-            std::memcpy(static_cast<epoc::internet::sinet6_address &>(info.real_addr_).address_32x4(), buf, sizeof(std::uint32_t) * 4);
-            buf_pointer += sizeof(std::uint32_t) * 4;
+            buf_pointer = nread;
+            return;
         }
 
+        const std::uint8_t address_type = static_cast<std::uint8_t>(buf[buf_pointer++]);
+        if (address_type > 3) {
+            LOG_ERROR(SERVICE_BLUETOOTH, "Player list from the matching server has invalid address type {}", address_type);
+            buf_pointer = nread;
+            return;
+        }
+        const bool has_port = (address_type == 2) || (address_type == 3);
+        const bool is_ipv4 = (address_type == 1) || (address_type == 2);
+        const std::int64_t address_size = is_ipv4 ? 4 : 16;
+
+        if (buf_pointer + address_size + (has_port ? 2 : 0) > nread) {
+            LOG_ERROR(SERVICE_BLUETOOTH, "Player list from the matching server is truncated (got {} bytes)", nread);
+
+            buf_pointer = nread;
+            return;
+        }
+
+        if (is_ipv4) {
+            info.real_addr_.family_ = epoc::internet::INET_ADDRESS_FAMILY;
+            std::memcpy(static_cast<epoc::internet::sinet_address &>(info.real_addr_).addr_long(), buf + buf_pointer, address_size);
+        } else {
+            info.real_addr_.family_ = epoc::internet::INET6_ADDRESS_FAMILY;
+            std::memcpy(static_cast<epoc::internet::sinet6_address &>(info.real_addr_).address_32x4(), buf + buf_pointer, address_size);
+        }
+
+        buf_pointer += address_size;
+
         info.real_addr_.port_ = HARBOUR_PORT;
+        if (has_port) {
+            info.real_addr_.port_ = (static_cast<std::uint16_t>(static_cast<std::uint8_t>(buf[buf_pointer])) << 8)
+                | static_cast<std::uint8_t>(buf[buf_pointer + 1]);
+            buf_pointer += 2;
+        }
         add_friend(info);
     }
 
@@ -377,7 +462,7 @@ lookup:
             return false;
         }
         const std::lock_guard<std::mutex> guard(friends_lock_);
-        if ((index >= friends_.size()) && (friends_[index].real_addr_.family_ == 0)) {
+        if ((index >= friends_.size()) || (friends_[index].real_addr_.family_ == 0)) {
             return false;
         }
 
@@ -439,18 +524,20 @@ lookup:
             } else {
                 friends_[start_pos].dvc_addr_ = *result;
                 friend_device_address_mapping_.emplace(friends_[start_pos].dvc_addr_, start_pos);
-
-                refresh_friend_info_async_impl(start_pos + 1, callback);
             }
+
+            refresh_friend_info_async_impl(start_pos + 1, callback);
         });
     }
 
     void midman_inet::refresh_friend_infos_async(std::function<void()> callback) {
         if (discovery_mode_ == DISCOVERY_MODE_OFF) {
+            callback();
             return;
         }
 
         if (friend_info_cached_ || (friends_.size() == 0)) {
+            callback();
             return;
         }
 
@@ -484,7 +571,8 @@ lookup:
         }
 
         if (should_upnp_apply_to_port()) {
-            UPnP::TryPortmapping(virtual_port - 1 + port_offset_, false);
+            UPnP::TryPortmapping(static_cast<std::uint16_t>(port_offset_ + virtual_port - 1), false);
+            port_upnp_mapped_[virtual_port - 1] = true;
         }
 
         allocated_ports_.force_fill(virtual_port - 1, 1);
@@ -531,8 +619,12 @@ lookup:
         if (allocated_ports_.is_allocated(virtual_port - 1)) {
             std::uint32_t ref_count = --port_refs_[virtual_port - 1];
             if (ref_count == 0) {
-                if (should_upnp_apply_to_port()) {
-                    UPnP::StopPortmapping(virtual_port, false);
+                if (port_upnp_mapped_[virtual_port - 1]) {
+                    // The mapped port is the host one, not the virtual port:
+                    // passing the latter deleted whatever mapping happened to
+                    // sit on port 1..60 of the router.
+                    UPnP::StopPortmapping(static_cast<std::uint16_t>(port_offset_ + virtual_port - 1), false);
+                    port_upnp_mapped_[virtual_port - 1] = false;
                 }
                 allocated_ports_.deallocate(virtual_port - 1, 1);
             }
@@ -646,7 +738,12 @@ lookup:
 
                 char request_friends = QUERY_OPCODE_GET_PLAYERS;
 
-                if (discovery_mode_ == DISCOVERY_MODE_LAN) {
+                // Direct IP has no network-wide search: its peers come from the
+                // config list. Either socket can also be null when its setup
+                // failed. Only the timeout below must happen unconditionally --
+                // an observer that never gets on_no_more_strangers() leaves its
+                // guest request outstanding forever.
+                if ((discovery_mode_ == DISCOVERY_MODE_LAN) && lan_discovery_call_listener_socket_) {
                     sockaddr_in6 server_addr_modded;
 
                     // A bit of overflow would be ok, I guess))
@@ -670,7 +767,7 @@ lookup:
 
                     lan_discovery_call_listener_socket_->broadcast(true);
                     lan_discovery_call_listener_socket_->send(*reinterpret_cast<sockaddr*>(&server_addr_modded), broadcast_buf.data(), static_cast<std::uint32_t>(broadcast_buf.size()));
-                } else {
+                } else if ((discovery_mode_ == DISCOVERY_MODE_PROXY_SERVER) && matching_server_socket_) {
                     matching_server_socket_->write(&request_friends, 1);
                 }
 
@@ -704,6 +801,12 @@ lookup:
         const std::lock_guard<std::mutex> guard(friends_lock_);
         if (observer == current_active_observer_) {
             current_active_observer_ = nullptr;
+
+            if (!pending_observers_.empty()) {
+                current_active_observer_ = pending_observers_.front();
+                pending_observers_.erase(pending_observers_.begin());
+                send_call_for_strangers();
+            }
             return;
         }
 

--- a/src/emu/services/src/bluetooth/protocols/btmidman_lan_matching.cpp
+++ b/src/emu/services/src/bluetooth/protocols/btmidman_lan_matching.cpp
@@ -39,9 +39,11 @@ namespace eka2l1::epoc::bt {
             addr_bind.sin6_family = AF_INET;
             addr_bind.sin6_port = htons(static_cast<std::uint16_t>(LAN_DISCOVERY_PORT));
 
-            lan_discovery_call_listener_socket_->bind(*reinterpret_cast<sockaddr*>(&addr_bind));
-            lan_discovery_call_listener_socket_->on<uvw::error_event>([this](const uvw::error_event &event, uvw::udp_handle &handle) {
-                handle_lan_discovery_receive(nullptr, event.code(), nullptr);
+            if (const int bind_err = lan_discovery_call_listener_socket_->bind(*reinterpret_cast<sockaddr*>(&addr_bind)); bind_err < 0) {
+                LOG_ERROR(SERVICE_BLUETOOTH, "Can't bind the LAN discovery socket to port {}! Libuv error code={}", LAN_DISCOVERY_PORT, bind_err);
+            }
+            lan_discovery_call_listener_socket_->on<uvw::error_event>([](const uvw::error_event &event, uvw::udp_handle &handle) {
+                LOG_ERROR(SERVICE_BLUETOOTH, "Error on the LAN discovery listener socket! Libuv error code={}", event.code());
             });
 
             lan_discovery_call_listener_socket_->on<uvw::udp_data_event>([this](const uvw::udp_data_event &event, uvw::udp_handle &handle) {
@@ -58,6 +60,11 @@ namespace eka2l1::epoc::bt {
     }
 
     void midman_inet::handle_lan_discovery_receive(const char *buf, std::int64_t nread, const sockaddr *addr) {
+        // Broadcast datagrams come from the network, so they may be truncated or hostile.
+        if (!addr || !buf || (nread < 1)) {
+            return;
+        }
+
         const std::uint32_t LOCALHOST_ADDR = 0x100007F;
         if ((memcmp(&(reinterpret_cast<const sockaddr_in*>(addr)->sin_addr), local_addr_.user_data_, 4) == 0) ||
             (memcmp(&(reinterpret_cast<const sockaddr_in*>(addr)->sin_addr), &LOCALHOST_ADDR, 4) == 0)) {
@@ -70,7 +77,14 @@ namespace eka2l1::epoc::bt {
             add_lan_friend(addr);
         } else if (buf[0] == QUERY_OPCODE_GET_PLAYERS) {
             // Accept this discover call by sending back to the one waving at us!
-            if ((buf[1] == password_.length()) && (std::memcmp(password_.data(), buf + 2, buf[1]) == 0)) {
+            const std::int64_t password_length = (nread < 2) ? -1 : static_cast<std::uint8_t>(buf[1]);
+
+            if ((password_length < 0) || (nread < 2 + password_length)) {
+                LOG_ERROR(SERVICE_BLUETOOTH, "LAN discovery call is truncated (got {} bytes)", nread);
+                return;
+            }
+
+            if ((password_length == static_cast<std::int64_t>(password_.length())) && (std::memcmp(password_.data(), buf + 2, static_cast<std::size_t>(password_length)) == 0)) {
                 for (std::uint16_t i = 0; i < RETRY_LAN_DISCOVERY_TIME_MAX; i++) {
                     lan_discovery_call_listener_socket_->send(*addr, &exist_opcode, 1);
                 }

--- a/src/emu/services/src/bluetooth/protocols/btmidman_proxserv_matching.cpp
+++ b/src/emu/services/src/bluetooth/protocols/btmidman_proxserv_matching.cpp
@@ -81,9 +81,8 @@ namespace eka2l1::epoc::bt {
 
             matching_server_socket_copy_copy->bind(*reinterpret_cast<sockaddr*>(&addr_temp));
 
-            matching_server_socket_copy_copy->on<uvw::error_event>([this](const uvw::error_event &event, uvw::tcp_handle &handle) {
-                // Accept the fate and resend login
-                send_login();
+            matching_server_socket_copy_copy->on<uvw::error_event>([](const uvw::error_event &event, uvw::tcp_handle &handle) {
+                LOG_ERROR(SERVICE_BLUETOOTH, "Error on the central Bluetooth Netplay server socket! Libuv error code={}", event.code());
             });
 
             matching_server_socket_copy_copy->on<uvw::connect_event>([matching_server_socket_copy_copy, this](const uvw::connect_event &event, uvw::tcp_handle &handle) {
@@ -92,6 +91,10 @@ namespace eka2l1::epoc::bt {
                 });
 
                 matching_server_socket_copy_copy->read();
+
+                // The server puts us in the room named by our password, so it has to
+                // hear the login before it can answer any player query.
+                send_login();
             });
 
             int err = matching_server_socket_copy_copy->connect(*reinterpret_cast<const sockaddr *>(&meta_server_addr));
@@ -135,7 +138,7 @@ namespace eka2l1::epoc::bt {
         int err = matching_server_socket_->write(&package, 1);
 
         if (err < 0) {
-            LOG_ERROR(SERVICE_BLUETOOTH, , err);
+            LOG_ERROR(SERVICE_BLUETOOTH, "Fail to send logout request to server! Libuv's error code {}", err);
         }
 
         if (close_and_reset) {
@@ -146,28 +149,94 @@ namespace eka2l1::epoc::bt {
     }
 
     void midman_inet::handle_matching_server_msg(std::int64_t nread, const char *buf) {
-        if (buf[0] == QUERY_OPCODE_NOTIFY_PLAYER_EXISTENCE) {
-            if (!current_active_observer_) {
+        if (!buf || (nread <= 0)) {
+            return;
+        }
+
+        // Opcode, player count, then one entry per player: a type byte, an address
+        // of at most 16 bytes and an optional port. Anything past that is not a
+        // message this protocol can produce, so stop reassembling instead of
+        // growing the buffer on whatever the socket keeps handing us.
+        static constexpr std::size_t MAX_MATCHING_SERVER_MESSAGE_SIZE = 2 + 255 * (1 + 16 + 2);
+
+        matching_server_receive_buffer_.insert(matching_server_receive_buffer_.end(), buf, buf + nread);
+        if (matching_server_receive_buffer_.size() > MAX_MATCHING_SERVER_MESSAGE_SIZE) {
+            LOG_ERROR(SERVICE_BLUETOOTH, "Matching server sent an oversized reply");
+            matching_server_receive_buffer_.clear();
+            return;
+        }
+
+        while (matching_server_receive_buffer_.size() >= 2) {
+            const std::uint8_t opcode = static_cast<std::uint8_t>(matching_server_receive_buffer_[0]);
+            if (opcode == QUERY_OPCODE_SERVER_PORT_EXTENSION) {
+                if (static_cast<std::uint8_t>(matching_server_receive_buffer_[1]) >= 1) {
+                    const std::uint16_t advertised_port = static_cast<std::uint16_t>(port_);
+                    char package[] = {
+                        static_cast<char>(QUERY_OPCODE_SERVER_PORT_EXTENSION),
+                        static_cast<char>(advertised_port >> 8),
+                        static_cast<char>(advertised_port & 0xFF)
+                    };
+                    matching_server_socket_->write(package, sizeof(package));
+                }
+                matching_server_receive_buffer_.erase(matching_server_receive_buffer_.begin(),
+                    matching_server_receive_buffer_.begin() + 2);
+                continue;
+            }
+
+            if (opcode != QUERY_OPCODE_NOTIFY_PLAYER_EXISTENCE) {
+                LOG_ERROR(SERVICE_BLUETOOTH, "Matching server sent unknown opcode {}", opcode);
+                matching_server_receive_buffer_.clear();
                 return;
+            }
+
+            const std::uint8_t friend_count = static_cast<std::uint8_t>(matching_server_receive_buffer_[1]);
+            std::size_t packet_size = 2;
+            bool complete = true;
+            for (std::uint8_t i = 0; i < friend_count; i++) {
+                if (packet_size >= matching_server_receive_buffer_.size()) {
+                    complete = false;
+                    break;
+                }
+
+                const std::uint8_t address_type = static_cast<std::uint8_t>(matching_server_receive_buffer_[packet_size]);
+                if (address_type > 3) {
+                    LOG_ERROR(SERVICE_BLUETOOTH, "Player list from the matching server has invalid address type {}", address_type);
+                    matching_server_receive_buffer_.clear();
+                    return;
+                }
+
+                const bool is_ipv4 = (address_type == 1) || (address_type == 2);
+                const bool has_port = (address_type == 2) || (address_type == 3);
+                packet_size += 1 + (is_ipv4 ? 4 : 16) + (has_port ? 2 : 0);
+                if (packet_size > matching_server_receive_buffer_.size()) {
+                    complete = false;
+                    break;
+                }
+            }
+
+            if (!complete) {
+                return;
+            }
+
+            if (!current_active_observer_) {
+                matching_server_receive_buffer_.erase(matching_server_receive_buffer_.begin(),
+                    matching_server_receive_buffer_.begin() + packet_size);
+                continue;
             }
 
             hearing_timeout_timer_->stop();
 
-            char friend_count = buf[1];
-            char packet_stream_pointer = 2;
+            std::int64_t packet_stream_pointer = 2;
 
-            for (char i = 0; i < friend_count; i++) {
-                if (packet_stream_pointer >= nread) {
-                    break;
-                }
-
-                read_and_add_friend(buf, packet_stream_pointer);
+            for (std::uint8_t i = 0; i < friend_count; i++) {
+                read_and_add_friend(matching_server_receive_buffer_.data(), packet_size, packet_stream_pointer);
             }
+
+            matching_server_receive_buffer_.erase(matching_server_receive_buffer_.begin(),
+                matching_server_receive_buffer_.begin() + packet_size);
 
             // No need to restart, it's one time thing
             on_timeout_friend_search();
         }
-
-        return;
     }
 }

--- a/src/emu/services/src/bluetooth/protocols/l2cap/socket_inet.cpp
+++ b/src/emu/services/src/bluetooth/protocols/l2cap/socket_inet.cpp
@@ -75,7 +75,7 @@ namespace eka2l1::epoc::bt {
 
     bool l2cap_inet_socket::set_option(const std::uint32_t option_id, const std::uint32_t option_family,
         std::uint8_t *buffer, const std::size_t avail_size) {
-        return socket::set_option(option_id, option_family, buffer, avail_size);
+        return btinet_socket::set_option(option_id, option_family, buffer, avail_size);
     }
 
     void l2cap_inet_socket::receive(std::uint8_t *data, const std::uint32_t data_size, std::uint32_t *sent_size, epoc::socket::saddress *addr,

--- a/src/emu/services/src/notifier/bluetooth.cpp
+++ b/src/emu/services/src/notifier/bluetooth.cpp
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include <services/notifier/bluetooth.h>
+
+#include <kernel/kernel.h>
+#include <services/bluetooth/btman.h>
+#include <services/bluetooth/protocols/btmidman_inet.h>
+#include <services/bluetooth/protocols/common.h>
+
+#include <common/log.h>
+#include <uvlooper/uvlooper.h>
+
+#include <utils/err.h>
+
+#include <array>
+#include <cstring>
+
+namespace eka2l1::epoc::notifier {
+    namespace {
+        constexpr std::size_t bt_device_response_size = 544;
+        constexpr std::size_t bt_device_name_offset = 8;
+        constexpr std::size_t bt_device_class_offset = 512;
+
+        int write_selected_device(kernel_system *kern, epoc::des8 *response,
+            epoc::notify_info &complete_info, const epoc::bt::device_address &selected_address) {
+            std::array<std::uint8_t, bt_device_response_size> result{};
+            std::memcpy(result.data(), &selected_address, sizeof(selected_address));
+
+            constexpr std::u16string_view peer_name = u"EKA2L1 peer";
+            const std::uint32_t name_info = (static_cast<std::uint32_t>(epoc::buf) << 28)
+                | static_cast<std::uint32_t>(peer_name.size());
+            const std::uint32_t name_capacity = 248;
+            std::memcpy(result.data() + bt_device_name_offset, &name_info, sizeof(name_info));
+            std::memcpy(result.data() + bt_device_name_offset + sizeof(name_info), &name_capacity, sizeof(name_capacity));
+            std::memcpy(result.data() + bt_device_name_offset + sizeof(name_info) + sizeof(name_capacity),
+                peer_name.data(), peer_name.size() * sizeof(char16_t));
+
+            const std::uint32_t phone_device_class = 0x0200;
+            const std::int32_t valid = 1;
+            const std::size_t validity_offset = bt_device_class_offset + (kern->is_eka1() ? 4 : 12);
+            std::memcpy(result.data() + bt_device_class_offset, &phone_device_class, sizeof(phone_device_class));
+            std::memcpy(result.data() + validity_offset, &valid, sizeof(valid));
+            std::memcpy(result.data() + validity_offset + sizeof(valid), &valid, sizeof(valid));
+            std::memcpy(result.data() + validity_offset + sizeof(valid) * 2, &valid, sizeof(valid));
+
+            kernel::process *requester = complete_info.requester->owning_process();
+            return response->assign(requester, result.data(), result.size()) == 0
+                ? epoc::error_none : epoc::error_overflow;
+        }
+    }
+
+    bluetooth_device_selection_plugin::~bluetooth_device_selection_plugin() {
+        cancel();
+    }
+
+    void bluetooth_device_selection_plugin::handle(epoc::desc8 *, epoc::des8 *response,
+        epoc::notify_info &complete_info) {
+        if (!response) {
+            complete_info.complete(epoc::error_argument);
+            return;
+        }
+
+        btman_server *btman = kern_->get_by_name<btman_server>(
+            get_btman_server_name_by_epocver(kern_->get_epoc_version()));
+        if (!btman || !btman->get_midman() || btman->get_midman()->type() != epoc::bt::MIDMAN_INET_BT) {
+            complete_info.complete(epoc::error_not_supported);
+            return;
+        }
+
+        auto *midman = static_cast<epoc::bt::midman_inet *>(btman->get_midman());
+        epoc::bt::device_address selected_address{};
+        if (midman->get_friend_device_address(0, selected_address)) {
+            complete_info.complete(write_selected_device(kern_, response, complete_info, selected_address));
+            return;
+        }
+
+        const std::shared_ptr<request_state> state = request_state_;
+        std::lock_guard<std::mutex> guard(state->lock);
+        if (state->response) {
+            complete_info.complete(epoc::error_in_use);
+            return;
+        }
+
+        state->midman = midman;
+        state->response = response;
+        state->complete_info = complete_info;
+        state->generation.fetch_add(1, std::memory_order_acq_rel);
+        midman->begin_hearing_stranger_call(this);
+    }
+
+    void bluetooth_device_selection_plugin::cancel() {
+        const std::shared_ptr<request_state> state = request_state_;
+        epoc::bt::midman_inet *midman = nullptr;
+        epoc::notify_info complete_info;
+        {
+            std::lock_guard<std::mutex> guard(state->lock);
+            state->generation.fetch_add(1, std::memory_order_acq_rel);
+            midman = state->midman;
+            complete_info = state->complete_info;
+            state->midman = nullptr;
+            state->response = nullptr;
+            state->complete_info = epoc::notify_info();
+        }
+
+        if (midman) {
+            midman->unregister_stranger_call_observer(this);
+            complete_info.complete(epoc::error_cancel);
+        }
+    }
+
+    void bluetooth_device_selection_plugin::on_stranger_call(epoc::socket::saddress &, std::uint32_t) {
+        // The peer list is read from the midman once the search ends, so an
+        // individual sighting needs no bookkeeping here.
+    }
+
+    void bluetooth_device_selection_plugin::on_no_more_strangers() {
+        const std::shared_ptr<request_state> state = request_state_;
+        const std::uint64_t generation = state->generation.load(std::memory_order_acquire);
+        libuv::default_looper->one_shot([state, generation]() {
+            if (generation != state->generation.load(std::memory_order_acquire)) {
+                return;
+            }
+
+            epoc::bt::midman_inet *midman = nullptr;
+            {
+                std::lock_guard<std::mutex> guard(state->lock);
+                midman = state->midman;
+            }
+
+            // Hearing no stranger does not mean there is no peer: direct IP takes
+            // its peers from the config list and never announces them through the
+            // observer, so a silent search there just means the friend's virtual
+            // address is not resolved yet. Let the refresh below decide.
+            if (!midman) {
+                finish_request(state, generation);
+                return;
+            }
+
+            epoc::bt::device_address selected_address{};
+            if (midman->get_friend_device_address(0, selected_address)) {
+                finish_request(state, generation);
+                return;
+            }
+
+            midman->refresh_friend_infos_async([state, generation]() {
+                finish_request(state, generation);
+            });
+        });
+    }
+
+    void bluetooth_device_selection_plugin::finish_request(const std::shared_ptr<request_state> &state,
+        const std::uint64_t generation) {
+        if (generation != state->generation.load(std::memory_order_acquire)) {
+            return;
+        }
+
+        state->kern->lock();
+        std::lock_guard<std::mutex> guard(state->lock);
+        if ((generation != state->generation.load(std::memory_order_acquire)) || !state->response) {
+            state->kern->unlock();
+            return;
+        }
+
+        epoc::bt::device_address selected_address{};
+        const bool found = state->midman && state->midman->get_friend_device_address(0, selected_address);
+        const int result = found
+            ? write_selected_device(state->kern, state->response, state->complete_info, selected_address)
+            : epoc::error_not_found;
+
+        state->midman = nullptr;
+        state->response = nullptr;
+        epoc::notify_info complete_info = state->complete_info;
+        state->complete_info = epoc::notify_info();
+        state->generation.fetch_add(1, std::memory_order_acq_rel);
+        complete_info.complete(result);
+        state->kern->unlock();
+    }
+}

--- a/src/emu/services/src/notifier/notifier.cpp
+++ b/src/emu/services/src/notifier/notifier.cpp
@@ -176,6 +176,11 @@ namespace eka2l1 {
             break;
 
         case notifier_cancel:
+            if (const std::optional<epoc::uid> plugin_uid = ctx->get_argument_value<epoc::uid>(0)) {
+                if (epoc::notifier::plugin_base *plug = server<notifier_server>()->get_plugin(*plugin_uid)) {
+                    plug->cancel();
+                }
+            }
             ctx->complete(epoc::error_none);
             break;
 

--- a/src/emu/services/src/notifier/queries.cpp
+++ b/src/emu/services/src/notifier/queries.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <services/notifier/queries.h>
+#include <services/notifier/bluetooth.h>
 #include <services/ui/plugins/keylocknof.h>
 #include <services/ui/plugins/notenof.h>
 
@@ -26,6 +27,7 @@ namespace eka2l1::epoc::notifier {
 #define ADD_PLUGIN(name) plugins.push_back(std::make_unique<name>(kern))
         ADD_PLUGIN(note_display_plugin);
         ADD_PLUGIN(keylock_plugin);
+        ADD_PLUGIN(bluetooth_device_selection_plugin);
 #undef ADD_PLUGIN
 
         std::sort(plugins.begin(), plugins.end(), [](const plugin_instance &lhs, const plugin_instance &rhs) {


### PR DESCRIPTION
Bluetooth netplay could not complete a session in any of its three discovery modes, and shutting one down took the emulator with it. This is one batch because the fixes are sequential — each one only becomes reachable once the one before it is in place — but they are independent in what they touch, and the table at the end says which symptom each repairs.

Nothing here branches on a game UID or a platform.

## Reaching a peer at all

**Login was never sent.** `send_login()` was only ever called from the matching socket's `error_event` listener, so we logged in if and only if the connection had already failed. It now goes out from `connect_event` — the server puts us in the room named by our password, so it has to hear the login before it can answer any player query.

**One TCP read was assumed to be one message.** `handle_matching_server_msg()` now reassembles across reads, tolerates a truncated or oversized reply, and answers `QUERY_OPCODE_SERVER_PORT_EXTENSION` so two peers behind the same public address can be told apart by port.

**`read_and_add_friend()` read from the front of the buffer instead of the cursor**, so any player list with more than one entry produced garbage friends. It now honours the cursor and parses all four address-type encodings (v4/v6, with and without a port).

**Direct IP never selected a peer.** Its peers come from the configured list and are never announced through the observer. `send_call_for_strangers()` wrote to `matching_server_socket_` for every non-LAN mode although only proxy-server mode creates it, and the LAN branch dereferenced a listener socket that `setup_lan_discovery()` leaves null when it finds no usable interface. Both are guarded, and the hearing timeout is now armed unconditionally — an observer that never receives `on_no_more_strangers()` leaves its guest request outstanding forever.

**One unreachable friend stopped the rest.** `refresh_friend_info_async_impl()` only continued the chain on success; `refresh_friend_infos_async()` dropped its callback on both early-out paths. `get_friend_address()` also tested `(index >= size()) && (family == 0)`, which accepts an out-of-range index — it is an `||`.

## The device-selection notifier

Games pick their peer through the Bluetooth device-selection notifier (`0x100069D1`) before they open a socket. It was not implemented, so the notifier server answered nothing and the game bounced straight back to its role menu. This adds the plugin, backed by the midman's friend list, and makes `notifier_cancel` reach the plugin rather than just completing the message.

## Bluetooth socket options

Symbian's `CBluetoothSAP` sets `KBTSetNoSecurityRequired` before any protocol-specific option, and inet netplay has no security manager to configure, so `btinet_socket` accepts it for every emulated SAP and L2CAP defers to that instead of straight to `socket::set_option`. `btlink_inet_protocol::make_socket()` returned null, although clients open the raw link-manager socket to issue HCI/link-manager ioctls; it now returns a control socket that also accepts the Symbian 8.1 provider-enable option.

## Teardown

A uvw handle keeps itself alive inside libuv from `init()` until `close()`, so releasing the owning `shared_ptr` does not stop it dispatching into listeners that captured a `this` about to be freed. The previous code copied the shared_ptrs into an empty `one_shot`, which only moved the release to the loop thread. Handles are now reset and closed there.

`midman_inet` waits for that to finish. `asker_inet` cannot: `RSocket::Close` runs under the kernel lock that the loop thread may itself be waiting for, so it hands its handles to the loop and disarms its callbacks through a shared flag instead.

## Hardening the network-facing parsers

`handle_queries_request()` read a four-byte asker ID and an opcode out of an unvalidated datagram, and its `error_event` listener called it with a null buffer — dereferencing null on the first byte. `handle_lan_discovery_receive()` read a password length and then compared that many bytes. Both now check the datagram against what each opcode needs before reading it.

## UPnP

`close_port()` unmapped the *virtual* port number rather than the host port it had mapped, deleting an unrelated mapping on the router while leaving the real one behind. The destructor's sweep keyed off port refcounts, which `accept()` raises for ports that were never published. Both now follow a record of the ports this instance actually asked the router to forward.

Also: `bind()` failures on the two discovery sockets were silent, and one logout error used `LOG_ERROR(SERVICE_BLUETOOTH, , err)` — an empty format string.

## What breaks without each piece

| Removed | Symptom |
|---|---|
| login from `connect_event` | proxy-server mode never receives a player list |
| message reassembly | a player list split across reads is dropped or misparsed |
| cursor in `read_and_add_friend` | second and later friends have garbage addresses |
| unconditional hearing timeout | direct IP: the guest request never completes, game hangs on its role menu |
| notifier plugin | the game returns to its role menu instead of a peer list |
| `refresh_friend_info_async_impl` continuation | one unreachable friend hides every friend after it |
| `make_socket` control socket | link-manager ioctls (scan mode) fail on 8.1 clients |
| handle close on the loop thread | crash on session teardown, in a listener holding a freed `this` |
| datagram bounds checks | null dereference / overread from any host on the network |
| UPnP host-port record | an unrelated mapping is deleted from the router; ours is left behind |

## Verification

- Two emulator instances on one host, LAN mode and direct IP mode: both reach the synchronized in-game state.
- Proxy-server mode against the central server.
- `ekatests` on macOS arm64: 184 test cases / 3341 assertions, all passing — identical to `master` on the same build.

> **Correction.** This section first reported "87/95 passing, 8 pre-existing failures". That was an artefact of running `ekatests` from the repository root: its loader tests open `loaderassets/` relative to the working directory, and the missing asset crashes `simple_icon_handler` with SIGSEGV, which aborts the run partway and makes Catch2 print a partial summary. Run from the build directory the suite is fully green, on this branch and on `master` alike.
