### PR TITLE
Fix ROM loading crashes for ROMs with unaligned base addresses (fixes #666)

### DIFF
--- a/src/emu/common/src/allocator.cpp
+++ b/src/emu/common/src/allocator.cpp
@@ -130,6 +130,12 @@ namespace eka2l1::common {
     }
 
     int bitmap_allocator::force_fill(const std::uint32_t offset, const int size, const bool or_mode) {
+        // The loop below only guards against running over the end of the bitmap;
+        // an offset already past it would start reading and writing foreign memory.
+        if ((offset >> 5) >= words_.size()) {
+            return 0;
+        }
+
         std::uint32_t *word = &words_[0] + (offset >> 5);
         const std::uint32_t set_bit = offset & 31;
         int end_bit = static_cast<int>(set_bit + size);

--- a/src/emu/kernel/include/kernel/codeseg.h
+++ b/src/emu/kernel/include/kernel/codeseg.h
@@ -80,8 +80,8 @@ namespace eka2l1::kernel {
 
         epoc::security_info sinfo;
 
-        std::uint8_t *constant_data;
-        std::uint8_t *code_data;
+        std::uint8_t *constant_data = nullptr;
+        std::uint8_t *code_data = nullptr;
     };
 
     enum codeseg_state {

--- a/src/emu/kernel/include/kernel/kernel.h
+++ b/src/emu/kernel/include/kernel/kernel.h
@@ -338,6 +338,7 @@ namespace eka2l1 {
 
         mutable std::atomic<kernel::uid> uid_counter_;
         void *rom_map_;
+        std::size_t rom_map_size_;
 
         std::uint64_t base_time_;
         std::uint32_t cpu_hz_;
@@ -515,6 +516,7 @@ namespace eka2l1 {
         codeseg_ptr pull_codeseg_by_ep(const address ep);
 
         bool map_rom(const mem::vm_address addr, const std::string &path);
+        void unmap_rom();
         bool should_panic_be_blocked(kernel::thread *thr, const std::string &category, const std::int32_t code);
 
         epocver get_epoc_version() const {

--- a/src/emu/kernel/src/codeseg.cpp
+++ b/src/emu/kernel/src/codeseg.cpp
@@ -57,14 +57,28 @@ namespace eka2l1::kernel {
         code_addr = info.code_load_addr;
         data_addr = info.data_load_addr;
 
+        // The source pointers come from translating guest addresses supplied by an
+        // image header. A malformed or mislocated header yields a null pointer here,
+        // and copying from it takes the emulator down with a segfault far away from
+        // the actual cause. Refuse the copy and leave the buffer unpopulated instead.
         if (info.data_size) {
-            constant_data = std::make_unique<std::uint8_t[]>(info.data_size);
-            std::copy(info.constant_data, info.constant_data + info.data_size, constant_data.get());
+            if (info.constant_data) {
+                constant_data = std::make_unique<std::uint8_t[]>(info.data_size);
+                std::copy(info.constant_data, info.constant_data + info.data_size, constant_data.get());
+            } else {
+                LOG_ERROR(KERNEL, "Code segment {} claims {} bytes of constant data but supplies no "
+                                  "pointer to it; skipping the copy", name, info.data_size);
+            }
         }
 
         if (code_addr == 0) {
-            code_data = std::make_unique<std::uint8_t[]>(info.code_size);
-            std::copy(info.code_data, info.code_data + info.code_size, code_data.get());
+            if (info.code_data) {
+                code_data = std::make_unique<std::uint8_t[]>(info.code_size);
+                std::copy(info.code_data, info.code_data + info.code_size, code_data.get());
+            } else {
+                LOG_ERROR(KERNEL, "Code segment {} has no load address and no code data pointer; "
+                                  "skipping the copy", name);
+            }
         }
 
         relocation_list = info.relocation_list;

--- a/src/emu/kernel/src/codeseg.cpp
+++ b/src/emu/kernel/src/codeseg.cpp
@@ -741,6 +741,10 @@ namespace eka2l1::kernel {
     }
 
     bool codeseg::add_dependency(const codeseg_dependency_info &codeseg) {
+        if (!codeseg.dep_) {
+            return false;
+        }
+
         // Check if this codeseg is unique first (no duplicate)
         // We don't check the UID though (TODO)
         auto result = std::find_if(dependencies.begin(), dependencies.end(),

--- a/src/emu/kernel/src/codeseg.cpp
+++ b/src/emu/kernel/src/codeseg.cpp
@@ -57,28 +57,19 @@ namespace eka2l1::kernel {
         code_addr = info.code_load_addr;
         data_addr = info.data_load_addr;
 
-        // The source pointers come from translating guest addresses supplied by an
-        // image header. A malformed or mislocated header yields a null pointer here,
-        // and copying from it takes the emulator down with a segfault far away from
-        // the actual cause. Refuse the copy and leave the buffer unpopulated instead.
+        // The creators guarantee these pointers before construction - a nonzero
+        // data_size comes with constant data to copy, and a missing load address
+        // comes with a code buffer (see the header validation in load_as_romimg).
+        // A half-initialized codeseg must never exist: later paths dereference
+        // these buffers whenever the sizes are nonzero.
         if (info.data_size) {
-            if (info.constant_data) {
-                constant_data = std::make_unique<std::uint8_t[]>(info.data_size);
-                std::copy(info.constant_data, info.constant_data + info.data_size, constant_data.get());
-            } else {
-                LOG_ERROR(KERNEL, "Code segment {} claims {} bytes of constant data but supplies no "
-                                  "pointer to it; skipping the copy", name, info.data_size);
-            }
+            constant_data = std::make_unique<std::uint8_t[]>(info.data_size);
+            std::copy(info.constant_data, info.constant_data + info.data_size, constant_data.get());
         }
 
         if (code_addr == 0) {
-            if (info.code_data) {
-                code_data = std::make_unique<std::uint8_t[]>(info.code_size);
-                std::copy(info.code_data, info.code_data + info.code_size, code_data.get());
-            } else {
-                LOG_ERROR(KERNEL, "Code segment {} has no load address and no code data pointer; "
-                                  "skipping the copy", name);
-            }
+            code_data = std::make_unique<std::uint8_t[]>(info.code_size);
+            std::copy(info.code_data, info.code_data + info.code_size, code_data.get());
         }
 
         relocation_list = info.relocation_list;

--- a/src/emu/kernel/src/kernel.cpp
+++ b/src/emu/kernel/src/kernel.cpp
@@ -106,8 +106,6 @@ namespace eka2l1 {
         wiping_ = true;
         timing_->remove_event(realtime_ipc_signal_evt_);
 
-        unmap_rom();
-
 #define OBJECT_CONTAINER_CLEANUP(container) \
     for (auto &obj : container) {           \
         if (obj)                            \
@@ -175,6 +173,12 @@ namespace eka2l1 {
             btrace_inst_->close_trace_session();
 
         cpu_->clear_instruction_cache();
+
+        // Only now is the host backing safe to release: the ROM chunk destroyed
+        // with the containers above held page-table entries and CPU mappings
+        // pointing into it.
+        unmap_rom();
+
         wiping_ = false;
     }
 

--- a/src/emu/kernel/src/kernel.cpp
+++ b/src/emu/kernel/src/kernel.cpp
@@ -46,6 +46,7 @@
 #include <kernel/scheduler.h>
 #include <kernel/thread.h>
 #include <loader/romimage.h>
+#include <mem/control.h>
 #include <mem/mem.h>
 #include <mem/ptr.h>
 #include <vfs/vfs.h>
@@ -82,6 +83,7 @@ namespace eka2l1 {
         , realtime_ipc_signal_evt_(0)
         , uid_counter_(0)
         , rom_map_(nullptr)
+        , rom_map_size_(0)
         , kern_ver_(epocver::epoc94)
         , lang_(language::en)
         , global_data_chunk_(nullptr)
@@ -104,11 +106,7 @@ namespace eka2l1 {
         wiping_ = true;
         timing_->remove_event(realtime_ipc_signal_evt_);
 
-        if (rom_map_) {
-            common::unmap_file(rom_map_);
-        }
-
-        rom_map_ = nullptr;
+        unmap_rom();
 
 #define OBJECT_CONTAINER_CLEANUP(container) \
     for (auto &obj : container) {           \
@@ -1355,28 +1353,82 @@ namespace eka2l1 {
     }
 
     bool kernel_system::map_rom(const mem::vm_address addr, const std::string &path) {
-        rom_map_ = common::map_file(path, prot_read_write, 0, true);
         const std::size_t rom_size = common::file_size(path);
 
-        if (!rom_map_) {
-            return false;
+        // The memory model can only place a chunk at a chunk-span-aligned base; a forced
+        // address gets aligned down to the previous boundary. Most ROMs declare an aligned
+        // base, and the file mapping can then back the chunk directly. A ROM with an
+        // unaligned base (e.g. 0xF80F1000 on the Nokia 5500 Sport) must instead be placed
+        // at its in-chunk offset, in a buffer starting at the aligned base - otherwise
+        // every guest-to-host translation inside the ROM comes out shifted by the
+        // discarded bits, and the ROM's tail ends up outside the chunk entirely.
+        const mem::vm_address aligned_base = addr & ~mem_->get_control()->chunk_mask_;
+        const std::size_t rebase_offset = addr - aligned_base;
+
+        if (rebase_offset == 0) {
+            rom_map_ = common::map_file(path, prot_read_write, 0, true);
+            rom_map_size_ = 0;
+
+            if (!rom_map_) {
+                return false;
+            }
+        } else {
+            LOG_INFO(KERNEL, "ROM base 0x{:X} is not chunk-aligned, mapping the ROM at offset 0x{:X} of a chunk at 0x{:X}",
+                addr, rebase_offset, aligned_base);
+
+            rom_map_size_ = rebase_offset + rom_size;
+            rom_map_ = common::map_memory(rom_map_size_);
+
+            if (!rom_map_) {
+                return false;
+            }
+
+            if (!common::commit(rom_map_, rom_map_size_, prot_read_write)) {
+                unmap_rom();
+                return false;
+            }
+
+            void *rom_file_map = common::map_file(path, prot_read, 0, true);
+
+            if (!rom_file_map) {
+                unmap_rom();
+                return false;
+            }
+
+            std::memcpy(reinterpret_cast<std::uint8_t *>(rom_map_) + rebase_offset, rom_file_map, rom_size);
+            common::unmap_file(rom_file_map);
         }
 
         LOG_TRACE(KERNEL, "Rom mapped to address: 0x{:x}", reinterpret_cast<std::uint64_t>(rom_map_));
 
+        const std::size_t chunk_size = rebase_offset + rom_size;
+
         // Don't care about the result as long as it's not null.
-        kernel::chunk *rom_chunk = create<kernel::chunk>(mem_, nullptr, "ROM", 0, static_cast<address>(rom_size),
-            rom_size, prot_read_write_exec, kernel::chunk_type::normal, kernel::chunk_access::rom,
-            kernel::chunk_attrib::none, 0x00, false, addr, rom_map_);
+        kernel::chunk *rom_chunk = create<kernel::chunk>(mem_, nullptr, "ROM", 0, static_cast<address>(chunk_size),
+            chunk_size, prot_read_write_exec, kernel::chunk_type::normal, kernel::chunk_access::rom,
+            kernel::chunk_attrib::none, 0x00, false, aligned_base, rom_map_);
 
         if (!rom_chunk) {
             LOG_ERROR(KERNEL, "Can't create ROM chunk!");
 
-            common::unmap_file(rom_map_);
+            unmap_rom();
             return false;
         }
 
         return true;
+    }
+
+    void kernel_system::unmap_rom() {
+        if (rom_map_) {
+            if (rom_map_size_) {
+                common::unmap_memory(rom_map_, rom_map_size_);
+            } else {
+                common::unmap_file(rom_map_);
+            }
+        }
+
+        rom_map_ = nullptr;
+        rom_map_size_ = 0;
     }
 
     void kernel_system::stop_cores_idling() {

--- a/src/emu/kernel/src/kernel.cpp
+++ b/src/emu/kernel/src/kernel.cpp
@@ -1359,15 +1359,21 @@ namespace eka2l1 {
     bool kernel_system::map_rom(const mem::vm_address addr, const std::string &path) {
         const std::size_t rom_size = common::file_size(path);
 
-        // The memory model can only place a chunk at a chunk-span-aligned base; a forced
-        // address gets aligned down to the previous boundary. Most ROMs declare an aligned
-        // base, and the file mapping can then back the chunk directly. A ROM with an
-        // unaligned base (e.g. 0xF80F1000 on the Nokia 5500 Sport) must instead be placed
-        // at its in-chunk offset, in a buffer starting at the aligned base - otherwise
-        // every guest-to-host translation inside the ROM comes out shifted by the
-        // discarded bits, and the ROM's tail ends up outside the chunk entirely.
-        const mem::vm_address aligned_base = addr & ~mem_->get_control()->chunk_mask_;
-        const std::size_t rebase_offset = addr - aligned_base;
+        // The multiple model can only place a chunk on a chunk-span boundary; a forced
+        // address below one gets aligned down. Most ROMs declare an aligned base, and
+        // the file mapping can then back the chunk directly. A ROM with an unaligned
+        // base (e.g. 0xF80F1000 on the Nokia 5500 Sport) must instead be placed at its
+        // in-chunk offset, in a buffer starting at the aligned base - otherwise every
+        // guest-to-host translation inside the ROM comes out shifted by the discarded
+        // bits, and the ROM's tail ends up outside the chunk entirely. The flexible
+        // model honors page-granular forced addresses and keeps the declared base.
+        mem::vm_address chunk_base = addr;
+        std::size_t rebase_offset = 0;
+
+        if (mem_->get_model_type() == mem::mem_model_type::multiple) {
+            chunk_base = addr & ~mem_->get_control()->chunk_mask_;
+            rebase_offset = addr - chunk_base;
+        }
 
         if (rebase_offset == 0) {
             rom_map_ = common::map_file(path, prot_read_write, 0, true);
@@ -1378,7 +1384,7 @@ namespace eka2l1 {
             }
         } else {
             LOG_INFO(KERNEL, "ROM base 0x{:X} is not chunk-aligned, mapping the ROM at offset 0x{:X} of a chunk at 0x{:X}",
-                addr, rebase_offset, aligned_base);
+                addr, rebase_offset, chunk_base);
 
             rom_map_size_ = rebase_offset + rom_size;
             rom_map_ = common::map_memory(rom_map_size_);
@@ -1387,6 +1393,11 @@ namespace eka2l1 {
                 return false;
             }
 
+            // The pad below the base is committed on purpose: this kind of ROM is
+            // sectioned, and the guest reads data below the declared base during boot
+            // (the section start holds the ROM header, for one) - leaving a hole there
+            // faults the boot. The dump carries no content for that range, so
+            // zero-filled pages are the closest thing to the real ROM's prefix.
             if (!common::commit(rom_map_, rom_map_size_, prot_read_write)) {
                 unmap_rom();
                 return false;
@@ -1408,9 +1419,9 @@ namespace eka2l1 {
         const std::size_t chunk_size = rebase_offset + rom_size;
 
         // Don't care about the result as long as it's not null.
-        kernel::chunk *rom_chunk = create<kernel::chunk>(mem_, nullptr, "ROM", 0, static_cast<address>(chunk_size),
-            chunk_size, prot_read_write_exec, kernel::chunk_type::normal, kernel::chunk_access::rom,
-            kernel::chunk_attrib::none, 0x00, false, aligned_base, rom_map_);
+        kernel::chunk *rom_chunk = create<kernel::chunk>(mem_, nullptr, "ROM", 0,
+            static_cast<address>(chunk_size), chunk_size, prot_read_write_exec, kernel::chunk_type::normal,
+            kernel::chunk_access::rom, kernel::chunk_attrib::none, 0x00, false, chunk_base, rom_map_);
 
         if (!rom_chunk) {
             LOG_ERROR(KERNEL, "Can't create ROM chunk!");

--- a/src/emu/kernel/src/libmanager.cpp
+++ b/src/emu/kernel/src/libmanager.cpp
@@ -717,6 +717,18 @@ namespace eka2l1::hle {
         info.exception_descriptor = romimg.header.exception_des;
         info.constant_data = reinterpret_cast<std::uint8_t *>(mem_->get_real_pointer(romimg.header.data_address));
 
+        // A ROM image that declares constant data must point at an address we can
+        // map. When it does not, the header we parsed is not a real image header --
+        // parse_romimg only fails on short reads, so arbitrary bytes parse "fine" --
+        // and going ahead would copy from a null pointer using a nonsense length.
+        if (romimg.header.data_size && !info.constant_data) {
+            LOG_ERROR(KERNEL, "ROM image {} declares {} bytes of constant data at unmapped address 0x{:X}; "
+                              "refusing to load it", common::ucs2_to_utf8(path), romimg.header.data_size,
+                romimg.header.data_address);
+
+            return nullptr;
+        }
+
         const std::string seg_name = (path.empty()) ? "codeseg" :
             common::lowercase_string(common::ucs2_to_utf8(eka2l1::filename(path)));
 
@@ -805,7 +817,13 @@ namespace eka2l1::hle {
                             common::ro_buf_stream buf_stream(eka2l1::ptr<std::uint8_t>(romimg_addr).get(mem_), 0xFFFF);
 
                             // Load new romimage and add dependency
-                            loader::romimg rimg = *loader::parse_romimg(reinterpret_cast<common::ro_stream *>(&buf_stream), mem_, kern_->get_epoc_version());
+                            auto rimg_parsed = loader::parse_romimg(reinterpret_cast<common::ro_stream *>(&buf_stream), mem_, kern_->get_epoc_version());
+                            if (!rimg_parsed) {
+                                LOG_ERROR(KERNEL, "Unable to parse ROM image dependency at address 0x{:X}, skipping it", romimg_addr);
+                                continue;
+                            }
+
+                            loader::romimg rimg = std::move(*rimg_parsed);
                             std::u16string path_to_dll;
 
                             for (std::size_t i = 0; i < search_paths.size(); i++) {

--- a/src/emu/kernel/src/libmanager.cpp
+++ b/src/emu/kernel/src/libmanager.cpp
@@ -741,14 +741,19 @@ namespace eka2l1::hle {
             return cs;
         }
 
+        const int baseline_access_count = cs->get_access_count();
+
         struct dll_ref_table {
             std::uint16_t flags;
             std::uint16_t num_entries;
             std::uint32_t rom_img_headers_ref[25];
         };
 
-        // Find dependencies
-        std::function<void(loader::rom_image_header *, codeseg_ptr)> dig_dependencies;
+        // Find dependencies. Returns false when a listed dependency cannot be
+        // loaded: the ROM dependency table has no optional entries, so a missing
+        // one leaves an incomplete graph whose holes resurface later as ordinal
+        // or execution errors far from the cause.
+        std::function<bool(loader::rom_image_header *, codeseg_ptr)> dig_dependencies;
         dig_dependencies = [&](loader::rom_image_header *header, codeseg_ptr acs) {
             if (header->dll_ref_table_address != 0) {
                 dll_ref_table *ref_table = eka2l1::ptr<dll_ref_table>(header->dll_ref_table_address).get(mem_);
@@ -822,8 +827,8 @@ namespace eka2l1::hle {
                             // Load new romimage and add dependency
                             auto rimg_parsed = loader::parse_romimg(reinterpret_cast<common::ro_stream *>(&buf_stream), mem_, kern_->get_epoc_version());
                             if (!rimg_parsed) {
-                                LOG_ERROR(KERNEL, "Unable to parse ROM image dependency at address 0x{:X}, skipping it", romimg_addr);
-                                continue;
+                                LOG_ERROR(KERNEL, "Unable to parse ROM image dependency of {} at address 0x{:X}", acs->name(), romimg_addr);
+                                return false;
                             }
 
                             loader::romimg rimg = std::move(*rimg_parsed);
@@ -849,19 +854,36 @@ namespace eka2l1::hle {
                             dep_info.dep_ = load_as_romimg(rimg, path_to_dll);
 
                             if (!dep_info.dep_) {
-                                LOG_ERROR(KERNEL, "Failed to load ROM image dependency {} of {}, skipping it",
+                                LOG_ERROR(KERNEL, "Failed to load ROM image dependency {} of {}",
                                     common::ucs2_to_utf8(path_to_dll), acs->name());
-                                continue;
+                                return false;
                             }
 
-                            acs->add_dependency(dep_info);
+                            if (!acs->add_dependency(dep_info)) {
+                                return false;
+                            }
                         }
                     }
                 }
             }
+
+            return true;
         };
 
-        dig_dependencies(&romimg.header, cs);
+        if (!dig_dependencies(&romimg.header, cs)) {
+            LOG_ERROR(KERNEL, "ROM image {} depends on an image that cannot be loaded; refusing to load it",
+                common::ucs2_to_utf8(path));
+
+            // A dependency loaded before the failing one may already reference this
+            // codeseg (the ROM graph has cycles); destroying it then would leave a
+            // dangling dependency, so only reclaim it when nothing looked at it.
+            if (cs->get_access_count() == baseline_access_count) {
+                kern_->destroy(cs);
+            }
+
+            return nullptr;
+        }
+
         try_apply_patch(cs);
 
         return cs;

--- a/src/emu/kernel/src/libmanager.cpp
+++ b/src/emu/kernel/src/libmanager.cpp
@@ -717,13 +717,16 @@ namespace eka2l1::hle {
         info.exception_descriptor = romimg.header.exception_des;
         info.constant_data = reinterpret_cast<std::uint8_t *>(mem_->get_real_pointer(romimg.header.data_address));
 
-        // A ROM image that declares constant data must point at an address we can
-        // map. When it does not, the header we parsed is not a real image header --
+        // A ROM image executes code in place, so it must carry a code address, and
+        // any constant data it declares must sit at an address we can map. When
+        // either does not hold, the header we parsed is not a real image header --
         // parse_romimg only fails on short reads, so arbitrary bytes parse "fine" --
-        // and going ahead would copy from a null pointer using a nonsense length.
-        if (romimg.header.data_size && !info.constant_data) {
-            LOG_ERROR(KERNEL, "ROM image {} declares {} bytes of constant data at unmapped address 0x{:X}; "
-                              "refusing to load it", common::ucs2_to_utf8(path), romimg.header.data_size,
+        // and constructing a codeseg from it would copy from a null pointer using
+        // a nonsense length.
+        if ((romimg.header.data_size && !info.constant_data) || !romimg.header.code_address) {
+            LOG_ERROR(KERNEL, "ROM image {} has an invalid header (code address 0x{:X}, {} bytes of "
+                              "constant data at address 0x{:X}); refusing to load it",
+                common::ucs2_to_utf8(path), romimg.header.code_address, romimg.header.data_size,
                 romimg.header.data_address);
 
             return nullptr;

--- a/src/emu/kernel/src/libmanager.cpp
+++ b/src/emu/kernel/src/libmanager.cpp
@@ -845,6 +845,12 @@ namespace eka2l1::hle {
                             kernel::codeseg_dependency_info dep_info;
                             dep_info.dep_ = load_as_romimg(rimg, path_to_dll);
 
+                            if (!dep_info.dep_) {
+                                LOG_ERROR(KERNEL, "Failed to load ROM image dependency {} of {}, skipping it",
+                                    common::ucs2_to_utf8(path_to_dll), acs->name());
+                                continue;
+                            }
+
                             acs->add_dependency(dep_info);
                         }
                     }

--- a/src/emu/mem/src/model/multiple/chunk.cpp
+++ b/src/emu/mem/src/model/multiple/chunk.cpp
@@ -336,11 +336,22 @@ namespace eka2l1::mem {
         } else {
             addr &= ~(((1 << control_->page_per_tab_shift_) << control_->page_size_bits_) - 1);
 
-            // Mark those as allocated
-            max_size_ = chunk_sec->alloc_.force_fill((addr - chunk_sec->beg_) >> control_->page_size_bits_,
-                static_cast<int>(total_pt << control_->page_per_tab_shift_), false);
+            // A forced address does not have to lie inside the section the flags picked:
+            // a moving-model ROM sits at 0xF8000000, while this model's ROM section covers
+            // 0x80000000..0x90000000. Only mark pages in the section allocator when the
+            // chunk actually falls inside the section -- an out-of-section offset would
+            // run far past the end of the allocator's bitmap. The internal flag is set
+            // either way, so the destructor also knows not to give a foreign range back.
+            if ((addr >= chunk_sec->beg_) && (addr < chunk_sec->end_)) {
+                // Mark those as allocated
+                max_size_ = chunk_sec->alloc_.force_fill((addr - chunk_sec->beg_) >> control_->page_size_bits_,
+                    static_cast<int>(total_pt << control_->page_per_tab_shift_), false);
 
-            max_size_ <<= control_->page_size_bits_;
+                max_size_ <<= control_->page_size_bits_;
+            } else {
+                max_size_ = static_cast<std::size_t>(total_pt) << control_->chunk_shift_;
+            }
+
             create_flags_ |= MEM_MODEL_CHUNK_INTERNAL_FORCE_FILL;
         }
 


### PR DESCRIPTION
Fixes #666 - the emulator segfaulted during startup on ROMs whose base address is
not 1 MB aligned (e.g. the Nokia 5500 Sport, `rom_base = 0xF80F1000`), and silently
corrupted the heap on every boot of such a ROM, which surfaced later as
`free(): invalid size` / `malloc(): invalid next size` aborts - typically when
switching devices.

Three problems, found peeling the same onion:

## 1. Unaligned ROM base skewed every guest -> host translation

`kernel_system::map_rom` forced the ROM chunk to `rom_base`, but the multiple
memory model can only place a chunk on a page-table-span boundary (1 MB):
`do_create` silently aligns the forced address down (`0xF80F1000` -> `0xF8000000`).
The host file mapping still corresponded to `rom_base`, so every translation
inside the ROM landed `0xF1000` bytes too deep in the file. `parse_romimg`
then read Thumb code as image headers - it only fails on short reads, so
arbitrary bytes parse "fine" - and a garbage ~2 GB `data_size` with a null
source pointer reached the `memcpy` in `codeseg::codeseg()` -> SIGSEGV.
Sized from the aligned-down base, the chunk also left the ROM's last
`0xF1000` bytes unmapped entirely.

**Fix:** `map_rom` detects the unaligned base, creates the chunk at the aligned
base with the ROM contents placed at the correct in-chunk offset, and sizes it
to cover the full ROM. Aligned ROMs (the common case) keep the zero-copy
private file mapping unchanged.

## 2. Out-of-section ROM chunk scribbled the heap

The multiple model's ROM section covers `0x80000000..0x90000000`, but
moving-model ROMs live at `0xF8000000`. `do_create` marked the forced range in
the section's bitmap allocator using a page offset (491,520) far beyond the
bitmap's 65,536 pages, and `bitmap_allocator::force_fill` never bounds-checks
its *starting* word — its loop guard only catches running off the end, not
starting past it. Every boot of the 5500 wrote ~1.2 KB across the heap,
~88 KB past the 8 KB bitmap. The corruption stayed latent until an unrelated
`malloc`/`free` walked the damaged bins (reproduced under gdb:
`malloc(): invalid next size (unsorted)` inside the next device's `map_rom`).
This also plausibly explains the "bogus header values" from the issue notes —
`uid1 = 0x7FFF85F0` is a heap pointer, not ROM data.

**Fix:** only fill the section bitmap when the forced address actually lies
inside the section (the existing internal flag already keeps the destructor
from returning the foreign range), and make `force_fill` refuse a start offset
beyond its bitmap.

## 3. No guards on the copy path (defense in depth)

`codeseg::codeseg()` copied from header-derived pointers without null checks,
and `load_as_romimg` dereferenced a failed `parse_romimg` optional. Now a ROM
image that declares constant data at an unmappable address is refused with a
log, unparseable ROM image dependencies are skipped, and codeseg refuses
null-source copies - a corrupt ROM degrades into error logs instead of taking
the emulator down far from the cause.

## Testing

- Nokia 5500 Sport (RM-86): boots past the previous segfault with correct
  ROM image headers.
- Device switching (N95 <-> 5500 <-> RH-29 in one session): previously aborted
  with heap-corruption errors, now clean.
- Aligned-ROM devices (N95 `0x80000000`, RH-29 `0x50000000`): code path
  unchanged, boots verified.

Note: the 5500 now logs `Invalid ordinal … requested from euser.dll by
ecam_general.dll` - a pre-existing, unrelated incompatibility (the camera patch
DLL targets a newer SDK than this 2006-era ROM's euser). It was invisible
before only because boot crashed earlier.

---

I disclose I have used LLM based tools for searching in GDB logs and mapping the bug. All changes are verified and commited by human.