### PR TITLE
services/bluetooth: keep netplay-off from killing two-player mode

### DIFF
--- a/src/emu/services/src/bluetooth/protocols/btmidman_inet.cpp
+++ b/src/emu/services/src/bluetooth/protocols/btmidman_inet.cpp
@@ -51,6 +51,13 @@ namespace eka2l1::epoc::bt {
         , password_(conf.btnet_password)
         , discovery_mode_(static_cast<discovery_mode>(conf.btnet_discovery_mode))
         , asker_counter_(0) {
+        // Local state the guest still reaches with discovery off.
+        std::fill(port_refs_.begin(), port_refs_.end(), 0);
+        std::fill(port_upnp_mapped_.begin(), port_upnp_mapped_.end(), false);
+        for (std::uint32_t i = 0; i < 6; i++) {
+            random_device_addr_.addr_[i] = static_cast<std::uint8_t>(random_range(0, 0xFF));
+        }
+
         if (discovery_mode_ == DISCOVERY_MODE_OFF) {
             return;
         }
@@ -58,9 +65,6 @@ namespace eka2l1::epoc::bt {
         if (discovery_mode_ == DISCOVERY_MODE_LAN) {
             port_ = HARBOUR_PORT;
         }
-
-        std::fill(port_refs_.begin(), port_refs_.end(), 0);
-        std::fill(port_upnp_mapped_.begin(), port_upnp_mapped_.end(), false);
 
         std::vector<std::uint64_t> errs;
         update_friend_list(conf.friend_addresses, errs);
@@ -72,10 +76,6 @@ namespace eka2l1::epoc::bt {
             } else if (errs[i] & FRIEND_UPDATE_ERROR_INVALID_ADDR) {
                 LOG_ERROR(SERVICE_BLUETOOTH, "Bluetooth netplay friend address number {} has invalid address ({})", index + 1, conf.friend_addresses[index].addr_);
             }
-        }
-
-        for (std::uint32_t i = 0; i < 6; i++) {
-            random_device_addr_.addr_[i] = static_cast<std::uint8_t>(random_range(0, 0xFF));
         }
 
         auto looper = libuv::default_looper;
@@ -200,6 +200,10 @@ namespace eka2l1::epoc::bt {
     void midman_inet::reset_friend_timeout_timer() {
         if (!reset_timeout_timer_task_) {
             reset_timeout_timer_task_ = libuv::create_task([this]() {
+                if (!hearing_timeout_timer_) {
+                    return;
+                }
+
                 const std::uint32_t duration = (discovery_mode_ == DISCOVERY_MODE_LAN) ? TIMEOUT_HEARING_STRANGER_LAN_MS : TIMEOUT_HEARING_STRANGER_MS;
                 const auto duration_chrono = std::chrono::milliseconds(duration);
 
@@ -561,10 +565,6 @@ lookup:
     }
 
     void midman_inet::ref_and_public_port(const std::uint16_t virtual_port) {
-        if (discovery_mode_ == DISCOVERY_MODE_OFF) {
-            return;
-        }
-
         if ((virtual_port > MAX_PORT) || (virtual_port == 0)) {
             LOG_ERROR(SERVICE_BLUETOOTH, "Port {} is out of allowed range!", virtual_port);
             return;
@@ -580,10 +580,6 @@ lookup:
     }
     
     std::uint16_t midman_inet::get_free_port() {
-        if (discovery_mode_ == DISCOVERY_MODE_OFF) {
-            return 0;
-        }
-
         // Reserve first 20 ports for system
         int size = 1;
         const int offset = allocated_ports_.allocate_from(20, size, false);
@@ -595,9 +591,6 @@ lookup:
     }
 
     void midman_inet::ref_port(const std::uint16_t virtual_port) {
-        if (discovery_mode_ == DISCOVERY_MODE_OFF) {
-            return;
-        }
         if ((virtual_port > MAX_PORT) || (virtual_port == 0)) {
             LOG_ERROR(SERVICE_BLUETOOTH, "Port {} is out of allowed range!", virtual_port);
             return;
@@ -607,10 +600,6 @@ lookup:
     }
 
     void midman_inet::close_port(const std::uint16_t virtual_port) {
-        if (discovery_mode_ == DISCOVERY_MODE_OFF) {
-            return;
-        }
-
         if ((virtual_port > MAX_PORT) || (virtual_port == 0)) {
             LOG_ERROR(SERVICE_BLUETOOTH, "Port {} is out of allowed range!", virtual_port);
             return;
@@ -781,6 +770,11 @@ lookup:
     }
 
     void midman_inet::begin_hearing_stranger_call(inet_stranger_call_observer *observer) {
+        // No discovery means no handle to search with; callers complete on their own.
+        if (discovery_mode_ == DISCOVERY_MODE_OFF) {
+            return;
+        }
+
         const std::lock_guard<std::mutex> guard(friends_lock_);
 
         for (std::size_t i = 0; i < friends_.size(); i++) {
@@ -798,6 +792,10 @@ lookup:
     }
 
     void midman_inet::unregister_stranger_call_observer(inet_stranger_call_observer *observer) {
+        if (discovery_mode_ == DISCOVERY_MODE_OFF) {
+            return;
+        }
+
         const std::lock_guard<std::mutex> guard(friends_lock_);
         if (observer == current_active_observer_) {
             current_active_observer_ = nullptr;

--- a/src/emu/services/src/notifier/bluetooth.cpp
+++ b/src/emu/services/src/notifier/bluetooth.cpp
@@ -77,6 +77,13 @@ namespace eka2l1::epoc::notifier {
         }
 
         auto *midman = static_cast<epoc::bt::midman_inet *>(btman->get_midman());
+
+        // Netplay off: no discovery runs, so answer like a search that found nobody.
+        if (midman->get_discovery_mode() == epoc::bt::DISCOVERY_MODE_OFF) {
+            complete_info.complete(epoc::error_not_found);
+            return;
+        }
+
         epoc::bt::device_address selected_address{};
         if (midman->get_friend_device_address(0, selected_address)) {
             complete_info.complete(write_selected_device(kern_, response, complete_info, selected_address));


### PR DESCRIPTION
## Symptom

With **Bluetooth netplay discovery set to off**, entering a game's two-player mode takes
the whole emulator down. Reproduced with Dragon World on the N-Gage ROM (nem-4): *Double
Game → As Client* or *As Server* crashes every time, on device and in the simulator.

```
Thread 13 Crashed:
0  uv_timer_stop + 0
1  eka2l1::epoc::bt::midman_inet::reset_friend_timeout_timer()::$_0::operator()()
2  libuv::looper::tasks_handle_function()::$_0::__invoke(uv_async_s*)
3  uv__async_io
...
EXC_BAD_ACCESS (SIGSEGV)  KERN_INVALID_ADDRESS at 0x0000000000000070
```

Any other discovery mode plays fine.

## Root cause

`midman_inet`'s constructor returns early when the discovery mode is off, before it
creates any libuv resource, so `hearing_timeout_timer_` stays a null `shared_ptr` and
`uv_timer_stop` faults at a fixed offset 0x70.

Almost every public entry point of the class already opens with a
`discovery_mode_ == DISCOVERY_MODE_OFF` early return for exactly that reason. Two did
not: `begin_hearing_stranger_call()` and `unregister_stranger_call_observer()`. The
Bluetooth host resolver hid the gap because it checks the mode itself
(`get_discovery_mode() > DISCOVERY_MODE_DIRECT_IP`) before calling in. The device
selection notifier plugin (`RNotifier` UID `0x100069D1`, which is what the game uses to
pick a peer) has no such check, so it registered an observer → `send_call_for_strangers()`
was posted to the loop → `reset_friend_timeout_timer()` was posted → it stopped a timer
that never existed.

Behind that sat a second, independent failure on the server path. With discovery off
`get_free_port()` also returns 0, so the RFCOMM "give me a free server channel" ioctl
answers 0 and `bind()` fails with `KErrEof` (`Bluetooth ports have ran out. Can't bind!`).
Once the host crash was gone, the guest instead died with `USER 0`. Virtual Bluetooth
ports are nothing but a local bitmap, so refusing to hand them out is over-strict:
netplay off means "no peers", not "no Bluetooth stack".

## Changes

* `begin_hearing_stranger_call()` / `unregister_stranger_call_observer()` are no-ops when
  discovery is off, matching the rest of the class; the timer-reset task also bails out on
  a null handle.
* The device selection notifier answers `KErrNotFound` immediately when discovery is off —
  the same answer a search that finds nobody produces. Answering there matters: with no
  loop running the midman cannot report "no strangers" itself, and the guest request would
  hang forever.
* The virtual port allocator (`get_free_port`, `ref_port`, `ref_and_public_port`,
  `close_port`) works in every mode now, and `port_refs_` / `port_upnp_mapped_` are filled
  before the constructor's early return. `get_host_port()` still returns 0 when discovery
  is off, so the socket falls back to an ephemeral local bind and **no port is published
  or UPnP-mapped**.
* The random virtual Bluetooth address moved above the early return as well.
  `device_address` is a POD with no initializers, so with discovery off
  `local_device_address()` — read back by `btinet_socket::local_name()` — was handing the
  guest uninitialized memory. Nothing reached that far while `bind()` still failed.

Only the `DISCOVERY_MODE_OFF` path changes; the other modes take the same code as before.

## Verification (nem-4 + Dragon World, Release build)

| | before | after |
| --- | --- | --- |
| discovery off, As Client | host SIGSEGV at 0x70 | returns to the menu (no peer found) |
| discovery off, As Server | host SIGSEGV at 0x70 (guest `USER 0` once the crash was fixed) | "waiting connection…" |
| direct IP, As Server | "waiting connection…", listens on 15000/15020 | unchanged, same ports |

The crash was reproduced first on an unpatched build; the decoded simulator `.ips` matches
the device report frame for frame, which is what pinned the diagnosis. Emulator log is
clean of panics and errors afterwards. iOS standard regression suite (Final Battle,
Calculator, N95 Calculator) 12/12.
