### PR TITLE
common: fold case-different names into the existing entry when copying a folder

### DIFF
--- a/src/emu/common/src/fileutils.cpp
+++ b/src/emu/common/src/fileutils.cpp
@@ -911,7 +911,8 @@ namespace eka2l1::common {
     }
 
     std::string resolve_case_insensitive_path(const std::string &base, const std::string &relative) {
-        if (!exists(base)) {
+        // A content URI is not a host path: only add_path() knows how to extend one.
+        if (is_content_uri(base) || !exists(base)) {
             return add_path(base, relative);
         }
 
@@ -991,21 +992,23 @@ namespace eka2l1::common {
         std::uint64_t total_copied = 0;
 
         auto do_copy_stuffs = [&](const bool is_measuring) {
-            // Keep source and destination paths separate. Lowercase-name mode
-            // transforms destination names, but the source may live on a
-            // case-sensitive filesystem and must retain its real spelling.
+            // The source path stays relative to target_folder and keeps its real
+            // spelling; the destination is absolute and resolved against what is already
+            // on disk, so a dump spelling a folder "System" lands in an existing
+            // "system" instead of beside it. Two host directories differing only in case
+            // hide each other from every case-insensitive lookup done afterwards.
             std::stack<std::pair<std::string, std::string>> folder_stacks;
             common::dir_entry entry;
 
             const std::string root_path(1, eka2l1::get_separator());
-            folder_stacks.push({ root_path, root_path });
+            folder_stacks.push({ root_path, eka2l1::add_path(dest_folder_to_reside, root_path) });
 
             while (!folder_stacks.empty()) {
                 if (cancel_cb && cancel_cb()) {
                     break;
                 }
                 if (!is_measuring)
-                    create_directories(eka2l1::add_path(dest_folder_to_reside, folder_stacks.top().second));
+                    create_directories(folder_stacks.top().second);
 
                 const std::string source_top_path = folder_stacks.top().first;
                 const std::string dest_top_path = folder_stacks.top().second;
@@ -1059,7 +1062,7 @@ namespace eka2l1::common {
                             : entry.name;
                         folder_stacks.push({
                             eka2l1::add_path(source_top_path, source_name_to_use + eka2l1::get_separator()),
-                            eka2l1::add_path(dest_top_path, name_to_use + eka2l1::get_separator())
+                            resolve_case_insensitive_path(dest_top_path, name_to_use) + eka2l1::get_separator()
                         });
                     } else {
                         if (is_measuring) {
@@ -1070,7 +1073,7 @@ namespace eka2l1::common {
                                     continue;
                                 }
 
-                                if (!common::copy_file(eka2l1::add_path(iterator->dir_name, entry.name), eka2l1::add_path(eka2l1::add_path(dest_folder_to_reside, dest_top_path), name_to_use), overwrite_on_file_exist)) {
+                                if (!common::copy_file(eka2l1::add_path(iterator->dir_name, entry.name), resolve_case_insensitive_path(dest_top_path, name_to_use), overwrite_on_file_exist)) {
                                     return false;
                                 }
 

--- a/src/emu/system/src/epoc.cpp
+++ b/src/emu/system/src/epoc.cpp
@@ -1096,7 +1096,8 @@ namespace eka2l1 {
         common::get_current_directory(current_dir);
 
         std::string drive_e_path_root = eka2l1::absolute_path(drive_e_path, current_dir);
-        drive_e_path = eka2l1::add_path(drive_e_path_root, "system\\");
+        drive_e_path = common::resolve_case_insensitive_path(drive_e_path_root, "system")
+            + eka2l1::get_separator();
 
         if (!common::exists(drive_e_path)) {
             common::create_directories(drive_e_path);
@@ -1142,13 +1143,14 @@ namespace eka2l1 {
                     progress_cb(copied * 100 / total, total_percentage);
             });
         if (!copied) {
+            LOG_ERROR(SYSTEM, "Failed to copy N-Gage card content from {} to {}", folder_path, drive_e_path_root);
             return ngage_game_card_general_error;
         }
 
         // Remove the app registeration file of the original
         if (!specific_app_2.empty()) {
-            const std::string real_aif_remove = eka2l1::add_path(drive_e_path, eka2l1::add_path(
-                    "\\apps\\", eka2l1::add_path(specific_app, specific_app + ".aif")));
+            const std::string real_aif_remove = common::resolve_case_insensitive_path(drive_e_path,
+                eka2l1::add_path("\\apps\\", eka2l1::add_path(specific_app, specific_app + ".aif")));
             common::remove(real_aif_remove);
         }
 
@@ -1159,7 +1161,8 @@ namespace eka2l1 {
             std::uint32_t percentage_per_explicit_copy = (!explicit_lib_copy.empty() && !explicit_program_copy.empty()) ? 50 : 100;
             std::uint32_t current_perct = 100;
 
-            const std::string app_folder_dest = eka2l1::add_path(eka2l1::add_path(drive_e_path, "apps\\"), specific_app + "\\");
+            const std::string app_folder_dest = common::resolve_case_insensitive_path(drive_e_path,
+                eka2l1::add_path("apps\\", specific_app)) + eka2l1::get_separator();
 
             if (!explicit_lib_copy.empty()) {
                 common::copy_folder(eka2l1::add_path(system_folder_path, explicit_lib_copy + "\\"), app_folder_dest,

--- a/src/tests/common/casepath.cpp
+++ b/src/tests/common/casepath.cpp
@@ -63,6 +63,20 @@ namespace {
     bool volume_distinguishes_case(const std::string &dir) {
         return !common::is_path_case_insensitive(dir);
     }
+
+    std::size_t count_entries(const std::string &dir) {
+        auto ite = common::make_directory_iterator(dir, "");
+        common::dir_entry entry;
+        std::size_t count = 0;
+
+        while (ite && ite->is_valid() && (ite->next_entry(entry) == 0)) {
+            if ((entry.name != ".") && (entry.name != "..")) {
+                count++;
+            }
+        }
+
+        return count;
+    }
 }
 
 TEST_CASE("case_insensitive_resolve_finds_entries_stored_in_another_case", "casepath") {
@@ -168,4 +182,42 @@ TEST_CASE("path_case_sensitivity_is_answered_per_path_not_per_build", "casepath"
     // And it has to agree with what the filesystem actually does.
     tree.make_file("Probe.dat");
     REQUIRE(common::exists(eka2l1::add_path(tree.root, "probe.dat")) == insensitive);
+}
+
+TEST_CASE("copy_folder_folds_a_differently_cased_name_into_the_existing_one", "casepath") {
+    scratch_tree source("casefold_copy_source");
+    scratch_tree dest("casefold_copy_dest");
+
+    // A game card dump spells its folders in upper case; the drive it is copied
+    // onto already holds the lower-case ones every other install path creates.
+    source.make_file("System/Apps/GAME/GAME.APP");
+    source.make_file("System/Libs/GAMEUTILS.DLL");
+
+    dest.make_file("system/apps/other/other.app");
+    dest.make_file("system/libs/gameutils.dll");
+
+    REQUIRE(common::copy_folder(source.root, dest.root, 0));
+
+    // One system folder, not two: a second one differing only in case would hide
+    // everything in the first from every case-insensitive lookup.
+    REQUIRE(count_entries(dest.root) == 1);
+    REQUIRE(count_entries(eka2l1::add_path(dest.root, "system")) == 2);
+    REQUIRE(count_entries(eka2l1::add_path(dest.root, "system/libs")) == 1);
+
+    REQUIRE(common::exists(eka2l1::add_path(dest.root, "system/apps/other/other.app")));
+    REQUIRE(common::exists(eka2l1::add_path(dest.root, "system/apps/GAME/GAME.APP")));
+}
+
+TEST_CASE("copy_folder_keeps_names_the_destination_has_no_counterpart_for", "casepath") {
+    scratch_tree source("casefold_keep_source");
+    scratch_tree dest("casefold_keep_dest");
+
+    source.make_file("System/Apps/GAME/GAME.APP");
+    dest.make_dir("system");
+
+    REQUIRE(common::copy_folder(source.root, dest.root, 0));
+
+    // Only "System" had something to fold onto. The rest arrives spelled as the
+    // source spelled it, the way a case-preserving filesystem behaves.
+    REQUIRE(common::exists(eka2l1::add_path(dest.root, "system/Apps/GAME/GAME.APP")));
 }


### PR DESCRIPTION
### The bug

`copy_folder()` reproduces the source tree's spelling verbatim. On a case-sensitive filesystem that creates a *second* directory next to one that already exists and differs only in case — and a case-insensitive lookup can then only ever see one of the two, so everything in the other becomes invisible.

Installing an N-Gage game card is where this shows up. Card dumps spell their folders `System/Apps/...`, while everything else on the E drive lives under `system`. After an import the drive holds both `system` and `System`, and because `applist` scans `E:\System\Apps\` capitalised, `physical_file_system::get_real_physical_path()` matches that literal spelling first and lands in the folder the card just created. The app list then shows the game that was just imported and nothing installed before it.

The same import can also fail outright on a volume that is case-insensitive underneath but resolves case-sensitively above (the iOS Simulator does exactly this): `mkdir` reports `EEXIST` for the directory it wants to create, which nothing can then look up, and the copy dies on its first file with a general error.

### The change

- `copy_folder()` keeps the destination as an absolute path resolved against what is already on disk, via the existing `resolve_case_insensitive_path()`. A name that differs only in case folds onto the existing entry; a name with no counterpart still arrives spelled the way the source spelled it, which is what a case-preserving filesystem does. When the spelling matches — every case-insensitive host, and most paths on a case-sensitive one — the resolver's first `exists()` hits, so the cost is one `stat`.
- That resolver now leaves Android content URIs to `add_path()`, the only thing that can extend one. It is reachable from `physical_file_system` with a SAF drive path, so this was already a latent problem there.
- `install_ngage_game_card()` stopped assuming spellings in three more places: the `system` folder it creates on the drive, the duplicate `.aif` registration it deletes from the original app folder (without which a card game with a `_1` fix folder appears twice in the list), and the destination it copies `System/Libs` / `System/Programs` into. It also logs a failed copy instead of only returning `ngage_game_card_general_error`.

### Tests

Two cases added to `src/tests/common/casepath.cpp`. On a case-sensitive volume they fail before the change (`count_entries(dest) == 2`, i.e. the two `system` folders) and pass after; on a case-insensitive one they hold either way. The whole suite passes on both: 196 test cases on a case-sensitive APFS volume and on a normal one.

Also verified end to end by importing a real N-Gage card (System Rush) — the drive keeps a single `system` folder, the imported game appears once, and the games installed before it stay in the list.