### PR TITLE
fix(desktop): expose Settings in the macOS application menu

### DIFF
--- a/src/emu/qt/src/mainwindow.ui
+++ b/src/emu/qt/src/mainwindow.ui
@@ -95,6 +95,8 @@
     <addaction name="action_refresh_app_list"/>
     <addaction name="menu_mount_game_card_dump"/>
     <addaction name="action_mount_recent_dumps"/>
+    <addaction name="separator"/>
+    <addaction name="action_settings"/>
    </widget>
    <widget class="QMenu" name="menu_view">
     <property name="title">
@@ -155,7 +157,6 @@
    <addaction name="menu_view"/>
    <addaction name="menu_control"/>
    <addaction name="menu_bluetooth"/>
-   <addaction name="action_settings"/>
    <addaction name="menu_help"/>
   </widget>
   <widget class="QStatusBar" name="status_bar"/>
@@ -180,6 +181,9 @@
    </property>
   </action>
   <action name="action_settings">
+   <property name="menuRole">
+    <enum>QAction::PreferencesRole</enum>
+   </property>
    <property name="text">
     <string>Settings</string>
    </property>


### PR DESCRIPTION
## Summary
- move the Settings action into the File menu
- mark it as `QAction::PreferencesRole` so Qt merges it into the native macOS application menu
- keep the action reachable through File on other desktop platforms

## Testing
- `ninja -C build/macos eka2l1_qt`
- verified `Preferences...` appears in the native macOS application menu
- verified it opens the Settings dialog