### PR TITLE
feat(ios): pull the app grid down to re-scan the registry

### DIFF
--- a/src/emu/ios/App/ContentView.swift
+++ b/src/emu/ios/App/ContentView.swift
@@ -10,7 +10,7 @@ import UniformTypeIdentifiers
 //     switcher and, below a divider, "Install device" and "Manage devices";
 //     the ellipsis menu holds Settings, the system-apps toggle and help; the
 //     "+" menu installs a SIS, a classic N-Gage game card, or an N-Gage 2.0
-//     package onto the device.
+//     package onto the device. Pulling the grid down re-scans the registry.
 
 // SIS files only — device ROM / RPKG go through ImportDeviceView's own picker.
 private let sisTypes: [UTType] = {
@@ -339,6 +339,8 @@ struct ContentView: View {
             }
             .padding()
         }
+        // Pull down on the grid to re-scan the device's app registry.
+        .refreshable { await store.refreshApps() }
     }
 
     // The navigation title's tap menu (SwiftUI toolbarTitleMenu): the device

--- a/src/emu/ios/App/DeviceStore.swift
+++ b/src/emu/ios/App/DeviceStore.swift
@@ -38,6 +38,27 @@ final class DeviceStore: ObservableObject {
         apps = currentIndex >= 0 ? EKA2L1Bridge.shared.rescanApps() : []
     }
 
+    // Pull-to-refresh on the home grid: re-read the device titles and re-scan
+    // the booted device's registry, picking up apps that appeared behind the
+    // frontend's back (a package dropped in through the Files app, a guest-side
+    // installer). The scan stays on the main actor — rescanApps only try-locks
+    // the emulator session and hands back its cached list rather than blocking
+    // (see IosEmulator.mm) — so the async signature exists purely to keep the
+    // refresh control's spinner up until the new list is published.
+    func refreshApps() async {
+        guard !busy else { return }
+        let started = Date()
+        reloadDevices()
+        reloadApps()
+        // A scan that lost the session lock returns instantly; hold the spinner
+        // for a beat so the gesture still reads as "refreshed" instead of
+        // snapping back before the user let go.
+        let remaining = 0.4 - Date().timeIntervalSince(started)
+        if remaining > 0 {
+            try? await Task.sleep(nanoseconds: UInt64(remaining * 1_000_000_000))
+        }
+    }
+
     // Titles only (a rename in Settings): the device set and booted device are
     // unchanged, so neither a reboot nor an app re-scan is needed.
     func reloadDevices() {


### PR DESCRIPTION
## Summary

The iOS home grid only re-scanned the device's app registry on boot, on a package install/uninstall, and on a system-language switch. Anything that changed the registry behind the frontend's back — a guest-side installer, a package dropped onto a drive through the Files app — left the grid stale, with no way to refresh it short of switching devices back and forth.

This attaches a standard SwiftUI refresh control to the grid: pull down, the registry is re-scanned and the device titles are re-read.

## Notes

- The scan stays on the main actor. `rescanApps()` only *try*-locks the emulator session and hands back its cached list rather than blocking (see `IosEmulator.mm`), so the `async` refresh action exists purely to keep the spinner up until the new list is published — with a short floor so a scan that lost the lock still reads as a refresh instead of snapping back before the user lets go.
- Refreshing is skipped while a long emulator operation (device switch, package install) is in flight, matching the other controls that gate on `busy`.
- `.refreshable` on a `ScrollView` needs iOS 16, which is the project's deployment target.
- No new localized strings — the `Apps (N)` header and the grid itself are the feedback.

## Testing

Debug simulator build, iPhone 16 Pro, N95 device with 20 apps installed:

- Pull-to-refresh shows the standard refresh spinner; on release the grid returns intact.
- The emulator log records a full `[Service.Applist]: Loading app registries … Done loading!` cycle for the gesture, so the re-scan genuinely runs rather than re-publishing the cached list.
- No panics, access violations or graphics halts in the log.

Frontend-only change; the underlying path is the same `rescanApps` call already made on boot and after a package install, so emulator behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZ7NvaBCpuHVphrvhLkHtF