### PR TITLE
Fix GLES2 attribute binding, desktop shaders, and Qt touch input

### DIFF
--- a/src/emu/dispatch/src/libraries/gles2/gles2.cpp
+++ b/src/emu/dispatch/src/libraries/gles2/gles2.cpp
@@ -97,7 +97,7 @@ namespace eka2l1::dispatch {
         }
 
         // Add version and qualifiers for shader that is missing it
-        if (drv->is_stricted()) {
+        if (drv->is_stricted() || drv->support_extension(drivers::graphics_driver_extension_glsl_es_100)) {
             changed_source.insert(0, "#version 100\n");
 
             std::string str_precision;

--- a/src/emu/dispatch/src/libraries/gles2/gles2.cpp
+++ b/src/emu/dispatch/src/libraries/gles2/gles2.cpp
@@ -1265,7 +1265,7 @@ APPLY_PENDING_ROUTES:
     }
 
     bool egl_context_es2::prepare_vertex_attributes(drivers::graphics_driver *drv, kernel::process *crr_process, const std::int32_t first_index, const std::int32_t vcount) {
-        if (attrib_changed_ || (first_index != previous_first_index_)) {
+        if (attrib_changed_ || (first_index != previous_first_index_) || (using_program_ != previous_using_program_)) {
             std::vector<drivers::input_descriptor> descs;
             std::vector<drivers::handle> vertex_buffers_alloc;
 
@@ -1274,7 +1274,27 @@ APPLY_PENDING_ROUTES:
 
             bool attrib_not_persistent = false;
 
-            for (std::uint32_t i = 0; i < GLES2_EMU_MAX_VERTEX_ATTRIBS_COUNT; i++) {
+            std::vector<std::pair<std::uint32_t, std::uint32_t>> attribute_locations;
+            const auto *metadata = using_program_->get_readonly_metadata();
+            for (std::uint32_t index = 0; index < metadata->get_attribute_count(); index++) {
+                std::string name;
+                std::int32_t location, array_size;
+                drivers::shader_var_type type;
+                metadata->get_attribute_info(index, name, location, type, array_size);
+
+                const std::uint32_t guest_location = using_program_->get_routed_attribute_num(location, true).value_or(location);
+                const std::uint32_t columns = type == drivers::shader_var_type::mat2 ? 2
+                    : type == drivers::shader_var_type::mat3 ? 3
+                    : type == drivers::shader_var_type::mat4 ? 4 : 1;
+                for (std::uint32_t column = 0; column < columns; column++) {
+                    if (guest_location + column < GLES2_EMU_MAX_VERTEX_ATTRIBS_COUNT) {
+                        attribute_locations.emplace_back(guest_location + column, location + column);
+                    }
+                }
+            }
+
+            // Inactive guest attributes can alias host locations assigned to active attributes.
+            for (const auto &[i, location] : attribute_locations) {
                 if ((attributes_enabled_ & (1 << i)) == 0) {
                     attributes_[i].use_constant_vcomp_ = true;
                 } else {
@@ -1297,12 +1317,7 @@ APPLY_PENDING_ROUTES:
                     return false;
                 }
 
-                auto route_ite = using_program_->get_routed_attribute_num(i);
-                if (route_ite.has_value()) {
-                    desc_temp.location = route_ite.value();
-                } else {
-                    desc_temp.location = static_cast<int>(i);
-                }
+                desc_temp.location = location;
 
                 if (attributes_[i].use_constant_vcomp_) {
                     desc_temp.set_normalized(false);

--- a/src/emu/drivers/include/drivers/graphics/backend/ogl/graphics_ogl.h
+++ b/src/emu/drivers/include/drivers/graphics/backend/ogl/graphics_ogl.h
@@ -65,6 +65,7 @@ namespace eka2l1::drivers {
         OGL_FEATURE_SUPPORT_PVRTC = 1 << 1,
         OGL_FEATURE_SUPPORT_ANISOTROPHY = 1 << 2,
         OGL_FEATURE_COMPABILITY_ES31 = 1 << 3,
+        OGL_FEATURE_SUPPORT_GLSL_ES_100 = 1 << 4,
         OGL_MAX_FEATURE = 2
     };
 

--- a/src/emu/drivers/include/drivers/graphics/graphics.h
+++ b/src/emu/drivers/include/drivers/graphics/graphics.h
@@ -110,7 +110,8 @@ namespace eka2l1::drivers {
 
     enum graphics_driver_extension {
         graphics_driver_extension_anisotrophy_filtering = 1 << 0,
-        graphics_driver_extension_float_precision_qualifier = 1 << 1
+        graphics_driver_extension_float_precision_qualifier = 1 << 1,
+        graphics_driver_extension_glsl_es_100 = 1 << 2
     };
 
     enum graphics_driver_extension_query {

--- a/src/emu/drivers/src/graphics/backend/ogl/graphics_ogl.cpp
+++ b/src/emu/drivers/src/graphics/backend/ogl/graphics_ogl.cpp
@@ -171,6 +171,10 @@ namespace eka2l1::drivers {
                 glGetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &anisotrophy_max_);
             }
 
+            if (strcmp(reinterpret_cast<const char*>(next_extension), "GL_ARB_ES2_compatibility") == 0) {
+                feature_flags_ |= OGL_FEATURE_SUPPORT_GLSL_ES_100;
+            }
+
             if (strcmp(reinterpret_cast<const char*>(next_extension), "GL_ARB_ES3_1_compatibility") == 0) {
                 feature_flags_ |= OGL_FEATURE_COMPABILITY_ES31;
             }
@@ -220,6 +224,10 @@ namespace eka2l1::drivers {
     }
 
     bool ogl_graphics_driver::support_extension(const graphics_driver_extension ext) {
+        if (ext == graphics_driver_extension_glsl_es_100) {
+            return is_gles || (feature_flags_ & OGL_FEATURE_SUPPORT_GLSL_ES_100);
+        }
+
         if (ext == graphics_driver_extension_anisotrophy_filtering) {
             return (feature_flags_ & OGL_FEATURE_SUPPORT_ANISOTROPHY);
         }

--- a/src/emu/qt/src/displaywidget.cpp
+++ b/src/emu/qt/src/displaywidget.cpp
@@ -194,11 +194,21 @@ void display_widget::keyReleaseEvent(QKeyEvent *event) {
     }
 }
 
+static int mouse_button_index(Qt::MouseButtons buttons) {
+    std::uint32_t mask = static_cast<std::uint32_t>(buttons);
+    int index = -1;
+    while (mask) {
+        ++index;
+        mask >>= 1;
+    }
+    return index;
+}
+
 void display_widget::mousePressEvent(QMouseEvent *event) {
     const qreal pixel_ratio = devicePixelRatioF();
 
     if (raw_mouse_event) {
-        const int button = eka2l1::common::find_most_significant_bit_one(event->button());
+        const int button = mouse_button_index(event->button());
         raw_mouse_event(userdata_, eka2l1::vec3(event->pos().x() * pixel_ratio, event->pos().y() * pixel_ratio, 0), button, 0, 0);
     }
 }
@@ -207,7 +217,7 @@ void display_widget::mouseReleaseEvent(QMouseEvent *event) {
     if (raw_mouse_event) {
         const qreal pixel_ratio = devicePixelRatioF();
 
-        const int button = eka2l1::common::find_most_significant_bit_one(event->button());
+        const int button = mouse_button_index(event->button());
         raw_mouse_event(userdata_, eka2l1::vec3(event->pos().x() * pixel_ratio, event->pos().y() * pixel_ratio, 0), button, 2, 0);
     }
 }
@@ -217,7 +227,7 @@ void display_widget::mouseMoveEvent(QMouseEvent *event) {
     const qreal pixel_ratio = devicePixelRatioF();
 
     if (raw_mouse_event) {
-        const int button = (event->buttons() == Qt::NoButton) ? -1 : eka2l1::common::find_most_significant_bit_one(event->buttons());
+        const int button = mouse_button_index(event->buttons());
         raw_mouse_event(userdata_, eka2l1::vec3(event->pos().x() * pixel_ratio, event->pos().y() * pixel_ratio, 0), button, 1, 0);
     }
 }


### PR DESCRIPTION
Need for Speed: Shift on the X7 exposed three compatibility issues: missing wheels, a startup panic on macOS, and unresponsive mouse-driven touch controls on desktop.

The GLES2 descriptor builder now uses the current program's active attributes and reverse-maps host locations to guest sources. Previously, an inactive guest normal array could overwrite the host position binding and make the wheels disappear. Matrix columns remain supported, and switching programs refreshes descriptors even when array pointers are unchanged.

Desktop drivers advertising GL_ARB_ES2_compatibility now use the existing GLSL ES 1.00 source path. macOS Core Profile rejected the previous GLSL 1.20 translation, leading to failed shader compilation and a guest panic. Drivers without this capability retain the existing fallback.

Qt mouse button masks now convert to zero-based driver indices for press, release, and drag. The previous bit-width conversion turned left clicks into right-button guest events, which normal touch controls ignored. All three fixes are general compatibility changes without game-specific conditions.

Validation:
- Initial attribute fix: Release iOS simulator wheels reviewed visually; iPhone Air wheels confirmed by the user. All 26 checks passed across the default, Angry Birds, and Asphalt 6 suites, including a rendered Nassau race.
- Additional desktop fixes: macOS build passed; Shift reaches a rendered race without the previous shader failure, guest panic, or graphics halt. Language arrows and confirmation respond to left clicks. The user confirmed manual verification passed.
- Release iOS regression after the shader capability change: all 12 default checks and all 5 Angry Birds checks passed, including taps and carousel dragging.
- Temporary diagnostics removed. The upstream commits contain the same code changes validated in the iOS fork; Android and Windows runtime testing was not performed.
