### PR TITLE
Fix GDI command payload alignment under UBSan

### DIFF
--- a/src/emu/services/include/services/window/classes/gstore.h
+++ b/src/emu/services/include/services/window/classes/gstore.h
@@ -25,6 +25,7 @@
 #include <drivers/graphics/common.h>
 #include <drivers/itc.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 
@@ -147,7 +148,7 @@ namespace eka2l1::epoc {
 
     struct gdi_store_command {
         gdi_store_command_opcode opcode_ = gdi_store_command_invalid;
-        std::uint8_t data_[MAX_COMMAND_STORE_DATA_SIZE];
+        alignas(std::max_align_t) std::uint8_t data_[MAX_COMMAND_STORE_DATA_SIZE];
         std::shared_ptr<std::vector<std::uint8_t>> dynamic_data_;
 
         std::uint8_t *allocate_dynamic_data(const std::size_t size) {
@@ -161,11 +162,15 @@ namespace eka2l1::epoc {
 
         template <typename T>
         T &get_data_struct() {
+            static_assert(sizeof(T) <= MAX_COMMAND_STORE_DATA_SIZE);
+            static_assert(alignof(T) <= alignof(std::max_align_t));
             return *reinterpret_cast<T*>(data_);
         }
         
         template <typename T>
         const T &get_data_struct_const() const {
+            static_assert(sizeof(T) <= MAX_COMMAND_STORE_DATA_SIZE);
+            static_assert(alignof(T) <= alignof(std::max_align_t));
             return *reinterpret_cast<const T*>(data_);
         }
     };

--- a/src/tests/epoc/services/window/surface.cpp
+++ b/src/tests/epoc/services/window/surface.cpp
@@ -22,6 +22,24 @@
 
 using namespace eka2l1;
 
+TEMPLATE_TEST_CASE("GDI command storage aligns every payload", "[window_surface],[gdi_store]",
+    epoc::gdi_store_command_draw_rect_data,
+    epoc::gdi_store_command_draw_line_data,
+    epoc::gdi_store_command_draw_polygon_data,
+    epoc::gdi_store_command_draw_text_data,
+    epoc::gdi_store_command_draw_bitmap_data,
+    epoc::gdi_store_command_update_texture_data,
+    epoc::gdi_store_command_set_clip_rect_single_data,
+    epoc::gdi_store_command_set_clip_rect_multiple_data) {
+    epoc::gdi_store_command commands[2];
+    for (auto &command : commands) {
+        REQUIRE(reinterpret_cast<std::uintptr_t>(command.data_) % alignof(TestType) == 0);
+        REQUIRE(static_cast<void *>(&command.get_data_struct<TestType>()) == command.data_);
+        const auto &stored = command;
+        REQUIRE(static_cast<const void *>(&stored.get_data_struct_const<TestType>()) == command.data_);
+    }
+}
+
 namespace {
     class surface_driver : public drivers::graphics_driver {
         drivers::handle next_ = 1;


### PR DESCRIPTION
Fixes the [sanitizer failure in #678](https://github.com/EKA2L1/EKA2L1/actions/runs/33977503348/job/101336689023): `get_data_struct<gdi_store_command_update_texture_data>()` binds an eight-byte-aligned reference to the byte buffer at offset four in `gdi_store_command`.

The new upload test exposed an existing host-storage alignment bug. The containing command's alignment does not align its byte-array member. Explicitly align the payload buffer to `std::max_align_t`, and reject payload types exceeding its capacity or alignment in both accessors. Add regression coverage for all eight payload types in consecutive commands, including const and mutable access.

Validation in the iOS fork, with identical changed files:

- Reproduced the exact UBSan error locally before the fix using the production header; the same ASan/UBSan reproduction passes afterward.
- Full macOS unit suite passes both normally and in a fresh ASan/UBSan build, with `ASAN_OPTIONS=detect_leaks=0` and `UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1` matching CI.
- Focused tests: 128 assertions in 18 cases.
- Release iOS Simulator default regression: 12/12; Angry Birds touch regression: 5/5. Screenshots inspected for Final Battle, both calculators, and the Angry Birds carousel.

Only host-side command storage and tests change. Guest ABI and patch DLLs are unaffected. No docs are included.
