### PR TITLE
iOS: add game-only AirPlay external display output

### DIFF
--- a/src/emu/drivers/CMakeLists.txt
+++ b/src/emu/drivers/CMakeLists.txt
@@ -192,6 +192,7 @@ elseif (EKA2L1_IOS)
         src/graphics/backend/context_eagl.mm
         include/drivers/graphics/backend/emu_window_ios.h
         src/graphics/backend/emu_window_ios.mm
+        src/graphics/backend/ios_external_display.mm
         src/ui/input_dialog_ios.mm
     )
 elseif(APPLE)

--- a/src/emu/drivers/include/drivers/graphics/backend/emu_window_ios.h
+++ b/src/emu/drivers/include/drivers/graphics/backend/emu_window_ios.h
@@ -5,6 +5,7 @@
 
 #include <common/vecx.h>
 #include <drivers/graphics/emu_window.h>
+#include <drivers/graphics/backend/ios_external_display.h>
 
 #include <atomic>
 #include <cstdint>
@@ -19,6 +20,8 @@ namespace eka2l1::drivers {
     class emu_window_ios final : public emu_window {
     public:
         emu_window_ios();
+
+        ios_external_display external_display;
 
         // Frontend hooks ----------------------------------------------------
         // Called by EAGLView whenever the bound CAEAGLLayer is created or

--- a/src/emu/drivers/include/drivers/graphics/backend/ios_external_display.h
+++ b/src/emu/drivers/include/drivers/graphics/backend/ios_external_display.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 EKA2L1 Team.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <common/vecx.h>
+#include <memory>
+
+namespace eka2l1::drivers {
+    class ios_external_display {
+    public:
+        ios_external_display();
+        ~ios_external_display();
+        void set_surface(void *layer, bool enabled);
+        void enqueue_frame(const rect &crop, const vec2 &surface_size);
+        // Called on the graphics thread before the phone drawable is presented.
+        void present(void *context, unsigned int source_framebuffer);
+        void release();
+
+    private:
+        struct impl;
+        std::unique_ptr<impl> impl_;
+    };
+}

--- a/src/emu/drivers/src/audio/backend/audiounit_ios/audio_audiounit_ios.mm
+++ b/src/emu/drivers/src/audio/backend/audiounit_ios/audio_audiounit_ios.mm
@@ -110,7 +110,8 @@ namespace eka2l1::drivers {
         const AVAudioSessionCategoryOptions options =
             AVAudioSessionCategoryOptionMixWithOthers |
             AVAudioSessionCategoryOptionAllowBluetoothHFP |
-            AVAudioSessionCategoryOptionAllowBluetoothA2DP;
+            AVAudioSessionCategoryOptionAllowBluetoothA2DP |
+            AVAudioSessionCategoryOptionAllowAirPlay;
         if (![session setCategory:AVAudioSessionCategoryPlayAndRecord
                               mode:AVAudioSessionModeDefault
                            options:options

--- a/src/emu/drivers/src/graphics/backend/context_eagl.h
+++ b/src/emu/drivers/src/graphics/backend/context_eagl.h
@@ -14,6 +14,8 @@ struct CAEAGLLayer;
 
 #include <drivers/graphics/context.h>
 
+namespace eka2l1::drivers { class ios_external_display; }
+
 namespace eka2l1::drivers::graphics {
     // EAGL-backed GLES3 context for the iOS frontend.
     //
@@ -66,5 +68,6 @@ namespace eka2l1::drivers::graphics {
         unsigned int m_depthbuffer = 0;
 
         bool m_paused = false;
+        ios_external_display *m_external_display = nullptr;
     };
 }

--- a/src/emu/drivers/src/graphics/backend/context_eagl.mm
+++ b/src/emu/drivers/src/graphics/backend/context_eagl.mm
@@ -4,6 +4,7 @@
 #include "context_eagl.h"
 
 #include <common/log.h>
+#include <drivers/graphics/backend/ios_external_display.h>
 #include <drivers/graphics/backend/ogl/ios_gl_loader.h>
 
 #import <OpenGLES/EAGL.h>
@@ -12,6 +13,7 @@
 namespace eka2l1::drivers::graphics {
     gl_context_eagl::gl_context_eagl(const window_system_info &wsi, bool /*stereo*/, bool /*core*/) {
         m_opengl_mode = mode::opengl_es;
+        m_external_display = static_cast<ios_external_display *>(wsi.render_window);
 
         m_context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3];
         if (!m_context) {
@@ -38,6 +40,10 @@ namespace eka2l1::drivers::graphics {
     }
 
     gl_context_eagl::~gl_context_eagl() {
+        make_current();
+        if (m_external_display) {
+            m_external_display->release();
+        }
         release_renderbuffers();
 
         if (m_framebuffer != 0) {
@@ -74,6 +80,10 @@ namespace eka2l1::drivers::graphics {
     }
 
     void gl_context_eagl::swap_buffers() {
+        if (m_external_display) {
+            m_external_display->present((__bridge void *)m_context,
+                (!m_paused && m_colorbuffer) ? m_framebuffer : 0);
+        }
         if (m_paused || !m_context || m_colorbuffer == 0) {
             return;
         }

--- a/src/emu/drivers/src/graphics/backend/emu_window_ios.mm
+++ b/src/emu/drivers/src/graphics/backend/emu_window_ios.mm
@@ -52,7 +52,7 @@ namespace eka2l1::drivers {
         window_system_info info;
         info.type = window_system_type::iOS;
         info.render_surface = layer_;
-        info.render_window = layer_;
+        info.render_window = &external_display;
         info.render_surface_scale = scale_;
         info.surface_width = static_cast<std::uint32_t>(fb_size_.x);
         info.surface_height = static_cast<std::uint32_t>(fb_size_.y);

--- a/src/emu/drivers/src/graphics/backend/ios_external_display.mm
+++ b/src/emu/drivers/src/graphics/backend/ios_external_display.mm
@@ -1,0 +1,162 @@
+// Copyright (c) 2026 EKA2L1 Team.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <drivers/graphics/backend/ios_external_display.h>
+#include <drivers/graphics/backend/ogl/ios_gl_loader.h>
+#include <common/log.h>
+
+#import <OpenGLES/EAGL.h>
+#import <QuartzCore/CAEAGLLayer.h>
+
+#include <algorithm>
+#include <deque>
+#include <mutex>
+
+namespace eka2l1::drivers {
+    struct ios_external_display::impl {
+        std::mutex mutex;
+        CAEAGLLayer *layer = nil;
+        CGSize size = CGSizeZero;
+        CGFloat scale = 0;
+        bool enabled = false;
+        std::uint64_t revision = 0;
+        std::uint64_t allocated_revision = 0;
+        GLuint framebuffer = 0;
+        GLuint colorbuffer = 0;
+        GLint width = 0;
+        GLint height = 0;
+        struct frame {
+            rect crop;
+            vec2 surface_size;
+        };
+        std::deque<frame> frames;
+    };
+
+    ios_external_display::ios_external_display() : impl_(std::make_unique<impl>()) {}
+    ios_external_display::~ios_external_display() = default;
+
+    void ios_external_display::set_surface(void *surface, bool enabled) {
+        CAEAGLLayer *layer = (__bridge CAEAGLLayer *)surface;
+        const CGSize size = layer ? layer.bounds.size : CGSizeZero;
+        const CGFloat scale = layer ? layer.contentsScale : 0;
+        auto &s = *impl_;
+        std::lock_guard<std::mutex> lock(s.mutex);
+        if (s.layer != layer || !CGSizeEqualToSize(s.size, size) || s.scale != scale || s.enabled != enabled) {
+            s.layer = layer;
+            s.size = size;
+            s.scale = scale;
+            s.enabled = enabled;
+            ++s.revision;
+        }
+    }
+
+    void ios_external_display::enqueue_frame(const rect &crop, const vec2 &surface_size) {
+        std::lock_guard<std::mutex> lock(impl_->mutex);
+        impl_->frames.push_back({ crop, surface_size });
+    }
+
+    void ios_external_display::release() {
+        auto &s = *impl_;
+        if (s.framebuffer) glDeleteFramebuffers(1, &s.framebuffer);
+        if (s.colorbuffer) glDeleteRenderbuffers(1, &s.colorbuffer);
+        s.framebuffer = s.colorbuffer = 0;
+        s.allocated_revision = 0;
+    }
+
+    void ios_external_display::present(void *context, unsigned int source_framebuffer) {
+        auto &s = *impl_;
+        impl::frame frame;
+        bool needs_storage;
+        {
+            std::lock_guard<std::mutex> lock(s.mutex);
+            if (s.frames.empty()) return;
+            frame = s.frames.front();
+            s.frames.pop_front();
+            if (!s.enabled || !s.layer || !source_framebuffer) return;
+            needs_storage = s.revision != s.allocated_revision;
+        }
+        EAGLContext *ctx = (__bridge EAGLContext *)context;
+        if (ctx.API != kEAGLRenderingAPIOpenGLES3) return;
+
+        if (needs_storage) {
+            // Never wait for UIKit while holding the mutex: disconnect and
+            // background callbacks on the main thread take the same lock.
+            [EAGLContext setCurrentContext:nil];
+            dispatch_block_t allocate = ^{
+                std::lock_guard<std::mutex> lock(s.mutex);
+                if (!s.enabled || !s.layer) return;
+                EAGLContext *previous = [EAGLContext currentContext];
+                [EAGLContext setCurrentContext:ctx];
+                GLint read_fbo, draw_fbo, renderbuffer;
+                glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &read_fbo);
+                glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &draw_fbo);
+                glGetIntegerv(GL_RENDERBUFFER_BINDING, &renderbuffer);
+                release();
+                glGenRenderbuffers(1, &s.colorbuffer);
+                glBindRenderbuffer(GL_RENDERBUFFER, s.colorbuffer);
+                if ([ctx renderbufferStorage:GL_RENDERBUFFER fromDrawable:s.layer]) {
+                    glGetRenderbufferParameteriv(GL_RENDERBUFFER, GL_RENDERBUFFER_WIDTH, &s.width);
+                    glGetRenderbufferParameteriv(GL_RENDERBUFFER, GL_RENDERBUFFER_HEIGHT, &s.height);
+                    glGenFramebuffers(1, &s.framebuffer);
+                    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, s.framebuffer);
+                    glFramebufferRenderbuffer(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                        GL_RENDERBUFFER, s.colorbuffer);
+                    if (glCheckFramebufferStatus(GL_DRAW_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE) {
+                        s.allocated_revision = s.revision;
+                    }
+                }
+                if (s.allocated_revision != s.revision) {
+                    LOG_ERROR(DRIVER_GRAPHICS, "iOS external display drawable allocation failed");
+                }
+                glBindFramebuffer(GL_READ_FRAMEBUFFER, read_fbo);
+                glBindFramebuffer(GL_DRAW_FRAMEBUFFER, draw_fbo);
+                glBindRenderbuffer(GL_RENDERBUFFER, renderbuffer);
+                [EAGLContext setCurrentContext:previous];
+            };
+            if ([NSThread isMainThread]) allocate();
+            else dispatch_sync(dispatch_get_main_queue(), allocate);
+            [EAGLContext setCurrentContext:ctx];
+        }
+
+        // The main-thread detach is also a barrier for all output GL work.
+        std::lock_guard<std::mutex> lock(s.mutex);
+        if (!s.enabled || !s.layer || s.allocated_revision != s.revision || !s.framebuffer
+            || frame.crop.size.x <= 0 || frame.crop.size.y <= 0 || s.width <= 0 || s.height <= 0) return;
+
+        GLint read_fbo, draw_fbo, renderbuffer;
+        GLfloat clear_color[4];
+        GLboolean color_mask[4];
+        glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &read_fbo);
+        glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &draw_fbo);
+        glGetIntegerv(GL_RENDERBUFFER_BINDING, &renderbuffer);
+        glGetFloatv(GL_COLOR_CLEAR_VALUE, clear_color);
+        glGetBooleanv(GL_COLOR_WRITEMASK, color_mask);
+        const GLboolean scissor = glIsEnabled(GL_SCISSOR_TEST);
+
+        const float scale = std::min(static_cast<float>(s.width) / frame.crop.size.x,
+            static_cast<float>(s.height) / frame.crop.size.y);
+        const int width = static_cast<int>(frame.crop.size.x * scale);
+        const int height = static_cast<int>(frame.crop.size.y * scale);
+        const int x = (s.width - width) / 2;
+        const int y = (s.height - height) / 2;
+        const int source_y = frame.surface_size.y - frame.crop.top.y - frame.crop.size.y;
+        glDisable(GL_SCISSOR_TEST);
+        glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, s.framebuffer);
+        glClearColor(0, 0, 0, 1);
+        glClear(GL_COLOR_BUFFER_BIT);
+        glBindFramebuffer(GL_READ_FRAMEBUFFER, source_framebuffer);
+        glBlitFramebuffer(frame.crop.top.x, source_y,
+            frame.crop.top.x + frame.crop.size.x, source_y + frame.crop.size.y,
+            x, y, x + width, y + height, GL_COLOR_BUFFER_BIT, GL_LINEAR);
+        glBindRenderbuffer(GL_RENDERBUFFER, s.colorbuffer);
+        [ctx presentRenderbuffer:GL_RENDERBUFFER];
+        glBindFramebuffer(GL_READ_FRAMEBUFFER, read_fbo);
+        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, draw_fbo);
+        glBindRenderbuffer(GL_RENDERBUFFER, renderbuffer);
+        glClearColor(clear_color[0], clear_color[1], clear_color[2], clear_color[3]);
+        glColorMask(color_mask[0], color_mask[1], color_mask[2], color_mask[3]);
+        if (scissor) glEnable(GL_SCISSOR_TEST);
+        glFinish();
+    }
+}

--- a/src/emu/ios/App/EKA2L1App.swift
+++ b/src/emu/ios/App/EKA2L1App.swift
@@ -19,24 +19,34 @@ extension UICollectionView {
 final class AppOrientationDelegate: NSObject, UIApplicationDelegate {
     func application(_ application: UIApplication,
                      supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
-        lockedInterfaceOrientationMask
+        window?.windowScene?.session.role == .windowExternalDisplayNonInteractive
+            ? .all : lockedInterfaceOrientationMask
     }
 }
 
 @main
 struct EKA2L1App: App {
     @UIApplicationDelegateAdaptor(AppOrientationDelegate.self) private var appDelegate
-    @Environment(\.scenePhase) private var scenePhase
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            MainSceneContent()
         }
+    }
+}
+
+private struct MainSceneContent: View {
+    @Environment(\.scenePhase) private var scenePhase
+
+    var body: some View {
+        ContentView()
         .onChange(of: scenePhase) { newPhase in
             switch newPhase {
             case .active:
                 EKA2L1Bridge.shared.resume()
+                ExternalDisplay.shared.setForeground(true)
             case .inactive, .background:
+                ExternalDisplay.shared.setForeground(false)
                 EKA2L1Bridge.shared.pause()
                 // pause() deactivates the audio session, which CoreHaptics
                 // shares; don't keep the iOS 16 fallback's generators alive

--- a/src/emu/ios/App/EKA2L1Bridge.swift
+++ b/src/emu/ios/App/EKA2L1Bridge.swift
@@ -207,6 +207,10 @@ final class EKA2L1Bridge {
         emulator.attach(layer: layer, pixelSize: pixelSize, scale: scale)
     }
 
+    func setExternalDisplay(layer: CAEAGLLayer?, enabled: Bool) {
+        emulator.setExternalDisplay(layer: layer, enabled: enabled)
+    }
+
     func detachLayer() {
         emulator.detachLayer()
     }

--- a/src/emu/ios/App/EmulatorView.swift
+++ b/src/emu/ios/App/EmulatorView.swift
@@ -542,6 +542,7 @@ enum DisplayOrientation {
 
     private static var activeScene: UIWindowScene? {
         let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+            .filter { $0.session.role == .windowApplication }
         return scenes.first { $0.activationState == .foregroundActive } ?? scenes.first
     }
 

--- a/src/emu/ios/App/EmulatorViewController.swift
+++ b/src/emu/ios/App/EmulatorViewController.swift
@@ -417,6 +417,10 @@ final class EmulatorViewController: UIViewController {
         super.viewDidAppear(animated)
         gameView.setNeedsLayout()
         gameView.layoutIfNeeded()
+        ExternalDisplay.shared.onSurfaceChange = { [weak self] in
+            self?.view.setNeedsLayout()
+        }
+        ExternalDisplay.shared.setGameVisible(true)
         peripheralInput.start()
         EKA2L1Bridge.shared.resume()
         // Launch once: viewDidAppear can re-fire (e.g. returning frontmost),
@@ -434,6 +438,8 @@ final class EmulatorViewController: UIViewController {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
+        ExternalDisplay.shared.onSurfaceChange = nil
+        ExternalDisplay.shared.setGameVisible(false)
         peripheralInput.stop()
         EKA2L1Bridge.shared.detachLayer()
     }

--- a/src/emu/ios/App/ExternalDisplay.swift
+++ b/src/emu/ios/App/ExternalDisplay.swift
@@ -1,0 +1,118 @@
+import QuartzCore
+import UIKit
+
+@MainActor
+final class ExternalDisplay {
+    static let shared = ExternalDisplay()
+
+    private weak var outputView: ExternalGameView?
+    private var gameVisible = false
+    private var foreground = false
+    var onSurfaceChange: (() -> Void)?
+
+    func connect(_ view: ExternalGameView) {
+        outputView = view
+        refresh()
+    }
+
+    func disconnect(_ view: ExternalGameView) {
+        guard outputView === view else { return }
+        outputView = nil
+        refresh()
+    }
+
+    func setGameVisible(_ visible: Bool) {
+        gameVisible = visible
+        foreground = UIApplication.shared.applicationState == .active
+        refresh()
+    }
+
+    func setForeground(_ active: Bool) {
+        foreground = active
+        refresh()
+    }
+
+    func refresh() {
+        let phase = outputView?.window?.windowScene?.activationState
+        let enabled = gameVisible && foreground && (phase == .foregroundActive || phase == .foregroundInactive)
+        outputView?.isHidden = !enabled
+        EKA2L1Bridge.shared.setExternalDisplay(layer: outputView?.renderLayer, enabled: enabled)
+        if enabled { onSurfaceChange?() }
+    }
+}
+
+final class ExternalGameView: UIView {
+    override class var layerClass: AnyClass { CAEAGLLayer.self }
+    var renderLayer: CAEAGLLayer { layer as! CAEAGLLayer }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        isUserInteractionEnabled = false
+        backgroundColor = .black
+        isOpaque = true
+        renderLayer.isOpaque = true
+        renderLayer.drawableProperties = [
+            kEAGLDrawablePropertyRetainedBacking: false,
+            kEAGLDrawablePropertyColorFormat: kEAGLColorFormatRGBA8
+        ]
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        contentScaleFactor = window?.windowScene?.screen.scale ?? 1
+        ExternalDisplay.shared.refresh()
+    }
+}
+
+final class ExternalDisplaySceneDelegate: UIResponder, UIWindowSceneDelegate {
+    var window: UIWindow?
+    private var gameView: ExternalGameView?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession,
+               options connectionOptions: UIScene.ConnectionOptions) {
+        guard let scene = scene as? UIWindowScene,
+              session.role == .windowExternalDisplayNonInteractive else { return }
+        let controller = UIViewController()
+        controller.view.backgroundColor = .black
+        let gameView = ExternalGameView(frame: controller.view.bounds)
+        gameView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        controller.view.addSubview(gameView)
+        let window = UIWindow(windowScene: scene)
+        window.frame = scene.coordinateSpace.bounds
+        window.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        window.rootViewController = controller
+        window.isHidden = false
+        self.window = window
+        self.gameView = gameView
+        ExternalDisplay.shared.connect(gameView)
+    }
+
+    func windowScene(_ windowScene: UIWindowScene, didUpdate previousCoordinateSpace: UICoordinateSpace,
+                     interfaceOrientation previousInterfaceOrientation: UIInterfaceOrientation,
+                     traitCollection previousTraitCollection: UITraitCollection) {
+        window?.frame = windowScene.coordinateSpace.bounds
+        window?.layoutIfNeeded()
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        if let gameView { ExternalDisplay.shared.connect(gameView) }
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        if let gameView { ExternalDisplay.shared.connect(gameView) }
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        if let gameView { ExternalDisplay.shared.disconnect(gameView) }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        if let gameView { ExternalDisplay.shared.disconnect(gameView) }
+        window?.isHidden = true
+        window = nil
+        gameView = nil
+    }
+}

--- a/src/emu/ios/App/SettingsView.swift
+++ b/src/emu/ios/App/SettingsView.swift
@@ -83,6 +83,12 @@ struct SettingsView: View {
                 Toggle("settings.fpsOverlay", isOn: $showFPSOverlay)
             }
             Section {
+                Text("settings.airplay.hint")
+                    .foregroundStyle(.secondary)
+            } header: {
+                Text(verbatim: "AirPlay")
+            }
+            Section {
                 Picker("settings.netplay.discoveryMode", selection: $btDiscoveryMode) {
                     Text("settings.netplay.mode.off").tag(0)
                     Text("settings.netplay.mode.directIp").tag(1)

--- a/src/emu/ios/Bridge/IosEmulator.h
+++ b/src/emu/ios/Bridge/IosEmulator.h
@@ -209,6 +209,8 @@ typedef NS_ENUM(NSInteger, EKA2L1InstallResult) {
          pixelSize:(CGSize)pixelSize
               scale:(CGFloat)scale NS_SWIFT_NAME(attach(layer:pixelSize:scale:));
 - (void)detachLayer NS_SWIFT_NAME(detachLayer());
+- (void)setExternalDisplayLayer:(nullable CAEAGLLayer *)layer enabled:(BOOL)enabled
+    NS_SWIFT_NAME(setExternalDisplay(layer:enabled:));
 
 - (void)pause;
 - (void)resume;

--- a/src/emu/ios/Bridge/IosEmulator.mm
+++ b/src/emu/ios/Bridge/IosEmulator.mm
@@ -734,6 +734,8 @@ namespace eka2l1::ios {
             dest.top.y = std::min(anchor_top, max_top);
         }
 
+        const eka2l1::rect external_crop = dest;
+
         scr->set_native_scale_factor(state->graphics_driver.get(), scale, scale);
         scr->absolute_pos = dest.top;
 
@@ -755,6 +757,7 @@ namespace eka2l1::ios {
 
         builder.load_backup_state();
         state->present_status[slot] = -100;
+        state->window->external_display.enqueue_frame(external_crop, swapchain_size);
         builder.present(&state->present_status[slot]);
         eka2l1::drivers::command_list commands = builder.retrieve_command_list();
         state->graphics_driver->submit_command_list(commands);
@@ -2074,6 +2077,12 @@ namespace eka2l1::ios {
     }
 }
 
+
+- (void)setExternalDisplayLayer:(CAEAGLLayer *)layer enabled:(BOOL)enabled {
+    if (_state && _state->window) {
+        _state->window->external_display.set_surface((__bridge void *)layer, enabled);
+    }
+}
 
 - (void)detachLayer {
     if (!_state) {

--- a/src/emu/ios/CMakeLists.txt
+++ b/src/emu/ios/CMakeLists.txt
@@ -35,6 +35,7 @@ set(EKA2L1_IOS_BRIDGE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Bridge")
 
 set(EKA2L1_IOS_SOURCES
     "${EKA2L1_IOS_APP_DIR}/EKA2L1App.swift"
+    "${EKA2L1_IOS_APP_DIR}/ExternalDisplay.swift"
     "${EKA2L1_IOS_APP_DIR}/ContentView.swift"
     "${EKA2L1_IOS_APP_DIR}/OnboardingView.swift"
     "${EKA2L1_IOS_APP_DIR}/DeviceManagerView.swift"

--- a/src/emu/ios/Resources/Info.plist
+++ b/src/emu/ios/Resources/Info.plist
@@ -51,6 +51,25 @@
          TestFlight build skips the manual export-compliance questionnaire. -->
     <key>ITSAppUsesNonExemptEncryption</key>
     <false/>
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <false/>
+        <key>UISceneConfigurations</key>
+        <dict>
+            <key>UIWindowSceneSessionRoleExternalDisplayNonInteractive</key>
+            <array>
+                <dict>
+                    <key>UISceneConfigurationName</key>
+                    <string>Game Display</string>
+                    <key>UISceneClassName</key>
+                    <string>UIWindowScene</string>
+                    <key>UISceneDelegateClassName</key>
+                    <string>$(PRODUCT_MODULE_NAME).ExternalDisplaySceneDelegate</string>
+                </dict>
+            </array>
+        </dict>
+    </dict>
     <key>UILaunchScreen</key>
     <dict/>
     <key>NSPhotoLibraryAddUsageDescription</key>

--- a/src/emu/ios/Resources/Localizable.xcstrings
+++ b/src/emu/ios/Resources/Localizable.xcstrings
@@ -1483,6 +1483,16 @@
         }
       }
     },
+    "settings.airplay.hint" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Control Center, choose Screen Mirroring, and select your TV or Mac."
+          }
+        }
+      }
+    },
     "settings.device" : {
       "localizations" : {
         "en" : {


### PR DESCRIPTION
AirPlay screen mirroring currently includes the virtual keypad, FPS overlay and host menus. This adds a noninteractive external-display scene that shows only the guest picture, while the phone keeps the game image and all controls. Users connect through **Control Center → Screen Mirroring**; the external display is black outside gameplay.

The iOS GLES backend crops and aspect-fits the guest framebuffer before presenting the phone drawable. Per-frame crop metadata follows the existing presentation fences, GL state is restored, and surface disconnect waits for GPU completion. The phone scene controls background suspension; passive external scenes accept both foreground states so Home/resume restores the TV picture. Recording audio sessions also permit AirPlay, and Settings explains how to connect.

All runtime changes are confined to the iOS frontend and iOS graphics/audio backends. This is one commit based on upstream `master`; unrelated fork changes are excluded.

Validation performed on the iOS integration branch before extracting this commit:

- Release simulator and signed Release device builds succeeded.
- Default simulator regression suite: **12/12 passed** (Final Battle, 5320 Calculator, N95 Calculator and string catalog).
- Angry Birds touch suite: **5/5 passed**. One earlier run hit the fixed-wait assertion during a slow menu transition; the unchanged suite passed on rerun without code or assertion changes.
- Visual checks with a 1080p external display: portrait letterboxing, landscape game-only output, reconnect of static screens, and Home/resume with the same guest process and working phone input.
- iPhone Air: the tester confirmed game-only video, working phone controls and TV audio.

The isolated upstream branch has been checked for patch consistency and whitespace; the full runtime suites above were run on the integration branch.

