### PR TITLE
Add Symbian Rotation sensor support on Android and iOS

### DIFF
--- a/src/emu/drivers/include/drivers/sensor/rotation.h
+++ b/src/emu/drivers/include/drivers/sensor/rotation.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+
+namespace eka2l1::drivers {
+    constexpr int ROTATION_RESOLUTION_DEGREES = 15;
+
+#pragma pack(push, 1)
+    struct sensor_rotation_data {
+        std::uint64_t timestamp_;
+        std::int32_t x_;
+        std::int32_t y_;
+        std::int32_t z_;
+        std::int32_t padding_ = 0;
+    };
+#pragma pack(pop)
+
+    static_assert(sizeof(sensor_rotation_data) == 24);
+
+    inline sensor_rotation_data rotation_from_acceleration(const std::uint64_t timestamp,
+        const double x, const double y, const double z) {
+        auto angle = [](const double sine, const double cosine) -> std::int32_t {
+            // Rotation around an axis parallel to gravity is undefined.
+            if (std::hypot(sine, cosine) < 1e-6) {
+                return -1;
+            }
+            constexpr double radians_to_degrees = 180.0 / 3.14159265358979323846;
+            double degrees = std::atan2(sine, cosine) * radians_to_degrees;
+            if (degrees < 0) {
+                degrees += 360.0;
+            }
+            return ((static_cast<int>(degrees) + ROTATION_RESOLUTION_DEGREES / 2)
+                / ROTATION_RESOLUTION_DEGREES * ROTATION_RESOLUTION_DEGREES) % 360;
+        };
+
+        // Symbian Orientation SSY uses Y as zero for X/Z, and -Z as zero for Y.
+        return { timestamp, angle(z, y), angle(x, -z), angle(-x, y), 0 };
+    }
+}

--- a/src/emu/drivers/src/sensor/backend/android/sensor_android.cpp
+++ b/src/emu/drivers/src/sensor/backend/android/sensor_android.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "sensor_android.h"
+#include <drivers/sensor/rotation.h>
 #include <common/log.h>
 #include <common/time.h>
 #include <common/android/jniutils.h>
@@ -25,6 +26,7 @@
 
 namespace eka2l1::drivers {
     static constexpr int SENSOR_LOOPER_ID = 3;
+    static constexpr std::uint32_t ROTATION_CHANNEL_FLAG = 0x80000000;
 
     // These values are taken from Nokia 5800 Xpress Music
     static constexpr std::int32_t ACCELEROMETER_SCALE_RANGE_MAX = 127;
@@ -38,7 +40,7 @@ namespace eka2l1::drivers {
     static const std::int32_t ACCELEROMETER_MEASURE_RANGE_MAX_OPTION = sizeof(ACCELEROMETER_MEASURE_RANGE_AVAILABLE) / sizeof(double);
     static const std::int32_t SAMPLING_RATE_MAX_OPTION = sizeof(SAMPLING_RATE_AVAILABLE) / sizeof(std::int32_t);
 
-    sensor_android::sensor_android(sensor_driver_android *driver, ASensorRef const asensor)
+    sensor_android::sensor_android(sensor_driver_android *driver, ASensorRef const asensor, bool rotation)
         : driver_(driver)
         , asensor_(asensor)
         , event_queue_(nullptr)
@@ -48,7 +50,8 @@ namespace eka2l1::drivers {
         , packet_size_(0)
         , active_accel_measure_range_(0)
         , active_sampling_rate_(1)
-        , sensor_type_(0) {
+        , sensor_type_(0)
+        , rotation_(rotation) {
         event_queue_ = ASensorManager_createEventQueue(ASensorManager_getInstance(), common::jni::main_looper,
                                         SENSOR_LOOPER_ID, [](int fd, int events, void *data) {
             sensor_android *sensor = reinterpret_cast<sensor_android*>(data);
@@ -66,7 +69,7 @@ namespace eka2l1::drivers {
 
         switch (sensor_type_) {
             case ASENSOR_TYPE_ACCELEROMETER:
-                packet_size_ = sizeof(sensor_accelerometer_axis_data);
+                packet_size_ = rotation_ ? sizeof(sensor_rotation_data) : sizeof(sensor_accelerometer_axis_data);
                 break;
 
             default:
@@ -85,6 +88,31 @@ namespace eka2l1::drivers {
 
     bool sensor_android::get_property(const sensor_property prop, const std::int32_t item_index,
                       const std::int32_t array_index, sensor_property_data &data) {
+        data = {};
+        data.property_id_ = prop;
+        data.item_index_ = -1;
+        data.array_index_ = SENSOR_PROPERTY_SINGLE;
+        if (rotation_) {
+            switch (prop) {
+            case SENSOR_PROPERTY_MEASURE_RANGE:
+                data.set_double(359.0);
+                data.set_double_range(0.0, 359.0);
+                return true;
+            case SENSOR_PROPERTY_ACCURACY:
+                data.set_double(ROTATION_RESOLUTION_DEGREES / 360.0);
+                data.set_double_range(data.float_value_, data.float_value_);
+                return true;
+            case SENSOR_PROPERTY_AVAILABILITY:
+                data.set_int(1);
+                data.set_int_range(0, 1);
+                return true;
+            case SENSOR_PROPERTY_SAMPLE_RATE:
+                break;
+            default:
+                return false;
+            }
+        }
+
         // Handle global property
         bool global_handled = true;
 
@@ -164,6 +192,9 @@ namespace eka2l1::drivers {
     }
 
     bool sensor_android::set_property(const sensor_property_data &data) {
+        if (rotation_ && data.property_id_ != SENSOR_PROPERTY_SAMPLE_RATE) {
+            return false;
+        }
         bool global_handled = true;
         switch (data.property_id_) {
             case SENSOR_PROPERTY_SAMPLE_RATE:
@@ -176,6 +207,7 @@ namespace eka2l1::drivers {
                     active_sampling_rate_ = static_cast<std::uint32_t>(data.int_value_);
                     ASensorEventQueue_setEventRate(event_queue_, asensor_, static_cast<std::int32_t>(
                             common::microsecs_per_sec / SAMPLING_RATE_AVAILABLE[active_sampling_rate_]));
+                    return true;
                 } else {
                     LOG_ERROR(SERVICE_SENSOR, "Trying to set read-only sample rate property! Only current sample rate index can be set!");
                     return false;
@@ -231,6 +263,13 @@ namespace eka2l1::drivers {
         // Hope it's fine :D
         switch (event.type) {
             case ASENSOR_TYPE_ACCELEROMETER: {
+                if (rotation_) {
+                    const auto data = rotation_from_acceleration(common::get_current_utc_time_in_microseconds_since_0ad(),
+                        event.acceleration.x, event.acceleration.y, event.acceleration.z);
+                    const auto *bytes = reinterpret_cast<const std::uint8_t *>(&data);
+                    events_translated_.insert(events_translated_.end(), bytes, bytes + sizeof(data));
+                    break;
+                }
                 sensor_accelerometer_axis_data axis_data;
 
                 static constexpr float alpha = 0.8f;
@@ -413,44 +452,42 @@ namespace eka2l1::drivers {
             }
         }
 
-        sensor_info info;
-
         for (int i = 0; i < sensor_count_; i++) {
-            int type = ASensor_getType(all_sensors_[i]);
-
-            // Add and handle types that we currently supported here!
-            switch (type) {
-                case ASENSOR_TYPE_ACCELEROMETER:
-                    info.type_ = SENSOR_TYPE_ACCELEROMETER;
-                    info.quantity_ = SENSOR_DATA_QUANTITY_ACCELERATION;
-                    info.data_type_ = SENSOR_DATA_TYPE_ACCELOREMETER_AXIS;
-                    info.item_size_ = sizeof(sensor_accelerometer_axis_data);
-                    break;
-
-                default:
-                    continue;
-            }
-
-            if (search_info.type_ != info.type_) {
+            if (ASensor_getType(all_sensors_[i]) != ASENSOR_TYPE_ACCELEROMETER) {
                 continue;
             }
 
-            info.name_ = ASensor_getName(all_sensors_[i]);
-            info.vendor_ = ASensor_getVendor(all_sensors_[i]);
-            info.id_ = static_cast<std::uint32_t>(i + 1);
+            for (const bool rotation : { false, true }) {
+                sensor_info info;
+                info.type_ = rotation ? SENSOR_TYPE_ROTATION : SENSOR_TYPE_ACCELEROMETER;
+                info.quantity_ = rotation ? SENSOR_DATA_QUANTITY_ROTATION : SENSOR_DATA_QUANTITY_ACCELERATION;
+                info.data_type_ = rotation ? SENSOR_DATA_TYPE_ROTATION : SENSOR_DATA_TYPE_ACCELOREMETER_AXIS;
+                info.item_size_ = rotation ? sizeof(sensor_rotation_data) : sizeof(sensor_accelerometer_axis_data);
 
-            results.push_back(info);
+                if ((search_info.type_ && search_info.type_ != info.type_)
+                    || (search_info.data_type_ && search_info.data_type_ != info.data_type_)
+                    || (search_info.quantity_ && search_info.quantity_ != info.quantity_)) {
+                    continue;
+                }
+
+                info.name_ = ASensor_getName(all_sensors_[i]);
+                info.vendor_ = ASensor_getVendor(all_sensors_[i]);
+                info.id_ = static_cast<std::uint32_t>(i + 1) | (rotation ? ROTATION_CHANNEL_FLAG : 0);
+                results.push_back(info);
+            }
         }
 
         return results;
     }
 
     std::unique_ptr<sensor> sensor_driver_android::new_sensor_controller(const std::uint32_t id) {
-        if ((id == 0) || (id > static_cast<std::uint32_t>(sensor_count_))) {
+        const std::uint32_t native_id = id & ~ROTATION_CHANNEL_FLAG;
+        if ((native_id == 0) || (native_id > static_cast<std::uint32_t>(sensor_count_))
+            || ASensor_getType(all_sensors_[native_id - 1]) != ASENSOR_TYPE_ACCELEROMETER) {
             return nullptr;
         }
 
-        return std::make_unique<sensor_android>(this, all_sensors_[id - 1]);
+        return std::make_unique<sensor_android>(this, all_sensors_[native_id - 1], (id & ROTATION_CHANNEL_FLAG) != 0);
     }
 
     void sensor_driver_android::track_active_listener(common::double_linked_queue_element *link) {

--- a/src/emu/drivers/src/sensor/backend/android/sensor_android.h
+++ b/src/emu/drivers/src/sensor/backend/android/sensor_android.h
@@ -46,6 +46,7 @@ namespace eka2l1::drivers {
         std::uint32_t active_accel_measure_range_;
         std::uint32_t active_sampling_rate_;
         int sensor_type_;
+        bool rotation_;
         std::mutex lock_;
 
         common::double_linked_queue_element listening_link_;
@@ -55,7 +56,7 @@ namespace eka2l1::drivers {
         bool enable_sensor_with_params();
 
     public:
-        explicit sensor_android(sensor_driver_android *driver, ASensorRef const asensor);
+        explicit sensor_android(sensor_driver_android *driver, ASensorRef const asensor, bool rotation = false);
         ~sensor_android() override;
 
         bool get_property(const sensor_property prop, const std::int32_t item_index,

--- a/src/emu/drivers/src/sensor/backend/ios/sensor_ios.h
+++ b/src/emu/drivers/src/sensor/backend/ios/sensor_ios.h
@@ -21,6 +21,7 @@
 
 #include <common/linked.h>
 #include <drivers/sensor/sensor.h>
+#include <drivers/sensor/rotation.h>
 
 #include <atomic>
 #include <memory>
@@ -39,6 +40,7 @@ namespace eka2l1::drivers {
         friend class sensor_driver_ios;
 
         sensor_driver_ios *driver_;
+        sensor_type type_;
         bool listening_;
 
         std::vector<std::uint8_t> events_translated_;
@@ -62,7 +64,7 @@ namespace eka2l1::drivers {
             std::size_t &packet_count_out);
 
     public:
-        explicit sensor_ios(sensor_driver_ios *driver);
+        explicit sensor_ios(sensor_driver_ios *driver, sensor_type type);
         ~sensor_ios() override;
 
         bool get_property(const sensor_property prop, const std::int32_t item_index,
@@ -77,7 +79,7 @@ namespace eka2l1::drivers {
         std::vector<sensor_property_data> get_all_properties(const sensor_property *prop_value = nullptr) override;
 
         std::uint32_t data_packet_size() const override {
-            return sizeof(sensor_accelerometer_axis_data);
+            return type_ == SENSOR_TYPE_ROTATION ? sizeof(sensor_rotation_data) : sizeof(sensor_accelerometer_axis_data);
         }
     };
 

--- a/src/emu/drivers/src/sensor/backend/ios/sensor_ios.mm
+++ b/src/emu/drivers/src/sensor/backend/ios/sensor_ios.mm
@@ -42,6 +42,7 @@ namespace eka2l1::drivers {
 
     static constexpr double STANDARD_GRAVITY_MS2 = 9.80665;
     static constexpr std::uint32_t ACCELEROMETER_SENSOR_ID = 1;
+    static constexpr std::uint32_t ROTATION_SENSOR_ID = 2;
 
     // The CoreMotion handler runs on its own NSOperationQueue thread and may
     // already be queued when the driver goes away, so it only reaches the
@@ -62,8 +63,9 @@ namespace eka2l1::drivers {
 
     // ---- sensor_ios ---------------------------------------------------------
 
-    sensor_ios::sensor_ios(sensor_driver_ios *driver)
+    sensor_ios::sensor_ios(sensor_driver_ios *driver, sensor_type type)
         : driver_(driver)
+        , type_(type)
         , listening_(false)
         , packets_wanted_(1)
         , packets_buffered_(0)
@@ -78,7 +80,31 @@ namespace eka2l1::drivers {
 
     bool sensor_ios::get_property(const sensor_property prop, const std::int32_t item_index,
         const std::int32_t array_index, sensor_property_data &data) {
+        data = {};
         data.property_id_ = prop;
+        data.item_index_ = -1;
+        data.array_index_ = SENSOR_PROPERTY_SINGLE;
+
+        if (type_ == SENSOR_TYPE_ROTATION) {
+            switch (prop) {
+            case SENSOR_PROPERTY_MEASURE_RANGE:
+                data.set_double(359.0);
+                data.set_double_range(0.0, 359.0);
+                return true;
+            case SENSOR_PROPERTY_ACCURACY:
+                data.set_double(ROTATION_RESOLUTION_DEGREES / 360.0);
+                data.set_double_range(data.float_value_, data.float_value_);
+                return true;
+            case SENSOR_PROPERTY_AVAILABILITY:
+                data.set_int(1);
+                data.set_int_range(0, 1);
+                return true;
+            case SENSOR_PROPERTY_SAMPLE_RATE:
+                break;
+            default:
+                return false;
+            }
+        }
 
         switch (prop) {
         case SENSOR_PROPERTY_SAMPLE_RATE:
@@ -156,6 +182,9 @@ namespace eka2l1::drivers {
             return false;
 
         case SENSOR_PROPERTY_MEASURE_RANGE:
+            if (type_ == SENSOR_TYPE_ROTATION) {
+                return false;
+            }
             if (data.array_index_ == SENSOR_PROPERTY_ARRAY) {
                 if ((data.int_value_ >= ACCELEROMETER_MEASURE_RANGE_MAX_OPTION) || (data.int_value_ < 0)) {
                     LOG_ERROR(SERVICE_SENSOR, "Trying to set out-of-bound measure range!");
@@ -183,21 +212,29 @@ namespace eka2l1::drivers {
             return;
         }
 
-        const double measure_range = ACCELEROMETER_MEASURE_RANGE_AVAILABLE[active_accel_measure_range_];
-        auto scale = [measure_range](const double value_ms2) -> std::int32_t {
-            const double scaled = value_ms2 * ACCELEROMETER_SCALE_RANGE_MAX / measure_range;
-            return static_cast<std::int32_t>(std::clamp<double>(scaled, ACCELEROMETER_SCALE_RANGE_MIN,
-                ACCELEROMETER_SCALE_RANGE_MAX));
+        const auto timestamp = common::get_current_utc_time_in_microseconds_since_0ad();
+        auto append = [this](const auto &packet) {
+            const auto *bytes = reinterpret_cast<const std::uint8_t *>(&packet);
+            events_translated_.insert(events_translated_.end(), bytes, bytes + sizeof(packet));
         };
 
-        sensor_accelerometer_axis_data axis_data;
-        axis_data.timestamp_ = common::get_current_utc_time_in_microseconds_since_0ad();
-        axis_data.axis_x_ = scale(x_ms2);
-        axis_data.axis_y_ = scale(y_ms2);
-        axis_data.axis_z_ = scale(z_ms2);
+        if (type_ == SENSOR_TYPE_ROTATION) {
+            append(rotation_from_acceleration(timestamp, x_ms2, y_ms2, z_ms2));
+        } else {
+            const double measure_range = ACCELEROMETER_MEASURE_RANGE_AVAILABLE[active_accel_measure_range_];
+            auto scale = [measure_range](const double value_ms2) -> std::int32_t {
+                const double scaled = value_ms2 * ACCELEROMETER_SCALE_RANGE_MAX / measure_range;
+                return static_cast<std::int32_t>(std::clamp<double>(scaled, ACCELEROMETER_SCALE_RANGE_MIN,
+                    ACCELEROMETER_SCALE_RANGE_MAX));
+            };
 
-        events_translated_.insert(events_translated_.end(), reinterpret_cast<std::uint8_t *>(&axis_data),
-            reinterpret_cast<std::uint8_t *>(&axis_data + 1));
+            sensor_accelerometer_axis_data axis_data;
+            axis_data.timestamp_ = timestamp;
+            axis_data.axis_x_ = scale(x_ms2);
+            axis_data.axis_y_ = scale(y_ms2);
+            axis_data.axis_z_ = scale(z_ms2);
+            append(axis_data);
+        }
 
         packets_buffered_++;
     }
@@ -480,39 +517,35 @@ namespace eka2l1::drivers {
             return results;
         }
 
-        sensor_info info;
-        info.type_ = SENSOR_TYPE_ACCELEROMETER;
-        info.quantity_ = SENSOR_DATA_QUANTITY_ACCELERATION;
-        info.data_type_ = SENSOR_DATA_TYPE_ACCELOREMETER_AXIS;
-        info.item_size_ = sizeof(sensor_accelerometer_axis_data);
-        info.name_ = "iOS Accelerometer";
-        info.vendor_ = "Apple";
-        info.id_ = ACCELEROMETER_SENSOR_ID;
+        for (const auto type : { SENSOR_TYPE_ACCELEROMETER, SENSOR_TYPE_ROTATION }) {
+            sensor_info info;
+            info.type_ = type;
+            const bool rotation = type == SENSOR_TYPE_ROTATION;
+            info.quantity_ = rotation ? SENSOR_DATA_QUANTITY_ROTATION : SENSOR_DATA_QUANTITY_ACCELERATION;
+            info.data_type_ = rotation ? SENSOR_DATA_TYPE_ROTATION : SENSOR_DATA_TYPE_ACCELOREMETER_AXIS;
+            info.item_size_ = rotation ? sizeof(sensor_rotation_data) : sizeof(sensor_accelerometer_axis_data);
+            info.name_ = rotation ? "iOS Rotation" : "iOS Accelerometer";
+            info.vendor_ = "Apple";
+            info.id_ = rotation ? ROTATION_SENSOR_ID : ACCELEROMETER_SENSOR_ID;
 
-        // Unset (zero) fields in the search pattern match everything, the same
-        // filtering the null backend applies.
-        if (search_info.type_ && (search_info.type_ != info.type_)) {
-            return results;
+            if ((search_info.type_ && search_info.type_ != info.type_)
+                || (search_info.data_type_ && search_info.data_type_ != info.data_type_)
+                || (search_info.quantity_ && search_info.quantity_ != info.quantity_)) {
+                continue;
+            }
+
+            results.push_back(info);
         }
-
-        if (search_info.data_type_ && (search_info.data_type_ != info.data_type_)) {
-            return results;
-        }
-
-        if (search_info.quantity_ && (search_info.quantity_ != info.quantity_)) {
-            return results;
-        }
-
-        results.push_back(info);
         return results;
     }
 
     std::unique_ptr<sensor> sensor_driver_ios::new_sensor_controller(const std::uint32_t id) {
-        if ((id != ACCELEROMETER_SENSOR_ID) || !accelerometer_available()) {
+        if ((id != ACCELEROMETER_SENSOR_ID && id != ROTATION_SENSOR_ID) || !accelerometer_available()) {
             return nullptr;
         }
 
-        return std::make_unique<sensor_ios>(this);
+        return std::make_unique<sensor_ios>(this,
+            id == ROTATION_SENSOR_ID ? SENSOR_TYPE_ROTATION : SENSOR_TYPE_ACCELEROMETER);
     }
 
     bool sensor_driver_ios::pause() {

--- a/src/emu/services/src/sensor/sensor.cpp
+++ b/src/emu/services/src/sensor/sensor.cpp
@@ -156,6 +156,7 @@ namespace eka2l1 {
                 list[i].vendor_id.assign(nullptr, infos[i].vendor_);
                 list[i].quantity = infos[i].quantity_;
                 list[i].data_item_size = infos[i].item_size_;
+                list[i].channel_data_type_id = infos[i].data_type_;
             }
         }
 

--- a/src/tests/epoc/CMakeLists.txt
+++ b/src/tests/epoc/CMakeLists.txt
@@ -23,6 +23,7 @@ set(CORE_TEST_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/services/fbs/linkedfont.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/svg_icon.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/sensor/buffering.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/services/sensor/rotation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/window/surface.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/centralrepo/crebinloader.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/services/domain/domain.cpp

--- a/src/tests/epoc/services/sensor/rotation.cpp
+++ b/src/tests/epoc/services/sensor/rotation.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include <catch2/catch.hpp>
+#include <drivers/sensor/rotation.h>
+
+TEST_CASE("Symbian rotation angles follow the device body axes", "[sensor]") {
+    struct sample {
+        double x, y, z;
+        int rotation_x, rotation_y, rotation_z;
+    };
+    const sample cases[] = {
+        { 0, 1, 0, 0, -1, 0 },
+        { 0, -1, 0, 180, -1, 180 },
+        { 1, 0, 0, -1, 90, 270 },
+        { -1, 0, 0, -1, 270, 90 },
+        { 0, 0, 1, 90, 180, -1 },
+        { 0, 0, -1, 270, 0, -1 },
+        { 1, 1, 1, 45, 135, 315 },
+        { -1, -1, -1, 225, 315, 135 },
+        { 1, -1, 1, 135, 135, 225 },
+        { -1, 1, -1, 315, 315, 45 },
+        { 0, 0, 0, -1, -1, -1 }
+    };
+    for (const auto &value : cases) {
+        const auto data = eka2l1::drivers::rotation_from_acceleration(123456, value.x, value.y, value.z);
+        CAPTURE(value.x, value.y, value.z);
+        CHECK(data.timestamp_ == 123456);
+        CHECK(data.x_ == value.rotation_x);
+        CHECK(data.y_ == value.rotation_y);
+        CHECK(data.z_ == value.rotation_z);
+        CHECK(data.padding_ == 0);
+    }
+}
+
+TEST_CASE("Symbian rotation wraps and quantizes independently of acceleration units", "[sensor]") {
+    constexpr double radians = 3.14159265358979323846 / 180.0;
+    for (int degrees = 0; degrees < 360; ++degrees) {
+        const double x = -std::sin(degrees * radians);
+        const double y = std::cos(degrees * radians);
+        const auto data = eka2l1::drivers::rotation_from_acceleration(0, x, y, 0.5);
+        const auto scaled = eka2l1::drivers::rotation_from_acceleration(0, x * 9.80665, y * 9.80665, 4.903325);
+        CAPTURE(degrees);
+        CHECK(data.z_ >= 0);
+        CHECK(data.z_ < 360);
+        CHECK(data.z_ % eka2l1::drivers::ROTATION_RESOLUTION_DEGREES == 0);
+        CHECK(data.x_ == scaled.x_);
+        CHECK(data.y_ == scaled.y_);
+        CHECK(data.z_ == scaled.z_);
+    }
+}


### PR DESCRIPTION
Icy Tower queries the Symbian Rotation channel (`0x10205089`), but the Android and iOS backends only advertise Accelerometer. Its channel search returns no matches, so tilt controls remain inactive even when accelerometer-based games work on the same device.

Add a derived Rotation channel to both mobile backends. The shared conversion follows the axis convention and 15-degree resolution of Nokia's [Orientation SSY](https://github.com/SymbianSource/oss.FCL.sf.os.devicesrv/blob/master/sensorservices/orientationssy/src/SsyOrientation.cpp), producing a 24-byte timestamp/XYZ packet with angles in 0–359 degrees and -1 for undefined rotation. It uses existing accelerometer samples and preserves the current acceleration channel IDs, scaling, and coordinate mapping. No game-specific behavior is added.

Channel queries also populate the previously omitted data-type ID. Android discovery now handles wildcard, data-type, and quantity filters for the two channel types. Tests cover cardinal positions, quadrant signs, undefined rotation, wrapping, resolution, timestamps, and invariance under acceleration-unit scaling.

Validation:

- Fresh focused build from this PR branch: 2,239 assertions in 3 sensor test cases pass.
- Android backend: NDK r27/API 21 compilation passes for ARM64 and ARMv7. A host harness with a fake native sensor provider also passes discovery, filtering, concurrent channel delivery, rearming, pause/resume, and close checks. Android hardware testing is still outstanding.
- Identical changed files in the iOS fork: Release simulator and signed device builds pass; Icy Tower tilt controls confirmed on iPhone Air.
- Release simulator regressions: standard 12/12, Angry Birds 5/5, Asphalt 6 9/9. Gameplay screenshots inspected.
