### PR TITLE
services/fbs: white-fill new EColor4K bitmaps with 0x0FFF, not 0xFFFF

### DIFF
--- a/src/emu/services/src/fbs/impls/bitmap.cpp
+++ b/src/emu/services/src/fbs/impls/bitmap.cpp
@@ -138,6 +138,22 @@ namespace eka2l1 {
         }
 
         static void do_white_fill(std::uint8_t *dest, const std::size_t size, epoc::display_mode mode) {
+            // EColor4K keeps 12 bits in a 16-bit pixel, so an all-ones byte fill gives 0xFFFF
+            // rather than white. Every other mode's all-ones pattern is already white.
+            if (mode == epoc::display_mode::color4k) {
+                const std::size_t pixel_count = size >> 1;
+                for (std::size_t i = 0; i < pixel_count; i++) {
+                    dest[i * 2] = 0xFF;
+                    dest[i * 2 + 1] = 0x0F;
+                }
+
+                if (size & 1) {
+                    dest[size - 1] = 0xFF;
+                }
+
+                return;
+            }
+
             std::fill(dest, dest + size, 0xFF);
         }
 
@@ -178,7 +194,7 @@ namespace eka2l1 {
             byte_width_ = get_byte_width(info.size_pixels.width(), static_cast<std::uint8_t>(info.bit_per_pixels));
 
             if (white_fill && (data_offset_ != 0)) {
-                do_white_fill(reinterpret_cast<std::uint8_t *>(data), info.bitmap_size - sizeof(loader::sbm_header), settings_.current_display_mode());
+                do_white_fill(reinterpret_cast<std::uint8_t *>(data), info.bitmap_size - sizeof(loader::sbm_header), disp_mode);
             }
         }
 


### PR DESCRIPTION
## Symptom

Metal Bluster 2 (`mb2`, UID `0x10206BB9`) on the N-Gage ROM (`nem-4`). Title screen, mission
select and briefing render fine; once a mission starts, the cutscene dialogue panels — two
176x38 bands at the top and bottom — come up as flat white rectangles. The text is drawn,
but in a pale cyan that is nearly invisible on white, so the panel reads as empty. On real
hardware those bands are semi-transparent blue panels with a character portrait and white
text.

## How it was narrowed down

The window server turned out to be irrelevant, and usefully so: a probe in
`canvas_base::add_draw_command` showed the game issuing exactly one GDI command per frame —
a blit of a single 176x208 bitmap covering the whole screen, no mask. Everything on screen,
dialogue included, comes out of one guest-owned `CFbsBitmap`.

Dumping that frame bitmap (12 bpp `EColor4K`, 352-byte stride) showed the two bands filled
with `0xFFFF`, while the rest of the frame held ordinary 12-bit values with a zero top
nibble. `0xFFFF` is not a colour the game writes — it is a byte-wise `0xFF` fill, and the
only thing that does that is `do_white_fill()` in `bitwise_bitmap::construct()`.

Logging `fbs_bitmap_create` confirmed the game creates a 176x38 `EColor4K` bitmap twice per
frame during the cutscene (once per panel), and dumping those at `free_bitmap()` time showed
they contain exactly two values: the `0xFFFF` fill and `0x0EFF`, the text. So the game draws
*only* the text into the panel bitmap.

The guest's own code settled it. `mb2.app` and its helper `xutil.dll` are uncompressed
E32Images, so the import table maps thunks to `DLL#ordinal` and the Thumb code disassembles
straight from the file. The call site builds `TSize(176, 38)` with mode `10` (`EColor4K`),
calls a thin `new CFbsBitmap` + `Create()` wrapper that neither checks the result nor clears
the bitmap, appends the dialogue string, and blits the result to the frame at y=12 and y=158
— the two band positions. The wrapper's constructor stores a literal `0x0FFF` at offset
`0xC` of its object, and the blit (`XUTIL#89`) reads it back as a **colour key**:

```
ldrh r1, [r0]        ; source pixel
cmp  r1, r4          ; r4 = key from object+0xC = 0x0FFF
beq  skip            ; transparent
strh r1, [r0]        ; else copy
```

## Root cause

`do_white_fill()` filled every byte with `0xFF` regardless of display mode. `EColor4K` keeps
12 significant bits in a 16-bit pixel, so that yields `0xFFFF`, not white (`0x0FFF`). The
game colour-keys against white, `0xFFFF != 0x0FFF`, so every background pixel of the panel
was copied opaquely instead of being skipped — burying the panel art and portrait the game
had already composited into the frame underneath.

The function had always taken a `display_mode` parameter and always ignored it. Its one call
site also passed `settings_.current_display_mode()`, which older FBS legacy levels (EPOC6
among them) never store, so it reads back as `none` — the mode would not have been usable
even if the fill had consulted it.

## Fix

Fill `EColor4K` with `0x0FFF` per pixel; keep the byte-wise `0xFF` fill for every other mode,
and pass the `disp_mode` argument `construct()` was given.

Every other display mode's all-ones pattern really is white: `EGray*`, `EColor16`/`EColor256`
(palette index 255 is white in both of the 256-colour tables in `services/fbs/palette.h`) and
the 16/24/32-bit colour modes. `EColor4K` is the only one that needs a different pattern, so
no other title's behaviour changes.

## Verification

- MB2 cutscene on `nem-4`: panels now render as semi-transparent blue with the portrait and
  white text, matching a photo of the game on real hardware.
- Ruled out along the way, in case anyone else chases them: `CWsScreenDevice::CopyScreenToBitmap`
  and `GetScanLine` are both stubbed in `scrdvc.cpp` and both log at `LOG_TRACE`, so they are
  invisible under a `*:info` filter — a "semi-transparent panel" is exactly what a screen
  read-back would be for, but promoting the stubs to `LOG_INFO` showed the game never calls
  either. Zero-filling new bitmaps instead makes the panel black with readable text, which
  looks like progress and is equally wrong.
- iOS regression suite (Final Battle, Calculator, N95 Calculator on a Release simulator
  build): 12/12 pass, unchanged from before.
- `Ashen` on `nem-4`, an `EColor4K` control title that writes its screen buffer directly:
  unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QLSs1SC7Gr8pYY3uEBd25
