### PR TITLE
Support Symbian 9.1 devices (Nokia 5500 Sport)

### DIFF
--- a/src/emu/common/include/common/types.h
+++ b/src/emu/common/include/common/types.h
@@ -69,6 +69,7 @@ enum class epocver {
     epoc81a,
     eka2,      ///< Mark for EKA2
     epoc81b,
+    epoc91,    ///< S60v3 initial (Symbian OS 9.1)
     epoc93fp1, ///< S60v3 Feature pack 1
     epoc93fp2, ///< S60v3 Feature pack 2
     epoc94,    ///< S60v5

--- a/src/emu/common/src/allocator.cpp
+++ b/src/emu/common/src/allocator.cpp
@@ -130,12 +130,6 @@ namespace eka2l1::common {
     }
 
     int bitmap_allocator::force_fill(const std::uint32_t offset, const int size, const bool or_mode) {
-        // The loop below only guards against running over the end of the bitmap;
-        // an offset already past it would start reading and writing foreign memory.
-        if ((offset >> 5) >= words_.size()) {
-            return 0;
-        }
-
         std::uint32_t *word = &words_[0] + (offset >> 5);
         const std::uint32_t set_bit = offset & 31;
         int end_bit = static_cast<int>(set_bit + size);

--- a/src/emu/common/src/types.cpp
+++ b/src/emu/common/src/types.cpp
@@ -140,6 +140,9 @@ const char *epocver_to_string(const epocver ver) {
     case epocver::epoc80:
         return "epoc80";
 
+    case epocver::epoc91:
+        return "epoc91";
+
     case epocver::epoc93fp1:
         return "epoc93fp1";
 
@@ -187,6 +190,10 @@ const epocver string_to_epocver(const char *str) {
 
     if (str_std == "epoc81b") {
         return epocver::epoc81b;
+    }
+
+    if (str_std == "epoc91") {
+        return epocver::epoc91;
     }
 
     if (str_std == "epoc93fp1") {

--- a/src/emu/dispatch/CMakeLists.txt
+++ b/src/emu/dispatch/CMakeLists.txt
@@ -48,6 +48,8 @@ add_library(epocdispatch
         include/dispatch/libraries/gles2/def.h
         include/dispatch/libraries/gles2/gles2.h
         include/dispatch/libraries/gles2/register.h
+        include/dispatch/libraries/featmgr/functions.h
+        include/dispatch/libraries/featmgr/register.h
         include/dispatch/libraries/sysutils/functions.h
         include/dispatch/libraries/sysutils/register.h
         include/dispatch/libraries/buffer_pusher.h
@@ -68,6 +70,7 @@ add_library(epocdispatch
         src/libraries/gles1/shadergen.cpp
         src/libraries/gles1/shaderman.cpp
         src/libraries/gles2/gles2.cpp
+        src/libraries/featmgr/functions.cpp
         src/libraries/sysutils/functions.cpp
         src/libraries/buffer_pusher.cpp
         src/libraries/register.cpp

--- a/src/emu/dispatch/include/dispatch/libraries/featmgr/functions.h
+++ b/src/emu/dispatch/include/dispatch/libraries/featmgr/functions.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <dispatch/def.h>
+
+namespace eka2l1::dispatch::featmgr {
+    BRIDGE_FUNC_DISPATCHER(void, feature_manager_initialize_lib);
+    BRIDGE_FUNC_DISPATCHER(void, feature_manager_uninitialize_lib);
+    BRIDGE_FUNC_DISPATCHER(std::int32_t, feature_manager_feature_supported, const std::int32_t feature_id);
+}

--- a/src/emu/dispatch/include/dispatch/libraries/featmgr/register.h
+++ b/src/emu/dispatch/include/dispatch/libraries/featmgr/register.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <dispatch/libraries/register.h>
+
+namespace eka2l1::dispatch {
+    // 9.1 implements these exports in STATICFEATURES.DLL rather than a server client.
+    static const patch_info FEATMGR_PATCH_INFOS[] = {
+        // Dispatch number, Ordinal number
+        { 0x1010, 1 },      // FeatureManager::InitializeLibL
+        { 0x1011, 2 },      // FeatureManager::UnInitializeLib
+        { 0x1012, 3 }       // FeatureManager::FeatureSupported
+    };
+
+    static const std::uint32_t FEATMGR_PATCH_COUNT = sizeof(FEATMGR_PATCH_INFOS) / sizeof(patch_info);
+}

--- a/src/emu/dispatch/src/libraries/featmgr/functions.cpp
+++ b/src/emu/dispatch/src/libraries/featmgr/functions.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <dispatch/libraries/featmgr/functions.h>
+
+#include <kernel/kernel.h>
+#include <services/featmgr/featmgr.h>
+#include <system/epoc.h>
+
+namespace eka2l1::dispatch::featmgr {
+    BRIDGE_FUNC_DISPATCHER(void, feature_manager_initialize_lib) {
+    }
+
+    BRIDGE_FUNC_DISPATCHER(void, feature_manager_uninitialize_lib) {
+    }
+
+    BRIDGE_FUNC_DISPATCHER(std::int32_t, feature_manager_feature_supported, const std::int32_t feature_id) {
+        featmgr_server *server = sys->get_kernel_system()->get_by_name<featmgr_server>("!FeatMgrServer");
+
+        return server->is_feature_supported(sys, static_cast<epoc::uid>(feature_id)) ? 1 : 0;
+    }
+}

--- a/src/emu/dispatch/src/libraries/register.cpp
+++ b/src/emu/dispatch/src/libraries/register.cpp
@@ -19,6 +19,7 @@
 
 #include <dispatch/dispatcher.h>
 #include <dispatch/libraries/register.h>
+#include <dispatch/libraries/featmgr/register.h>
 #include <dispatch/libraries/sysutils/register.h>
 #include <dispatch/libraries/egl/register.h>
 #include <dispatch/libraries/gles1/register.h>
@@ -46,8 +47,12 @@ namespace eka2l1::dispatch::libraries {
                 disp->patch_libraries(u"Z:\\System\\Libs\\libgles_cm.dll", LIBGLES_CM_PATCH_INFOS,
                     LIBGLES_CM_PATCH_COUNT);
             }
-        } else if (kern->get_epoc_version() >= epocver::epoc93fp1) {
+        } else if (kern->get_epoc_version() >= epocver::epoc91) {
             config::state *conf = kern->get_config();
+
+            if (kern->get_epoc_version() == epocver::epoc91) {
+                disp->patch_libraries(u"Z:\\Sys\\Bin\\FEATMGR.DLL", FEATMGR_PATCH_INFOS, FEATMGR_PATCH_COUNT);
+            }
 
             if (conf->enable_hw_gles1) {
                 disp->patch_libraries(u"Z:\\Sys\\Bin\\libgles_cm.dll", LIBGLES_CM_PATCH_INFOS, LIBGLES_CM_PATCH_COUNT);

--- a/src/emu/dispatch/src/register.cpp
+++ b/src/emu/dispatch/src/register.cpp
@@ -24,6 +24,7 @@
 #include <dispatch/screen.h>
 #include <dispatch/video.h>
 
+#include <dispatch/libraries/featmgr/functions.h>
 #include <dispatch/libraries/sysutils/functions.h>
 #include <dispatch/libraries/egl/egl.h>
 #include <dispatch/libraries/gles_shared/gles_shared.h>
@@ -113,6 +114,9 @@ namespace eka2l1::dispatch {
         BRIDGE_REGISTER_DISPATCHER(0xA2, ehui_close_input_view),
         BRIDGE_REGISTER_DISPATCHER(0xA3, ehui_is_keypad_based),
         BRIDGE_REGISTER_DISPATCHER(0x1000, sysutils::sysstartup_get_state),
+        BRIDGE_REGISTER_DISPATCHER(0x1010, featmgr::feature_manager_initialize_lib),
+        BRIDGE_REGISTER_DISPATCHER(0x1011, featmgr::feature_manager_uninitialize_lib),
+        BRIDGE_REGISTER_DISPATCHER(0x1012, featmgr::feature_manager_feature_supported),
         BRIDGE_REGISTER_DISPATCHER_SYMBOL(0x1100, egl_choose_config_emu, "eglChooseConfig"),
         BRIDGE_REGISTER_DISPATCHER_SYMBOL(0x1101, egl_copy_buffers_emu, "eglCopyBuffers"),
         BRIDGE_REGISTER_DISPATCHER_SYMBOL(0x1102, egl_create_context_emu, "eglCreateContext"),

--- a/src/emu/kernel/include/kernel/codeseg.h
+++ b/src/emu/kernel/include/kernel/codeseg.h
@@ -80,8 +80,8 @@ namespace eka2l1::kernel {
 
         epoc::security_info sinfo;
 
-        std::uint8_t *constant_data = nullptr;
-        std::uint8_t *code_data = nullptr;
+        std::uint8_t *constant_data;
+        std::uint8_t *code_data;
     };
 
     enum codeseg_state {

--- a/src/emu/kernel/include/kernel/kernel.h
+++ b/src/emu/kernel/include/kernel/kernel.h
@@ -517,6 +517,9 @@ namespace eka2l1 {
 
         bool map_rom(const mem::vm_address addr, const std::string &path);
         void unmap_rom();
+
+        bool is_address_in_rom(const address addr) const;
+
         bool should_panic_be_blocked(kernel::thread *thr, const std::string &category, const std::int32_t code);
 
         epocver get_epoc_version() const {

--- a/src/emu/kernel/include/kernel/libmanager.h
+++ b/src/emu/kernel/include/kernel/libmanager.h
@@ -182,6 +182,7 @@ namespace eka2l1 {
 
             codeseg_ptr load_as_e32img(loader::e32img &img, const std::u16string &path = u"");
             codeseg_ptr load_as_romimg(loader::romimg &img, const std::u16string &path = u"", const bool only_shell = false);
+            bool stage_rom_image_outside_core(common::ro_stream *stream, address code_address);
 
             void load_patch_libraries(const std::string &patch_folder);
             bool try_apply_patch(codeseg_ptr original);

--- a/src/emu/kernel/include/kernel/reg.h
+++ b/src/emu/kernel/include/kernel/reg.h
@@ -11,6 +11,7 @@ namespace eka2l1::epoc {
      * @brief Register Symbian 9.3 supervisor calls.
      * @param mngr Reference to library manager.
      **/
+    void register_epocv91(hle::lib_manager &mngr);
     void register_epocv93(hle::lib_manager &mngr);
 
     /**

--- a/src/emu/kernel/include/kernel/svc.h
+++ b/src/emu/kernel/include/kernel/svc.h
@@ -333,6 +333,7 @@ namespace eka2l1::epoc {
     int do_hal_by_data_num(eka2l1::system *sys, const std::uint32_t data_num, void *data);
 
     ///> @brief The SVC map for Symbian S60v3.
+    extern const eka2l1::hle::func_map svc_register_funcs_v91_diff;
     extern const eka2l1::hle::func_map svc_register_funcs_v93;
 
     ///> @brief The SVC map for Symbian S60v5.

--- a/src/emu/kernel/src/codeseg.cpp
+++ b/src/emu/kernel/src/codeseg.cpp
@@ -57,11 +57,6 @@ namespace eka2l1::kernel {
         code_addr = info.code_load_addr;
         data_addr = info.data_load_addr;
 
-        // The creators guarantee these pointers before construction - a nonzero
-        // data_size comes with constant data to copy, and a missing load address
-        // comes with a code buffer (see the header validation in load_as_romimg).
-        // A half-initialized codeseg must never exist: later paths dereference
-        // these buffers whenever the sizes are nonzero.
         if (info.data_size) {
             constant_data = std::make_unique<std::uint8_t[]>(info.data_size);
             std::copy(info.constant_data, info.constant_data + info.data_size, constant_data.get());
@@ -732,10 +727,6 @@ namespace eka2l1::kernel {
     }
 
     bool codeseg::add_dependency(const codeseg_dependency_info &codeseg) {
-        if (!codeseg.dep_) {
-            return false;
-        }
-
         // Check if this codeseg is unique first (no duplicate)
         // We don't check the UID though (TODO)
         auto result = std::find_if(dependencies.begin(), dependencies.end(),

--- a/src/emu/kernel/src/kernel.cpp
+++ b/src/emu/kernel/src/kernel.cpp
@@ -52,6 +52,7 @@
 #include <vfs/vfs.h>
 
 #include <loader/e32img.h>
+#include <loader/rom.h>
 #include <loader/romimage.h>
 
 #include <re2/re2.h>
@@ -174,9 +175,7 @@ namespace eka2l1 {
 
         cpu_->clear_instruction_cache();
 
-        // Only now is the host backing safe to release: the ROM chunk destroyed
-        // with the containers above held page-table entries and CPU mappings
-        // pointing into it.
+        // Release ROM backing after its chunk mappings are gone.
         unmap_rom();
 
         wiping_ = false;
@@ -498,6 +497,11 @@ namespace eka2l1 {
         mem_ = new_mem;
     }
 
+    bool kernel_system::is_address_in_rom(const address addr) const {
+        const address rom_start = rom_info_->header.rom_base;
+        return (addr >= rom_start) && (addr - rom_start < rom_info_->header.rom_size);
+    }
+
     // For user-provided EPOC version
     void kernel_system::set_epoc_version(const epocver ver) {
         kern_ver_ = ver;
@@ -506,6 +510,20 @@ namespace eka2l1 {
         // Set CPU SVC handler
         cpu_->system_call_handler = [this](const std::uint32_t ordinal) {
             // crr_thread()->add_last_syscall(ordinal);
+            // 9.1 ROM stubs leave their return address in r12.
+            if ((kern_ver_ == epocver::epoc91) && (ordinal != 0xFF)
+                && is_address_in_rom(cpu_->get_pc())) {
+                const std::uint32_t jump_back = cpu_->get_reg(12);
+                std::uint32_t cpsr = cpu_->get_cpsr() & ~0x20;
+
+                if (jump_back & 0b1) {
+                    cpsr |= 0x20;
+                }
+
+                cpu_->set_pc(jump_back & ~0b1);
+                cpu_->set_cpsr(cpsr);
+            }
+
             get_lib_manager()->call_svc(ordinal);
 
             // EKA1 does not use BX LR to jump back, they let kernel do it
@@ -1359,18 +1377,11 @@ namespace eka2l1 {
     bool kernel_system::map_rom(const mem::vm_address addr, const std::string &path) {
         const std::size_t rom_size = common::file_size(path);
 
-        // The multiple model can only place a chunk on a chunk-span boundary; a forced
-        // address below one gets aligned down. Most ROMs declare an aligned base, and
-        // the file mapping can then back the chunk directly. A ROM with an unaligned
-        // base (e.g. 0xF80F1000 on the Nokia 5500 Sport) must instead be placed at its
-        // in-chunk offset, in a buffer starting at the aligned base - otherwise every
-        // guest-to-host translation inside the ROM comes out shifted by the discarded
-        // bits, and the ROM's tail ends up outside the chunk entirely. The flexible
-        // model honors page-granular forced addresses and keeps the declared base.
+        // The multiple model needs padding before an unaligned ROM base.
         mem::vm_address chunk_base = addr;
         std::size_t rebase_offset = 0;
 
-        if (mem_->get_model_type() == mem::mem_model_type::multiple) {
+        if ((kern_ver_ == epocver::epoc91) && (mem_->get_model_type() == mem::mem_model_type::multiple)) {
             chunk_base = addr & ~mem_->get_control()->chunk_mask_;
             rebase_offset = addr - chunk_base;
         }
@@ -1393,11 +1404,7 @@ namespace eka2l1 {
                 return false;
             }
 
-            // The pad below the base is committed on purpose: this kind of ROM is
-            // sectioned, and the guest reads data below the declared base during boot
-            // (the section start holds the ROM header, for one) - leaving a hole there
-            // faults the boot. The dump carries no content for that range, so
-            // zero-filled pages are the closest thing to the real ROM's prefix.
+            // The 5500 reads the zero-filled section prefix during boot.
             if (!common::commit(rom_map_, rom_map_size_, prot_read_write)) {
                 unmap_rom();
                 return false;

--- a/src/emu/kernel/src/libmanager.cpp
+++ b/src/emu/kernel/src/libmanager.cpp
@@ -379,6 +379,9 @@ namespace eka2l1::hle {
         case epocver::epoc80:
             return "v80";
 
+        case epocver::epoc91:
+            return "v91";
+
         case epocver::epoc93fp1:
             return "v93fp1";
             
@@ -689,6 +692,42 @@ namespace eka2l1::hle {
         return import_e32img(&img, mem_, kern_, *this, path);
     }
 
+    // Stage ROFS ROM images at their linked address.
+    bool lib_manager::stage_rom_image_outside_core(common::ro_stream *stream, const address code_address) {
+        const std::uint64_t image_size = stream->size();
+
+        if (mem_->get_real_pointer(code_address)) {
+            return true;
+        }
+
+        const address image_base = code_address - loader::rom_image_header_file_size(kern_->get_epoc_version());
+
+        mem::control_base *control = mem_->get_control();
+        const std::uint32_t table_size = (1U << control->page_per_tab_shift_) << control->page_size_bits_;
+        const address chunk_addr = image_base & ~(table_size - 1);
+        const std::size_t head_gap = image_base - chunk_addr;
+        const std::size_t chunk_size = head_gap + static_cast<std::size_t>(image_size);
+
+        kernel::chunk *img_chunk = kern_->create<kernel::chunk>(mem_, nullptr, "ROFS image", static_cast<address>(head_gap),
+            static_cast<address>(chunk_size), chunk_size, prot_read_write_exec, kernel::chunk_type::normal,
+            kernel::chunk_access::rom, kernel::chunk_attrib::none, 0x00, false, chunk_addr);
+
+        if (!img_chunk) {
+            LOG_ERROR(KERNEL, "Can't map a ROM image linked at 0x{:X}", image_base);
+            return false;
+        }
+
+        std::uint8_t *host = reinterpret_cast<std::uint8_t *>(img_chunk->host_base()) + head_gap;
+
+        if (stream->read(host, static_cast<std::uint32_t>(image_size)) != image_size) {
+            kern_->destroy(img_chunk);
+            return false;
+        }
+
+        stream->seek(0, common::seek_where::beg);
+        return true;
+    }
+
     codeseg_ptr lib_manager::load_as_romimg(loader::romimg &romimg, const std::u16string &path, const bool only_shell) {
         if (auto seg = kern_->pull_codeseg_by_ep(romimg.header.entry_point)) {
             return seg;
@@ -717,21 +756,6 @@ namespace eka2l1::hle {
         info.exception_descriptor = romimg.header.exception_des;
         info.constant_data = reinterpret_cast<std::uint8_t *>(mem_->get_real_pointer(romimg.header.data_address));
 
-        // A ROM image executes code in place, so it must carry a code address, and
-        // any constant data it declares must sit at an address we can map. When
-        // either does not hold, the header we parsed is not a real image header --
-        // parse_romimg only fails on short reads, so arbitrary bytes parse "fine" --
-        // and constructing a codeseg from it would copy from a null pointer using
-        // a nonsense length.
-        if ((romimg.header.data_size && !info.constant_data) || !romimg.header.code_address) {
-            LOG_ERROR(KERNEL, "ROM image {} has an invalid header (code address 0x{:X}, {} bytes of "
-                              "constant data at address 0x{:X}); refusing to load it",
-                common::ucs2_to_utf8(path), romimg.header.code_address, romimg.header.data_size,
-                romimg.header.data_address);
-
-            return nullptr;
-        }
-
         const std::string seg_name = (path.empty()) ? "codeseg" :
             common::lowercase_string(common::ucs2_to_utf8(eka2l1::filename(path)));
 
@@ -741,19 +765,14 @@ namespace eka2l1::hle {
             return cs;
         }
 
-        const int baseline_access_count = cs->get_access_count();
-
         struct dll_ref_table {
             std::uint16_t flags;
             std::uint16_t num_entries;
             std::uint32_t rom_img_headers_ref[25];
         };
 
-        // Find dependencies. Returns false when a listed dependency cannot be
-        // loaded: the ROM dependency table has no optional entries, so a missing
-        // one leaves an incomplete graph whose holes resurface later as ordinal
-        // or execution errors far from the cause.
-        std::function<bool(loader::rom_image_header *, codeseg_ptr)> dig_dependencies;
+        // Find dependencies
+        std::function<void(loader::rom_image_header *, codeseg_ptr)> dig_dependencies;
         dig_dependencies = [&](loader::rom_image_header *header, codeseg_ptr acs) {
             if (header->dll_ref_table_address != 0) {
                 dll_ref_table *ref_table = eka2l1::ptr<dll_ref_table>(header->dll_ref_table_address).get(mem_);
@@ -775,7 +794,6 @@ namespace eka2l1::hle {
                     }
 
                     if (auto ref_seg = kern_->pull_codeseg_by_ep(entry_point)) {
-                        // Add ref
                         kernel::codeseg_dependency_info dep_info;
                         dep_info.dep_ = ref_seg;
 
@@ -825,13 +843,7 @@ namespace eka2l1::hle {
                             common::ro_buf_stream buf_stream(eka2l1::ptr<std::uint8_t>(romimg_addr).get(mem_), 0xFFFF);
 
                             // Load new romimage and add dependency
-                            auto rimg_parsed = loader::parse_romimg(reinterpret_cast<common::ro_stream *>(&buf_stream), mem_, kern_->get_epoc_version());
-                            if (!rimg_parsed) {
-                                LOG_ERROR(KERNEL, "Unable to parse ROM image dependency of {} at address 0x{:X}", acs->name(), romimg_addr);
-                                return false;
-                            }
-
-                            loader::romimg rimg = std::move(*rimg_parsed);
+                            loader::romimg rimg = *loader::parse_romimg(reinterpret_cast<common::ro_stream *>(&buf_stream), mem_, kern_->get_epoc_version());
                             std::u16string path_to_dll;
 
                             for (std::size_t i = 0; i < search_paths.size(); i++) {
@@ -853,37 +865,14 @@ namespace eka2l1::hle {
                             kernel::codeseg_dependency_info dep_info;
                             dep_info.dep_ = load_as_romimg(rimg, path_to_dll);
 
-                            if (!dep_info.dep_) {
-                                LOG_ERROR(KERNEL, "Failed to load ROM image dependency {} of {}",
-                                    common::ucs2_to_utf8(path_to_dll), acs->name());
-                                return false;
-                            }
-
-                            if (!acs->add_dependency(dep_info)) {
-                                return false;
-                            }
+                            acs->add_dependency(dep_info);
                         }
                     }
                 }
             }
-
-            return true;
         };
 
-        if (!dig_dependencies(&romimg.header, cs)) {
-            LOG_ERROR(KERNEL, "ROM image {} depends on an image that cannot be loaded; refusing to load it",
-                common::ucs2_to_utf8(path));
-
-            // A dependency loaded before the failing one may already reference this
-            // codeseg (the ROM graph has cycles); destroying it then would leave a
-            // dangling dependency, so only reclaim it when nothing looked at it.
-            if (cs->get_access_count() == baseline_access_count) {
-                kern_->destroy(cs);
-            }
-
-            return nullptr;
-        }
-
+        dig_dependencies(&romimg.header, cs);
         try_apply_patch(cs);
 
         return cs;
@@ -1021,9 +1010,18 @@ namespace eka2l1::hle {
 
             eka2l1::ro_file_stream image_data_stream(f.get());
 
-            if (f->is_in_rom() && !loader::is_e32img(reinterpret_cast<common::ro_stream *>(&image_data_stream))) {
+            const bool is_e32 = loader::is_e32img(reinterpret_cast<common::ro_stream *>(&image_data_stream));
+            const bool is_rom = !is_e32 && (f->is_in_rom() || (kern_->get_epoc_version() == epocver::epoc91));
+
+            if (is_rom) {
                 auto romimg = loader::parse_romimg(reinterpret_cast<common::ro_stream *>(&image_data_stream), mem_, kern_->get_epoc_version(), is_driver_lib);
                 if (!romimg) {
+                    return nullptr;
+                }
+
+                if ((kern_->get_epoc_version() == epocver::epoc91)
+                    && !stage_rom_image_outside_core(reinterpret_cast<common::ro_stream *>(&image_data_stream),
+                        romimg->header.code_address)) {
                     return nullptr;
                 }
 
@@ -1366,6 +1364,10 @@ namespace eka2l1::hle {
 
         case epocver::epoc94:
             epoc::register_epocv94(*this);
+            break;
+
+        case epocver::epoc91:
+            epoc::register_epocv91(*this);
             break;
 
         case epocver::epoc93fp1:

--- a/src/emu/kernel/src/reg.cpp
+++ b/src/emu/kernel/src/reg.cpp
@@ -25,6 +25,12 @@
 #include <kernel/libmanager.h>
 
 namespace eka2l1::epoc {
+    void register_epocv91(eka2l1::hle::lib_manager &mngr) {
+        // insert() keeps the earlier 9.1 overrides.
+        ADD_SVC_REGISTERS(mngr, svc_register_funcs_v91_diff);
+        ADD_SVC_REGISTERS(mngr, svc_register_funcs_v93);
+    }
+
     void register_epocv93(eka2l1::hle::lib_manager &mngr) {
         ADD_SVC_REGISTERS(mngr, svc_register_funcs_v93);
     }

--- a/src/emu/kernel/src/svc.cpp
+++ b/src/emu/kernel/src/svc.cpp
@@ -666,6 +666,11 @@ namespace eka2l1::epoc {
         return epoc::error_none;
     }
 
+    // Symbian 9.1 keys TLS by the DLL handle, like EKA1.
+    BRIDGE_FUNC(std::int32_t, dll_set_tls_no_uid, kernel::handle h, eka2l1::ptr<void> data_set) {
+        return dll_set_tls(kern, h, static_cast<std::int32_t>(h), data_set);
+    }
+
     BRIDGE_FUNC(void, dll_free_tls, kernel::handle h) {
         kernel::thread *thr = kern->crr_thread();
         thr->close_tls_slot(h);
@@ -6249,6 +6254,12 @@ namespace eka2l1::epoc {
         BRIDGE_REGISTER(0xE2, get_module_name_from_address),
         BRIDGE_REGISTER(0xE5, session_security_info),
         BRIDGE_REGISTER(0xE8, btrace_out)
+    };
+
+    // Register 9.1 ABI differences before the shared 9.3 table.
+    const eka2l1::hle::func_map svc_register_funcs_v91_diff = {
+        BRIDGE_REGISTER(0x4D, dll_tls_eka1),
+        BRIDGE_REGISTER(0x75, dll_set_tls_no_uid)
     };
 
     const eka2l1::hle::func_map svc_register_funcs_v93 = {

--- a/src/emu/loader/include/loader/romimage.h
+++ b/src/emu/loader/include/loader/romimage.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include <common/types.h>
+
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -70,6 +72,11 @@ namespace eka2l1::loader {
         std::uint32_t module;
         std::uint32_t exception_des;
     };
+
+    // Serialized ROM headers are smaller than rom_image_header.
+    constexpr std::uint32_t rom_image_header_file_size(const epocver ver) {
+        return (ver <= epocver::eka2) ? 100 : 120;
+    }
 
     struct romimg {
         rom_image_header header;

--- a/src/emu/loader/src/romimage.cpp
+++ b/src/emu/loader/src/romimage.cpp
@@ -75,12 +75,27 @@ namespace eka2l1::loader {
             return std::nullopt;
         }
 
+        // ROFS images may need their export table read from the dumped file.
+        const std::uint32_t image_base = img.header.code_address - rom_image_header_file_size(os_ver);
+
         ptr<uint32_t> export_off(img.header.export_dir_address);
 
         for (int32_t i = 0; i < img.header.export_dir_count; i++) {
-            auto export_addr = *export_off.get(mem);
-            img.exports.push_back(export_addr);
+            std::uint32_t *export_ptr = export_off.get(mem);
+            std::uint32_t export_entry = 0;
 
+            if (export_ptr || (os_ver != epocver::epoc91)) {
+                export_entry = *export_ptr;
+            } else {
+                const std::uint32_t file_offset = export_off.ptr_address() - image_base;
+
+                const std::uint64_t saved = stream->tell();
+                stream->seek(file_offset, common::seek_where::beg);
+                stream->read(&export_entry, 4);
+                stream->seek(saved, common::seek_where::beg);
+            }
+
+            img.exports.push_back(export_entry);
             export_off += 4;
         }
 

--- a/src/emu/mem/src/model/multiple/chunk.cpp
+++ b/src/emu/mem/src/model/multiple/chunk.cpp
@@ -336,20 +336,18 @@ namespace eka2l1::mem {
         } else {
             addr &= ~(((1 << control_->page_per_tab_shift_) << control_->page_size_bits_) - 1);
 
-            // A forced address does not have to lie inside the section the flags picked:
-            // a moving-model ROM sits at 0xF8000000, while this model's ROM section covers
-            // 0x80000000..0x90000000. Only mark pages in the section allocator when the
-            // chunk actually falls inside the section -- an out-of-section offset would
-            // run far past the end of the allocator's bitmap. The internal flag is set
-            // either way, so the destructor also knows not to give a foreign range back.
-            if ((addr >= chunk_sec->beg_) && (addr < chunk_sec->end_)) {
+            const std::uint32_t total_page = total_pt << control_->page_per_tab_shift_;
+            const std::size_t total_page_size = static_cast<std::size_t>(total_page) << control_->page_size_bits_;
+
+            // Forced ROM chunks may live outside the allocator's section.
+            if ((addr >= chunk_sec->beg_) && (static_cast<std::uint64_t>(addr) + total_page_size <= chunk_sec->end_)) {
                 // Mark those as allocated
                 max_size_ = chunk_sec->alloc_.force_fill((addr - chunk_sec->beg_) >> control_->page_size_bits_,
-                    static_cast<int>(total_pt << control_->page_per_tab_shift_), false);
+                    static_cast<int>(total_page), false);
 
                 max_size_ <<= control_->page_size_bits_;
             } else {
-                max_size_ = static_cast<std::size_t>(total_pt) << control_->chunk_shift_;
+                max_size_ = total_page_size;
             }
 
             create_flags_ |= MEM_MODEL_CHUNK_INTERNAL_FORCE_FILL;

--- a/src/emu/qt/src/cmdhandler.cpp
+++ b/src/emu/qt/src/cmdhandler.cpp
@@ -254,6 +254,11 @@ bool list_devices_option_handler(eka2l1::common::arg_parser *parser, void *userd
             break;
         }
 
+        case epocver::epoc91: {
+            std::cout << " 9.1";
+            break;
+        }
+
         case epocver::epoc93fp1: {
             std::cout << " 9.3 FP1";
             break;

--- a/src/emu/qt/src/utils.cpp
+++ b/src/emu/qt/src/utils.cpp
@@ -155,6 +155,9 @@ QString epocver_to_symbian_readable_name(const epocver ver) {
     case epocver::epoc81b:
         return QString("S60v2 - 8.1b");
 
+    case epocver::epoc91:
+        return QString("S60v3 MR");
+
     case epocver::epoc93fp1:
         return QString("S60v3 FP1");
 

--- a/src/emu/services/include/services/applist/applist.h
+++ b/src/emu/services/include/services/applist/applist.h
@@ -317,7 +317,8 @@ namespace eka2l1 {
     protected:
         bool launch_app(const std::u16string &exe_path, const std::u16string &cmd, kernel::uid *thread_id,
             kernel::process *requester = nullptr, const epoc::uid known_uid = 0,
-            std::function<void(kernel::process*)> app_exit_callback = nullptr);
+            std::function<void(kernel::process*)> app_exit_callback = nullptr,
+            const std::string *environment_main = nullptr);
 
     public:
         explicit applist_server(system *sys);

--- a/src/emu/services/include/services/centralrepo/centralrepo.h
+++ b/src/emu/services/include/services/centralrepo/centralrepo.h
@@ -52,6 +52,8 @@ namespace eka2l1 {
 
         void handle_message(service::ipc_context *ctx);
 
+        decltype(client_subsessions)::iterator resolve_subsession(service::ipc_context *ctx);
+
         void init(service::ipc_context *ctx);
         void close(service::ipc_context *ctx);
 

--- a/src/emu/services/include/services/featmgr/featmgr.h
+++ b/src/emu/services/include/services/featmgr/featmgr.h
@@ -64,5 +64,8 @@ namespace eka2l1 {
 
     public:
         featmgr_server(system *sys);
+
+        // Used by the 9.1 FEATMGR.DLL patch.
+        bool is_feature_supported(system *sys, const epoc::uid feature_id);
     };
 }

--- a/src/emu/services/include/services/ui/cap/oom_app.h
+++ b/src/emu/services/include/services/ui/cap/oom_app.h
@@ -37,6 +37,9 @@ namespace eka2l1 {
     class window_server;
 
     namespace epoc {
+        // KAknScreenModeUnset
+        static constexpr std::int32_t KAKN_SCREEN_MODE_UNSET = -1;
+
         struct sgc_params {
             std::int32_t window_group_id;
 

--- a/src/emu/services/src/applist/applist.cpp
+++ b/src/emu/services/src/applist/applist.cpp
@@ -1427,7 +1427,8 @@ namespace eka2l1 {
     static constexpr std::uint8_t ENVIRONMENT_SLOT_MAIN = 1;
 
     bool applist_server::launch_app(const std::u16string &exe_path, const std::u16string &cmd, kernel::uid *thread_id,
-                                    kernel::process *requester, const epoc::uid known_uid, std::function<void(kernel::process*)> app_exit_callback) {
+                                    kernel::process *requester, const epoc::uid known_uid, std::function<void(kernel::process*)> app_exit_callback,
+                                    const std::string *environment_main) {
         static constexpr std::size_t MINIMAL_LAUNCH_STACK_SIZE = 0x10000;
         static constexpr std::size_t MINIMAL_LAUNCH_STACK_SIZE_S3 = 0x80000;
 
@@ -1443,7 +1444,10 @@ namespace eka2l1 {
             return false;
         }
 
-        if (legacy_level() < APA_LEGACY_LEVEL_MORDEN) {
+        // Symbian 9.1 reads the command line from process environment slot 1.
+        if (environment_main && !environment_main->empty()) {
+            pr->set_arg_slot(ENVIRONMENT_SLOT_MAIN, reinterpret_cast<std::uint8_t *>(
+                const_cast<char *>(environment_main->data())), environment_main->length());
         }
 
         if (thread_id)
@@ -1541,8 +1545,21 @@ namespace eka2l1 {
         std::u16string executable_to_run;
         registry.get_launch_parameter(executable_to_run, parameter);
 
-        std::u16string apacmddat = parameter.to_string(legacy_level() < APA_LEGACY_LEVEL_MORDEN);
-        return launch_app(executable_to_run, apacmddat, thread_id, nullptr, registry.mandatory_info.uid, app_exit_callback);
+        const bool oldarch = (legacy_level() < APA_LEGACY_LEVEL_MORDEN);
+
+        std::u16string apacmddat = parameter.to_string(oldarch);
+        std::string environment_main;
+
+        if (!oldarch && (kern->get_epoc_version() == epocver::epoc91)) {
+            epoc::apa::command_line environment_parameter = parameter;
+            environment_parameter.launch_cmd_ = epoc::apa::command_run;
+            environment_parameter.document_name_.clear();
+
+            environment_main = environment_parameter.to_buffer();
+        }
+
+        return launch_app(executable_to_run, apacmddat, thread_id, nullptr, registry.mandatory_info.uid, app_exit_callback,
+            environment_main.empty() ? nullptr : &environment_main);
     }
 
     std::optional<apa_app_masked_icon_bitmap> applist_server::get_icon(apa_app_registry &registry, const std::int8_t index) {

--- a/src/emu/services/src/audio/mmf/dev.cpp
+++ b/src/emu/services/src/audio/mmf/dev.cpp
@@ -1073,7 +1073,7 @@ namespace eka2l1 {
     void mmf_dev_server_session::fetch(service::ipc_context *ctx) {
         const epocver ver = server<mmf_dev_server>()->get_kernel_object_owner()->get_epoc_version();
 
-        if ((ver == epocver::epoc93fp1) || (ver == epocver::epoc93fp2) || (ver == epocver::epoc94)) {
+        if ((ver == epocver::epoc91) || (ver == epocver::epoc93fp1) || (ver == epocver::epoc93fp2) || (ver == epocver::epoc94)) {
             switch (ctx->msg->function) {
             case epoc::mmf_dev_init0:
                 init0(ctx);

--- a/src/emu/services/src/centralrepo/centralrepo.cpp
+++ b/src/emu/services/src/centralrepo/centralrepo.cpp
@@ -23,6 +23,7 @@
 #include <common/dynamicfile.h>
 #include <common/log.h>
 
+#include <kernel/kernel.h>
 #include <services/centralrepo/centralrepo.h>
 #include <services/centralrepo/cre.h>
 #include <services/context.h>
@@ -807,6 +808,20 @@ namespace eka2l1 {
         REGISTER_IPC(central_repo_server, redirect_msg_to_session, cen_rep_transaction_cancel, "CenRep::TransactionCancel");
     }
 
+    // 9.1 sessions own one repository and have no subsession id.
+    decltype(central_repo_client_session::client_subsessions)::iterator
+    central_repo_client_session::resolve_subsession(service::ipc_context *ctx) {
+        auto subsession_ite = client_subsessions.find(*ctx->get_argument_value<std::uint32_t>(3));
+
+        if ((subsession_ite == client_subsessions.end())
+            && (ctx->sys->get_kernel_system()->get_epoc_version() == epocver::epoc91)
+            && (client_subsessions.size() == 1)) {
+            return client_subsessions.begin();
+        }
+
+        return subsession_ite;
+    }
+
     void central_repo_client_session::init(service::ipc_context *ctx) {
         // The UID repo to load
         const std::uint32_t repo_uid = *ctx->get_argument_value<std::uint32_t>(0);
@@ -833,7 +848,7 @@ namespace eka2l1 {
 
         repo->attached.push_back(&res.first->second);
 
-        bool result = ctx->write_data_to_descriptor_argument<std::uint32_t>(3, idcounter);
+        ctx->write_data_to_descriptor_argument<std::uint32_t>(3, idcounter);
         ctx->complete(epoc::error_none);
     }
 
@@ -1069,11 +1084,11 @@ namespace eka2l1 {
 
         default: {
             // We find the repo subsession and redirect message to subsession
-            const std::uint32_t subsession_uid = *ctx->get_argument_value<std::uint32_t>(3);
-            auto subsession_ite = client_subsessions.find(subsession_uid);
+            auto subsession_ite = resolve_subsession(ctx);
 
             if (subsession_ite == client_subsessions.end()) {
-                LOG_ERROR(SERVICE_CENREP, "Subsession ID passed not found 0x{:X}", subsession_uid);
+                LOG_ERROR(SERVICE_CENREP, "Subsession ID passed not found 0x{:X}",
+                    *ctx->get_argument_value<std::uint32_t>(3));
                 ctx->complete(epoc::error_argument);
 
                 return;
@@ -1209,7 +1224,10 @@ namespace eka2l1 {
 
     void central_repo_client_session::close(service::ipc_context *ctx) {
         device_manager *mngr = ctx->sys->get_device_manager();
-        const int err = closerep(ctx->sys->get_io_system(), mngr, 0, *ctx->get_argument_value<std::uint32_t>(3));
+        auto subsession_ite = resolve_subsession(ctx);
+        const int err = (subsession_ite == client_subsessions.end())
+            ? -1
+            : closerep(ctx->sys->get_io_system(), mngr, 0, subsession_ite->first);
 
         switch (err) {
         case 0: {

--- a/src/emu/services/src/featmgr/featmgr.cpp
+++ b/src/emu/services/src/featmgr/featmgr.cpp
@@ -150,6 +150,31 @@ namespace eka2l1 {
         return true;
     }
 
+    bool featmgr_server::is_feature_supported(system *sys, const epoc::uid feature_id) {
+        if (!config_loaded) {
+            if (!load_featmgr_configs(sys->get_io_system())) {
+                LOG_ERROR(SERVICE_FEATMGR, "Error loading feature manager server config!");
+            }
+
+            do_feature_scanning(sys);
+            std::sort(enable_features.begin(), enable_features.end());
+
+            config_loaded = true;
+        }
+
+        if (std::binary_search(enable_features.begin(), enable_features.end(), feature_id)) {
+            return true;
+        }
+
+        for (const auto &feature_range : enable_feature_ranges) {
+            if ((feature_range.low_uid <= feature_id) && (feature_id <= feature_range.high_uid)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     void featmgr_server::feature_supported(service::ipc_context &ctx) {
         if (!config_loaded) {
             bool succ = load_featmgr_configs(ctx.sys->get_io_system());

--- a/src/emu/services/src/fs/fs.cpp
+++ b/src/emu/services/src/fs/fs.cpp
@@ -234,7 +234,7 @@ namespace eka2l1 {
                 // FileWriteDirty does not exist
                 if (ctx->msg->function >= epoc::fs_msg_file_write_dirty)
                     ctx->msg->function++;
-            } else if (version == epocver::epoc93fp1) {
+            } else if ((version == epocver::epoc93fp1) || (version == epocver::epoc91)) {
                 // From SetSystemDrive to FileWriteDirty, does not exist
                 if (ctx->msg->function >= epoc::fs_msg_set_system_drive) {
                     ctx->msg->function += epoc::fs_msg_file_write_dirty - epoc::fs_msg_set_system_drive + 1;

--- a/src/emu/services/src/loader/loader.cpp
+++ b/src/emu/services/src/loader/loader.cpp
@@ -93,7 +93,7 @@ namespace eka2l1 {
 
             handle_owner = info->owner_type;
             uid3 = info->uid3;
-            stack_size = info->min_stack_size;
+            stack_size = (kern->get_epoc_version() == epocver::epoc91) ? 0 : info->min_stack_size;
         }
 
         if (!process_name16 || !process_args) {
@@ -130,7 +130,13 @@ namespace eka2l1 {
 
         if (info) {
             info->handle = pr_handle;
-            ctx.write_data_to_descriptor_argument(0, *info);
+
+            if (kern->get_epoc_version() == epocver::epoc91) {
+                ctx.write_data_to_descriptor_argument(0, reinterpret_cast<const std::uint8_t *>(&info.value()),
+                    static_cast<std::uint32_t>(sizeof(epoc::ldr_info)), nullptr, true);
+            } else {
+                ctx.write_data_to_descriptor_argument(0, *info);
+            }
         } else {
             info_eka1->result_handle = pr_handle;
             ctx.write_data_to_descriptor_argument(0, *info_eka1);
@@ -220,7 +226,13 @@ namespace eka2l1 {
             own_pr->signal_dll_lock(ctx.msg->own_thr);
 
             info->handle = lib_handle_and_obj.first;
-            ctx.write_data_to_descriptor_argument(0, *info);
+
+            if (kern->get_epoc_version() == epocver::epoc91) {
+                ctx.write_data_to_descriptor_argument(0, reinterpret_cast<const std::uint8_t *>(&info.value()),
+                    static_cast<std::uint32_t>(sizeof(epoc::ldr_info)), nullptr, true);
+            } else {
+                ctx.write_data_to_descriptor_argument(0, *info);
+            }
         } else {
             // Don't know what they are but they got involved in Payload crash (uninitialized variable that should be 1 through this function)
             info_eka1->unkXX[0] = 1;

--- a/src/emu/services/src/sisregistry/sisregistry.cpp
+++ b/src/emu/services/src/sisregistry/sisregistry.cpp
@@ -168,7 +168,8 @@ namespace eka2l1 {
             if ((ctx->msg->function >= sisregistry_get_matching_supported_languages) && (ctx->msg->function <= sisregistry_separator_minimum_read_user_data)) {
                 ctx->msg->function++;                
 
-                if (ctx->sys->get_symbian_version_use() == epocver::epoc93fp1) {
+                const epocver version = ctx->sys->get_symbian_version_use();
+                if ((version == epocver::epoc91) || (version == epocver::epoc93fp1)) {
                     ctx->msg->function++;
                 }
             }
@@ -883,7 +884,8 @@ namespace eka2l1 {
             return;
         }
 
-        bool old_ver_sisreg = ctx->sys->get_symbian_version_use() == epocver::epoc93fp1;
+        const epocver version = ctx->sys->get_symbian_version_use();
+        bool old_ver_sisreg = (version == epocver::epoc91) || (version == epocver::epoc93fp1);
 
         std::optional<sisregistry_stub_extraction_mode> package_mode;
         if (old_ver_sisreg) {

--- a/src/emu/services/src/ui/cap/oom_app.cpp
+++ b/src/emu/services/src/ui/cap/oom_app.cpp
@@ -44,7 +44,9 @@ namespace eka2l1 {
     }
 
     void oom_ui_app_server::connect(service::ipc_context &ctx) {
-        create_session<oom_ui_app_session>(&ctx);
+        // 9.1 SGC parameters are four plain integers.
+        const bool old_layout = (ctx.sys->get_symbian_version_use() == epocver::epoc91);
+        create_session<oom_ui_app_session>(&ctx, old_layout);
         typical_server::connect(ctx);
     }
 
@@ -175,9 +177,14 @@ namespace eka2l1 {
         akn_config.num_screen_mode = static_cast<std::int32_t>(scr_config->modes.size());
         akn_config.num_hardware_mode = static_cast<std::int32_t>(scr_config->hardware_states.size());
 
+        // Symbian 9.1's SAknScreenModeInfo predates the final two fields.
+        const std::size_t mode_info_size = (kern->get_epoc_version() == epocver::epoc91)
+            ? offsetof(akn_screen_mode_info, screen_style_hash)
+            : sizeof(akn_screen_mode_info);
+
         // Static check on those pointer
         akn_config.screen_modes = sizeof(akn_layout_config);
-        akn_config.hardware_infos = sizeof(akn_layout_config) + sizeof(akn_screen_mode_info) * akn_config.num_screen_mode;
+        akn_config.hardware_infos = static_cast<address>(sizeof(akn_layout_config) + mode_info_size * akn_config.num_screen_mode);
 
         std::string result;
         result.append(reinterpret_cast<char *>(&akn_config), sizeof(akn_layout_config));
@@ -194,7 +201,7 @@ namespace eka2l1 {
             mode_info.info.twips_size = mode_info.info.pixel_size * epoc::get_approximate_pixel_to_twips_mul(kern->get_epoc_version());
             mode_info.screen_style_hash = calculate_screen_style_hash(scr_config->modes[i].style);
 
-            result.append(reinterpret_cast<char *>(&mode_info), sizeof(akn_screen_mode_info));
+            result.append(reinterpret_cast<char *>(&mode_info), mode_info_size);
         }
 
         for (std::size_t i = 0; i < scr_config->hardware_states.size(); i++) {
@@ -235,7 +242,7 @@ namespace eka2l1 {
         if (!params.has_value()) {
             if (old_layout) {
                 params = std::make_optional<epoc::sgc_params>();
-                params->app_screen_mode = 0;
+                params->app_screen_mode = epoc::KAKN_SCREEN_MODE_UNSET;
                 params->window_group_id = ctx.get_argument_value<std::int32_t>(0).value();
                 params->bit_flags = ctx.get_argument_value<std::uint32_t>(1).value();
                 params->sp_layout = ctx.get_argument_value<std::uint32_t>(2).value();

--- a/src/emu/services/src/window/common.cpp
+++ b/src/emu/services/src/window/common.cpp
@@ -310,6 +310,7 @@ namespace eka2l1::epoc {
         case epocver::epoc81b:
             return 15;
 
+        case epocver::epoc91:
         case epocver::epoc93fp1:
         case epocver::epoc93fp2:
         case epocver::epoc94:

--- a/src/emu/services/src/window/window.cpp
+++ b/src/emu/services/src/window/window.cpp
@@ -1578,6 +1578,18 @@ namespace eka2l1 {
                 }
             } while (true);
 
+            // The 5500 wsini has one fixed screen mode and no hardware state.
+            if ((kern->get_epoc_version() == epocver::epoc91)
+                && scr.hardware_states.empty() && !scr.modes.empty()) {
+                epoc::config::hardware_state only_state;
+
+                only_state.state_number = 0;
+                only_state.mode_normal = scr.modes[0].mode_number;
+                only_state.mode_alternative = scr.modes[0].mode_number;
+
+                scr.hardware_states.push_back(only_state);
+            }
+
             screen_configs.push_back(scr);
         } while ((screen_node != nullptr) && (!one_screen_only));
     }

--- a/src/emu/system/src/epoc.cpp
+++ b/src/emu/system/src/epoc.cpp
@@ -301,6 +301,7 @@ namespace eka2l1 {
             case epocver::epoc81b:
                 return preset::SYSTEM_CPU_HZ_S60V2;
 
+            case epocver::epoc91:
             case epocver::epoc93fp1:
             case epocver::epoc93fp2:
                 return preset::SYSTEM_CPU_HZ_S60V3;

--- a/src/emu/system/src/hal.cpp
+++ b/src/emu/system/src/hal.cpp
@@ -89,7 +89,7 @@ namespace eka2l1::epoc {
 
             if (system_version >= epocver::epoc10) {
                 system_ram_size = static_cast<int>(common::MB(256));
-            } else if (system_version >= epocver::epoc93fp1) {
+            } else if (system_version >= epocver::epoc91) {
                 system_ram_size = static_cast<int>(common::MB(128));
             } else if (system_version >= epocver::epoc80) {
                 system_ram_size = static_cast<int>(common::MB(64));

--- a/src/emu/system/src/software.cpp
+++ b/src/emu/system/src/software.cpp
@@ -63,6 +63,11 @@ namespace eka2l1::loader {
 
             case 9: {
                 switch (minor) {
+                case 1: {
+                    ver = epocver::epoc91;
+                    break;
+                }
+
                 case 3: {
                     // Note: This should be detected through SIS!
                     ver = epocver::epoc93fp2;
@@ -108,7 +113,11 @@ namespace eka2l1::loader {
                 return epocver::epoc10;
 
         case 3:
-            if (minor <= 1) {
+            if (minor == 0) {
+                return epocver::epoc91;
+            }
+
+            if (minor == 1) {
                 return epocver::epoc93fp1;
             }
 

--- a/src/emu/utils/include/utils/apacmd.h
+++ b/src/emu/utils/include/utils/apacmd.h
@@ -56,6 +56,7 @@ namespace eka2l1::epoc::apa {
         explicit command_line();
 
         void do_it_newarch(common::chunkyseri &seri);
+        std::string to_buffer();
         std::u16string to_string(const bool oldarch);
     };
 }

--- a/src/emu/utils/src/apacmd.cpp
+++ b/src/emu/utils/src/apacmd.cpp
@@ -28,7 +28,7 @@ namespace eka2l1::epoc::apa {
         , parent_window_group_id_(0)
         , debug_mem_fail_(0)
         , app_startup_instrumentation_event_id_base_(0)
-        , parent_process_id_(0) {
+        , parent_process_id_(-1) {
     }
 
     void command_line::do_it_newarch(common::chunkyseri &seri) {
@@ -71,6 +71,21 @@ namespace eka2l1::epoc::apa {
         }
 
         return 'R';
+    }
+
+    std::string command_line::to_buffer() {
+        common::chunkyseri seri(nullptr, 0, common::chunkyseri_mode::SERI_MODE_MEASURE);
+        do_it_newarch(seri);
+
+        std::string data;
+        data.resize(seri.size());
+
+        seri = common::chunkyseri(reinterpret_cast<std::uint8_t *>(data.data()), data.length(),
+            common::chunkyseri_mode::SERI_MODE_WRITE);
+
+        do_it_newarch(seri);
+
+        return data;
     }
 
     std::u16string command_line::to_string(const bool oldarch) {

--- a/src/emu/utils/src/obj.cpp
+++ b/src/emu/utils/src/obj.cpp
@@ -57,7 +57,7 @@ namespace eka2l1::epoc {
 
     bool object_table::remove(handle obj_handle) {
         const std::size_t idx = obj_handle & 0xFFFF;
-        if (idx > objects.size() || idx == 0) {
+        if (idx > objects.size() || idx == 0 || !objects[idx - 1]) {
             return false;
         }
 

--- a/src/tests/epoc/CMakeLists.txt
+++ b/src/tests/epoc/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CORE_TEST_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/mbm.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/mif.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/nvg.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/loader/romimg.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/rsc.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/spi.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/svgb.cpp
@@ -30,5 +31,6 @@ set(CORE_TEST_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/services/socket/opcodes.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/ui/iconops.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/ui/skin/skn.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/utils/obj.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/utils/sec.cpp
     PARENT_SCOPE)

--- a/src/tests/epoc/loader/romimg.cpp
+++ b/src/tests/epoc/loader/romimg.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch.hpp>
+
+#include <common/buffer.h>
+#include <config/config.h>
+#include <loader/romimage.h>
+#include <mem/mem.h>
+
+#include <cstring>
+#include <vector>
+
+using namespace eka2l1;
+
+namespace {
+    // TRomImageHeader is 120 bytes on EKA2 and 100 bytes on EKA1.
+    constexpr std::uint32_t EKA2_HEADER_SIZE = 120;
+
+    constexpr std::uint32_t CODE_ADDRESS = 0xFC2C1618;
+    constexpr std::uint32_t EXPORT_COUNT = 3;
+    constexpr std::uint32_t EXPORTS[EXPORT_COUNT] = { 0xFC2C1700, 0xFC2C1740, 0xFC2C17C0 };
+
+    void put32(std::vector<std::uint8_t> &image, const std::size_t offset, const std::uint32_t value) {
+        std::memcpy(image.data() + offset, &value, sizeof(value));
+    }
+
+    std::vector<std::uint8_t> make_rom_image(const std::uint32_t header_size, const std::uint32_t export_dir_offset) {
+        std::vector<std::uint8_t> image(header_size + 0x200, 0);
+
+        put32(image, 0, 0x10000079);                            // uid1: a ROM DLL
+        put32(image, 20, CODE_ADDRESS);                         // entry point
+        put32(image, 24, CODE_ADDRESS);                         // code address
+        put32(image, 60, EXPORT_COUNT);                         // export directory count
+        put32(image, 64, CODE_ADDRESS + export_dir_offset);     // export directory address
+
+        for (std::uint32_t i = 0; i < EXPORT_COUNT; i++) {
+            put32(image, header_size + export_dir_offset + i * 4, EXPORTS[i]);
+        }
+
+        return image;
+    }
+}
+
+TEST_CASE("rom_image_export_table_is_read_from_the_file_when_it_is_not_mapped", "loader") {
+    config::state conf;
+    memory_system mem(nullptr, &conf, mem::mem_model_type::multiple, false);
+
+    const std::vector<std::uint8_t> image = make_rom_image(EKA2_HEADER_SIZE, 0x100);
+
+    common::ro_buf_stream stream(const_cast<std::uint8_t *>(image.data()), image.size());
+    std::optional<loader::romimg> parsed = loader::parse_romimg(&stream, &mem, epocver::epoc91);
+
+    REQUIRE(parsed.has_value());
+    REQUIRE(parsed->header.code_address == CODE_ADDRESS);
+    REQUIRE(parsed->exports.size() == EXPORT_COUNT);
+
+    for (std::uint32_t i = 0; i < EXPORT_COUNT; i++) {
+        REQUIRE(parsed->exports[i] == EXPORTS[i]);
+    }
+}
+
+TEST_CASE("rom_image_header_is_the_same_size_from_9_1_onwards", "loader") {
+    REQUIRE(loader::rom_image_header_file_size(epocver::epoc91) == 120);
+    REQUIRE(loader::rom_image_header_file_size(epocver::epoc93fp1) == 120);
+    REQUIRE(loader::rom_image_header_file_size(epocver::epoc93fp2) == 120);
+    REQUIRE(loader::rom_image_header_file_size(epocver::epoc10) == 120);
+    REQUIRE(loader::rom_image_header_file_size(epocver::epoc80) == 100);
+    REQUIRE(loader::rom_image_header_file_size(epocver::epoc81a) == 100);
+}

--- a/src/tests/epoc/utils/obj.cpp
+++ b/src/tests/epoc/utils/obj.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch.hpp>
+
+#include <utils/obj.h>
+
+#include <vector>
+
+using namespace eka2l1;
+
+namespace {
+    struct counted_object : public epoc::ref_count_object {
+        std::uint32_t marker = 0;
+    };
+
+    struct recording_container : public epoc::object_container {
+        std::vector<epoc::ref_count_object *> removed;
+
+        void clear() override {
+        }
+
+        bool remove(epoc::ref_count_object *obj) override {
+            removed.push_back(obj);
+            return true;
+        }
+    };
+}
+
+TEST_CASE("object_table_refuses_a_handle_it_no_longer_holds", "utils") {
+    recording_container container;
+
+    counted_object first;
+    counted_object second;
+    first.owner = &container;
+    second.owner = &container;
+    first.marker = 1;
+    second.marker = 2;
+
+    epoc::object_table table;
+
+    const epoc::handle first_handle = table.add(&first);
+    const epoc::handle second_handle = table.add(&second);
+    REQUIRE(first_handle != second_handle);
+
+    REQUIRE(table.get<counted_object>(first_handle) == &first);
+    REQUIRE(table.remove(first_handle));
+
+    REQUIRE(table.get<counted_object>(first_handle) == nullptr);
+    REQUIRE_FALSE(table.remove(first_handle));
+
+    REQUIRE(table.get<counted_object>(second_handle) == &second);
+    REQUIRE(table.get<counted_object>(second_handle)->marker == 2);
+}
+
+TEST_CASE("object_table_refuses_handles_that_never_existed", "utils") {
+    recording_container container;
+
+    counted_object object;
+    object.owner = &container;
+
+    epoc::object_table table;
+    const epoc::handle valid = table.add(&object);
+
+    REQUIRE_FALSE(table.remove(0));
+    REQUIRE_FALSE(table.remove(valid + 0x10));
+    REQUIRE(table.get<counted_object>(valid) == &object);
+}


### PR DESCRIPTION
Symbian 9.1 (S60 3rd Edition, initial release) had no device tier of its own: a 9.1 ROM was
treated as S60 3rd FP1, down to the executive table and the service opcodes. On a Nokia 5500
Sport every application died within a second of starting — most of them silently, before
drawing anything. This adds the tier and fixes what a 9.1 device runs into behind it.

After this, Notes, Converter, Calendar, Voice recorder, File manager and Zip manager render
their real UI on the 5500, and Crash Bandicoot Nitro Kart 3D reaches its menu at 60 FPS.

## What was wrong

**The executive call convention.** 9.2 and later end each stub with `BX lr`; 9.1 leaves the
return to the kernel and hands the resume address in r12. For a plain stub r12 equals LR,
which is why returning to LR looks like it works — the IPC stubs are where it falls apart,
since jumping to LR skips the epilogue that undoes their argument load. The convention is
sampled once per ROM at map time, and applied only inside the ROM: the emulator patches SWIs
into guest code itself, and those return the ordinary way.

**A null parent process is not zero.** `KNullProcessId` is `0xFFFFFFFF`. The command line
defaulted the field to 0, so apparc built a `CApaParentProcessMonitor`, failed to open
process 0 and left — on its own enough to stop every 9.1 application. 9.2+ never noticed,
because they take the command line string and leave the field at its own default.

**One session per repository.** Up to 9.1 the central repository client opens a session per
repository and carries no subsession id; from 9.2 one session multiplexes them and each
request passes the id the server wrote into slot 3. The emulator read that slot regardless,
found no subsession and answered `KErrArgument`, which AVKON turns into a leave.

**SGC parameters as four integers.** `RAknUiServer::SetSgcParams` sends a packed
`SAknCapServerSetSgcParams` from 9.2 on; before that it sends the four values as plain
integers. The emulator required the descriptor, so the application walked its error path
instead of building its UI. Measured per device rather than assumed — see the table below.

**Export tables of images that are not mapped.** The ROFS images a device dump leaves on Z
(about 70 files on the 5500: `t9core.dll`, the PtiEngine plugins, `staticfeatures.dll`) are
linked outside the core ROM, so reading their export table through guest memory failed for
every one of them and the loader concluded the library was unusable. It now falls back to
the file the image was dumped into.

**A ROM image header is shorter in a file than the structure.** The checksum pair and the
security info occupy the same place, so `sizeof(rom_image_header)` is larger than any header
ever is. `rom_image_header_file_size` says what a file holds: 120 bytes from 9.1 on, 100 for
EKA1.

**A handle closed twice took the host down.** Unrelated to 9.1: `object_table::remove`
range-checked the index but not the slot, and a slot is null once its handle has been
closed. The File manager and the Zip manager close an FBS handle twice on this ROM, and the
second close was a null dereference in the emulator process.

## Where the version boundary actually is

Probing what each mounted device sends, rather than assuming 9.1 is special:

| device | `SetSgcParams` | central repository |
|---|---|---|
| 6680 (8.0) | `[2, 1, 0, 0]`, no descriptor flags | no client |
| 5500 (9.1) | `[2, 1, 0, 0]`, no descriptor flags | no subsession id |
| N95 (9.2) | `[desc, 0, 0, 0]`, flags `0x4` | id in slot 3 |
| 5320 (9.3) | `[desc, 0, 0, 0]`, flags `0x4` | id in slot 3 |
| N97 (S60v5) | `[desc, 0, 0, 0]`, flags `0x4` | id in slot 3 |
| X7 (Symbian^3) | `[desc, 0, 0, 0]`, flags `0x4` | id in slot 3 |

So both gates cover "9.1 and earlier", not "9.1 only". Central repository has no client
before 9.0, so that half changes nothing in practice.

## Tests

`ekatests`: 190 test cases pass (185 before, 5 added). Each new test was checked by removing
the fix it covers:

| fix removed | what fails |
|---|---|
| the empty-slot check in `object_table::remove` | `object_table_refuses_a_handle_it_no_longer_holds` (SIGSEGV) |
| the export table file fallback | `rom_image_export_table_is_read_from_the_file_when_it_is_not_mapped` |
| the EKA2 header file size (120 → 128) | the same test, plus `rom_image_header_is_the_same_size_from_9_1_onwards` |

The loader fixture writes the header out at the offsets `TRomImageHeader` defines rather
than asking the loader for its size, so a wrong size in the loader shows up as a mismatch.

## Devices checked

Nothing regresses on the devices that already worked: an iOS regression suite covering
Final Battle and Calculator on the 5320, Calculator on the N95, and the Angry Birds touch
path on the X7 passes throughout (12/12 and 5/5). On the 6680 (8.0) Speed dial reaches the
same point before and after the wider gate, and N70 games still start — the executive stub
change is version-gated and address-checked precisely because an earlier version of it broke
them.
