### PR TITLE
fix(ios): drain the deferred teardown queue when a guest app is closed

### DIFF
--- a/src/emu/ios/Bridge/IosEmulator.mm
+++ b/src/emu/ios/Bridge/IosEmulator.mm
@@ -1851,8 +1851,9 @@ namespace eka2l1::ios {
     // is back, so an orphaned player would keep playing forever. Destroy them here instead,
     // now that the kernel lock is released: an audio teardown waits out the render callback
     // in flight, and that callback needs the kernel lock to finish guest notifications.
-    // TODO: the deferred-teardown queue this used to drain arrives with the audio
-    // lifetime work that follows this port; there is nothing to flush yet.
+    if (auto *dispatcher = _state->symsys->get_dispatcher()) {
+        dispatcher->flush_pending_teardown();
+    }
 }
 
 - (BOOL)installSisAtPath:(NSString *)sisPath {


### PR DESCRIPTION
Exiting a guest app from the iOS overlay menu leaves its audio playing forever. Only killing the whole iOS app, or launching another guest app (which reboots the session), stops it.

## The half that is already here

`closeRunningApp` carries the comment that explains exactly why a flush belongs at that point:

```objc
// Killing the process orphans the HLE objects it owned (audio players above all), and
// those are destroyed by the emulation loop — which is parked for good once the app list
// is back, so an orphaned player would keep playing forever. Destroy them here instead,
// now that the kernel lock is released: an audio teardown waits out the render callback
// in flight, and that callback needs the kernel lock to finish guest notifications.
// TODO: the deferred-teardown queue this used to drain arrives with the audio
// lifetime work that follows this port; there is nothing to flush yet.
```

That work has since landed. `dispatcher::on_process_exit` detaches every `dsp_medium` belonging to a dying process into `mediums_pending_destroy_`, and `dispatcher::flush_pending_teardown` destroys them. What it never got was this second call site, so the TODO is now stale and the comment above it describes a leak that is live.

## Why `system_impl::loop`'s call is not enough

A killed process never runs the guest destructor that would have released its `CMdaAudioPlayerUtility`, and the dispatcher's `dsp_manager` is process-agnostic — nothing else references those objects, so they are orphaned rather than freed.

They also cannot be destroyed inline in `process::kill`. Destroying a medium stops the host stream, `AudioOutputUnitStop` waits out the render callback in flight, and that callback takes the kernel lock to complete guest notifications — a lock `closeRunningApp` is holding while it kills the process. Deferring to the emulation loop is the right answer everywhere else; it is not here, because once the app list is back the OS thread is parked and `loop()` is never called again.

## Verification

Sampled on the simulator with `sample <pid>`, Angry Birds on the X7 with sound, counting `AURemoteIO::PerformIO` / `RenderBus` frames in the host process:

| | while playing | several seconds after Exit Game |
|---|---|---|
| `master` | 8 frames | **6 frames** |
| this branch | 8 frames | **0 frames** |

Same host process in both columns, so what persists on `master` is a live output unit still pulling, not a stale buffer:

```
+   15 AURemoteIO::PerformIO(...) + 1192
+     : 14 AURemoteIO::RenderBus(...) + 220
+     :   14 AUConverterBase::RenderBus(...) + 728
```

iOS regression suite 12/12 on the Release simulator build.