### PR TITLE
iOS: add independent controller sticks, AirPlay touch, motion and haptics

### DIFF
--- a/src/emu/drivers/CMakeLists.txt
+++ b/src/emu/drivers/CMakeLists.txt
@@ -148,6 +148,7 @@ elseif (EKA2L1_IOS)
         src/camera/backend/ios/camera_pixel_ios.mm
         src/camera/backend/ios/camera_simulator.mm
         src/sensor/backend/ios/sensor_ios.h
+        include/drivers/sensor/backend/ios/controller_motion.h
         src/sensor/backend/ios/sensor_ios.mm)
 else()
     target_sources(drivers PRIVATE
@@ -258,6 +259,7 @@ if (EKA2L1_IOS)
         "-framework CoreAudio"
         "-framework CoreHaptics"
         "-framework CoreMotion"
+        "-framework GameController"
         "-framework CoreMedia"
         "-framework CoreVideo"
         "-framework CoreGraphics"

--- a/src/emu/drivers/include/drivers/hwrm/backend/vibration_ios.h
+++ b/src/emu/drivers/include/drivers/hwrm/backend/vibration_ios.h
@@ -14,6 +14,9 @@
 #include <drivers/hwrm/vibration.h>
 
 namespace eka2l1::drivers::hwrm {
+    void set_controller_haptic_source(void *controller);
+    void set_vibration_suspended(bool suspended);
+
     class vibrator_ios final : public vibrator {
     public:
         vibrator_ios();
@@ -24,5 +27,9 @@ namespace eka2l1::drivers::hwrm {
 
     private:
         void *engine_ = nullptr;
+        void *player_ = nullptr;
+        std::uint64_t source_revision_ = 0;
+        void clear_engine_locked();
+        void stop_player_locked();
     };
 }

--- a/src/emu/drivers/include/drivers/sensor/backend/ios/controller_motion.h
+++ b/src/emu/drivers/include/drivers/sensor/backend/ios/controller_motion.h
@@ -1,0 +1,11 @@
+// Copyright (c) 2026 EKA2L1 Team.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+namespace eka2l1::drivers {
+    class sensor_driver;
+
+    void set_controller_motion_source(sensor_driver *driver, void *controller);
+    void set_controller_motion_rotation(sensor_driver *driver, int degrees);
+}

--- a/src/emu/drivers/src/hwrm/backend/vibration_ios.mm
+++ b/src/emu/drivers/src/hwrm/backend/vibration_ios.mm
@@ -12,74 +12,128 @@
 #include <drivers/hwrm/backend/vibration_ios.h>
 
 #include <algorithm>
+#include <cmath>
+#include <mutex>
 
 #import <CoreHaptics/CoreHaptics.h>
+#import <GameController/GameController.h>
 
 namespace eka2l1::drivers::hwrm {
-    vibrator_ios::vibrator_ios() {
-        if (!CHHapticEngine.capabilitiesForHardware.supportsHaptics) {
-            return;
+    namespace {
+        struct haptic_routing {
+            std::mutex mutex;
+            GCController *controller = nil;
+            NSHashTable<CHHapticEngine *> *engines = [NSHashTable weakObjectsHashTable];
+            std::uint64_t revision = 1;
+            bool suspended = false;
+        };
+
+        haptic_routing &routing() {
+            static haptic_routing state;
+            return state;
         }
 
-        NSError *error = nil;
-        CHHapticEngine *engine = [[CHHapticEngine alloc] initAndReturnError:&error];
-        if (error || !engine) {
-            return;
+        void stop_engines_locked(haptic_routing &state) {
+            for (CHHapticEngine *engine in state.engines) {
+                [engine stopWithCompletionHandler:nil];
+            }
+            ++state.revision;
         }
-
-        [engine startAndReturnError:nil];
-        engine_ = (__bridge_retained void *)engine;
     }
 
+    void set_controller_haptic_source(void *controller) {
+        auto &state = routing();
+        const std::lock_guard<std::mutex> hold(state.mutex);
+        GCController *source = (__bridge GCController *)controller;
+        if (!source.haptics) source = nil;
+        if (state.controller == source) return;
+        stop_engines_locked(state);
+        state.controller = source;
+    }
+
+    void set_vibration_suspended(bool suspended) {
+        auto &state = routing();
+        const std::lock_guard<std::mutex> hold(state.mutex);
+        if (state.suspended == suspended) return;
+        state.suspended = suspended;
+        if (suspended) stop_engines_locked(state);
+    }
+
+    vibrator_ios::vibrator_ios() = default;
+
     vibrator_ios::~vibrator_ios() {
-        stop_vibrate();
+        const std::lock_guard<std::mutex> hold(routing().mutex);
+        clear_engine_locked();
+    }
+
+    void vibrator_ios::stop_player_locked() {
+        if (player_) {
+            id<CHHapticPatternPlayer> player = (__bridge id<CHHapticPatternPlayer>)player_;
+            [player stopAtTime:CHHapticTimeImmediate error:nil];
+            CFRelease(player_);
+            player_ = nullptr;
+        }
+    }
+
+    void vibrator_ios::clear_engine_locked() {
+        stop_player_locked();
         if (engine_) {
+            CHHapticEngine *engine = (__bridge CHHapticEngine *)engine_;
+            [engine stopWithCompletionHandler:nil];
+            [routing().engines removeObject:engine];
             CFRelease(engine_);
             engine_ = nullptr;
         }
     }
 
     void vibrator_ios::vibrate(const std::uint32_t millisecs, const std::int16_t intensity) {
+        auto &state = routing();
+        const std::lock_guard<std::mutex> hold(state.mutex);
+        stop_player_locked();
+        if (state.suspended) return;
+        if (source_revision_ != state.revision) clear_engine_locked();
         if (!engine_) {
-            return;
+            CHHapticEngine *engine = nil;
+            if (state.controller) {
+                engine = [state.controller.haptics createEngineWithLocality:GCHapticsLocalityDefault];
+            } else if (CHHapticEngine.capabilitiesForHardware.supportsHaptics) {
+                engine = [[CHHapticEngine alloc] initAndReturnError:nil];
+            }
+            if (!engine) return;
+            engine.playsHapticsOnly = YES;
+            engine_ = (__bridge_retained void *)engine;
+            source_revision_ = state.revision;
+            [state.engines addObject:engine];
         }
 
         CHHapticEngine *engine = (__bridge CHHapticEngine *)engine_;
-        const float clamped = std::clamp(static_cast<float>(intensity), -100.0f, 100.0f);
-        const float normalized = std::max(0.15f, (clamped + 100.0f) / 200.0f);
-        const NSTimeInterval duration = std::max<NSTimeInterval>(0.03, static_cast<NSTimeInterval>(millisecs) / 1000.0);
-
+        if (![engine startAndReturnError:nil]) return;
+        // The driver API uses zero for default intensity; motor direction has no haptic equivalent.
+        const float normalized = intensity == 0 ? 0.5f
+            : std::min(1.0f, std::abs(static_cast<float>(intensity)) / 100.0f);
+        const NSTimeInterval duration = millisecs == 0 ? 1.0 : static_cast<NSTimeInterval>(millisecs) / 1000.0;
         CHHapticEventParameter *intensity_param = [[CHHapticEventParameter alloc]
             initWithParameterID:CHHapticEventParameterIDHapticIntensity value:normalized];
         CHHapticEventParameter *sharpness_param = [[CHHapticEventParameter alloc]
             initWithParameterID:CHHapticEventParameterIDHapticSharpness value:0.45f];
         CHHapticEvent *event = [[CHHapticEvent alloc]
             initWithEventType:CHHapticEventTypeHapticContinuous
-            parameters:@[ intensity_param, sharpness_param ]
-            relativeTime:0.0
-            duration:duration];
-
-        NSError *error = nil;
-        CHHapticPattern *pattern = [[CHHapticPattern alloc] initWithEvents:@[ event ] parameters:@[] error:&error];
-        if (error || !pattern) {
-            return;
+            parameters:@[ intensity_param, sharpness_param ] relativeTime:0.0 duration:duration];
+        CHHapticPattern *pattern = [[CHHapticPattern alloc] initWithEvents:@[ event ] parameters:@[] error:nil];
+        if (!pattern) return;
+        id<CHHapticAdvancedPatternPlayer> player = [engine createAdvancedPlayerWithPattern:pattern error:nil];
+        if (!player) return;
+        if (millisecs == 0) {
+            player.loopEnabled = YES;
+            player.loopEnd = duration;
         }
-
-        id<CHHapticPatternPlayer> player = [engine createPlayerWithPattern:pattern error:&error];
-        if (error || !player) {
-            return;
+        if ([player startAtTime:CHHapticTimeImmediate error:nil]) {
+            player_ = (__bridge_retained void *)player;
         }
-
-        [engine startAndReturnError:nil];
-        [player startAtTime:CHHapticTimeImmediate error:nil];
     }
 
     void vibrator_ios::stop_vibrate() {
-        if (!engine_) {
-            return;
-        }
-
-        CHHapticEngine *engine = (__bridge CHHapticEngine *)engine_;
-        [engine stopWithCompletionHandler:nil];
+        const std::lock_guard<std::mutex> hold(routing().mutex);
+        stop_player_locked();
     }
 }

--- a/src/emu/drivers/src/sensor/backend/ios/sensor_ios.h
+++ b/src/emu/drivers/src/sensor/backend/ios/sensor_ios.h
@@ -24,6 +24,7 @@
 #include <drivers/sensor/rotation.h>
 
 #include <atomic>
+#include <array>
 #include <memory>
 #include <mutex>
 #include <vector>
@@ -54,7 +55,7 @@ namespace eka2l1::drivers {
 
         common::double_linked_queue_element listening_link_;
 
-        // Called by the driver's CoreMotion pump for each accelerometer
+        // Called by the driver's motion pump for each accelerometer
         // sample, already converted to the Android/Symbian m/s^2 convention.
         void push_sample(const double x_ms2, const double y_ms2, const double z_ms2);
 
@@ -95,13 +96,15 @@ namespace eka2l1::drivers {
 
         // CCW angle from the iPhone's natural orientation to the emulated
         // device's natural orientation (see sensor_driver::set_motion_rotation).
-        // Written by the frontend's present path, read on the CoreMotion queue.
+        // Written by the frontend's present path, read on the sampling queue.
         std::atomic<int> motion_rotation_deg_;
+        std::atomic<int> controller_rotation_deg_{0};
+        std::atomic<bool> controller_motion_available_{false};
 
         void track_active_listener(common::double_linked_queue_element *link);
         void untrack_active_listener(common::double_linked_queue_element *link);
 
-        // Starts / stops / retunes CoreMotion accelerometer updates to match
+        // Starts / stops / retunes the motion source and sampling timer to match
         // the current listener set, pause state and requested sampling rate.
         // Callers must hold list_lock_.
         void refresh_pump_locked();
@@ -110,7 +113,8 @@ namespace eka2l1::drivers {
         void refresh_pump();
 
         // Pump handler: fan a sample out to every listening sensor.
-        void dispatch_sample(const double x_ms2, const double y_ms2, const double z_ms2);
+        void poll_sample();
+        void dispatch_sample(std::array<double, 3> acceleration, std::array<double, 3> gravity, int rotation);
 
         std::uint32_t max_requested_sampling_rate_locked();
 
@@ -124,6 +128,8 @@ namespace eka2l1::drivers {
         bool pause() override;
         bool resume() override;
         void set_motion_rotation(const int degrees) override;
+        void set_controller(void *controller);
+        void set_controller_rotation(int degrees);
 
         bool accelerometer_available() const;
     };

--- a/src/emu/drivers/src/sensor/backend/ios/sensor_ios.mm
+++ b/src/emu/drivers/src/sensor/backend/ios/sensor_ios.mm
@@ -18,8 +18,10 @@
  */
 
 #import <CoreMotion/CoreMotion.h>
+#import <GameController/GameController.h>
 
 #include "sensor_ios.h"
+#include <drivers/sensor/backend/ios/controller_motion.h>
 
 #include <common/log.h>
 #include <common/time.h>
@@ -44,10 +46,8 @@ namespace eka2l1::drivers {
     static constexpr std::uint32_t ACCELEROMETER_SENSOR_ID = 1;
     static constexpr std::uint32_t ROTATION_SENSOR_ID = 2;
 
-    // The CoreMotion handler runs on its own NSOperationQueue thread and may
-    // already be queued when the driver goes away, so it only reaches the
-    // driver through this guard: the driver's destructor (and the pause
-    // barrier) takes the lock and clears/blocks on it.
+    // Queued samples must pass this guard before accessing the driver;
+    // destruction clears the owner and pause waits out any callback in flight.
     struct core_motion_owner_guard {
         std::mutex lock_;
         sensor_driver_ios *owner_ = nullptr;
@@ -55,9 +55,9 @@ namespace eka2l1::drivers {
 
     struct core_motion_pump {
         CMMotionManager *manager_ = nil;
-        NSOperationQueue *queue_ = nil;
-        bool running_ = false;
-        std::uint32_t running_rate_hz_ = 0;
+        GCController *controller_ = nil;
+        dispatch_queue_t queue_ = nil;
+        dispatch_source_t timer_ = nil;
         std::shared_ptr<core_motion_owner_guard> guard_;
     };
 
@@ -329,9 +329,7 @@ namespace eka2l1::drivers {
         , paused_(false)
         , motion_rotation_deg_(0) {
         pump_->manager_ = [[CMMotionManager alloc] init];
-        pump_->queue_ = [[NSOperationQueue alloc] init];
-        pump_->queue_.maxConcurrentOperationCount = 1;
-        pump_->queue_.name = @"com.eka2l1.emulator.sensor";
+        pump_->queue_ = dispatch_queue_create("com.eka2l1.emulator.sensor", DISPATCH_QUEUE_SERIAL);
         pump_->guard_ = std::make_shared<core_motion_owner_guard>();
         pump_->guard_->owner_ = this;
     }
@@ -339,10 +337,8 @@ namespace eka2l1::drivers {
     sensor_driver_ios::~sensor_driver_ios() {
         {
             const std::lock_guard<std::mutex> hold(list_lock_);
-            if (pump_->running_) {
-                [pump_->manager_ stopAccelerometerUpdates];
-                pump_->running_ = false;
-            }
+            paused_ = true;
+            refresh_pump_locked();
         }
 
         // Barrier: a handler block already dequeued keeps the guard alive via
@@ -353,7 +349,30 @@ namespace eka2l1::drivers {
     }
 
     bool sensor_driver_ios::accelerometer_available() const {
-        return pump_->manager_.accelerometerAvailable;
+        return pump_->manager_.accelerometerAvailable || controller_motion_available_.load(std::memory_order_relaxed);
+    }
+
+    void set_controller_motion_source(sensor_driver *driver, void *controller) {
+        if (driver) static_cast<sensor_driver_ios *>(driver)->set_controller(controller);
+    }
+
+    void set_controller_motion_rotation(sensor_driver *driver, int degrees) {
+        if (driver) static_cast<sensor_driver_ios *>(driver)->set_controller_rotation(degrees);
+    }
+
+    void sensor_driver_ios::set_controller(void *controller) {
+        const std::lock_guard<std::mutex> hold(list_lock_);
+        GCController *source = (__bridge GCController *)controller;
+        if (source == pump_->controller_) return;
+        GCMotion *previous = pump_->controller_.motion;
+        if (previous.sensorsRequireManualActivation) previous.sensorsActive = NO;
+        pump_->controller_ = source;
+        controller_motion_available_.store(source.motion != nil, std::memory_order_relaxed);
+        refresh_pump_locked();
+    }
+
+    void sensor_driver_ios::set_controller_rotation(int degrees) {
+        controller_rotation_deg_.store(((degrees % 360) + 360) % 360, std::memory_order_relaxed);
     }
 
     std::uint32_t sensor_driver_ios::max_requested_sampling_rate_locked() {
@@ -378,48 +397,72 @@ namespace eka2l1::drivers {
 
     void sensor_driver_ios::refresh_pump_locked() {
         const bool want_running = !paused_ && !listening_list_.empty();
+        GCMotion *motion = pump_->controller_.motion;
+        if (motion.sensorsRequireManualActivation && motion.sensorsActive != want_running) {
+            motion.sensorsActive = want_running;
+        }
+
+        if (!want_running || motion) {
+            [pump_->manager_ stopAccelerometerUpdates];
+        } else if (!pump_->manager_.accelerometerActive) {
+            [pump_->manager_ startAccelerometerUpdates];
+        }
 
         if (!want_running) {
-            if (pump_->running_) {
-                [pump_->manager_ stopAccelerometerUpdates];
-                pump_->running_ = false;
-                pump_->running_rate_hz_ = 0;
+            if (pump_->timer_) {
+                dispatch_source_cancel(pump_->timer_);
+                pump_->timer_ = nil;
             }
             return;
         }
 
         const std::uint32_t rate_hz = max_requested_sampling_rate_locked();
         pump_->manager_.accelerometerUpdateInterval = 1.0 / static_cast<double>(rate_hz);
-
-        if (pump_->running_) {
-            pump_->running_rate_hz_ = rate_hz;
+        const std::uint64_t interval = NSEC_PER_SEC / rate_hz;
+        if (pump_->timer_) {
+            dispatch_source_set_timer(pump_->timer_, DISPATCH_TIME_NOW, interval, interval / 10);
             return;
         }
 
+        pump_->timer_ = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, pump_->queue_);
         std::shared_ptr<core_motion_owner_guard> guard = pump_->guard_;
-        [pump_->manager_ startAccelerometerUpdatesToQueue:pump_->queue_
-                                              withHandler:^(CMAccelerometerData *data, NSError *error) {
-            if (!data) {
-                return;
-            }
-
+        dispatch_source_set_event_handler(pump_->timer_, ^{
             const std::lock_guard<std::mutex> hold(guard->lock_);
-            if (!guard->owner_) {
-                return;
+            if (guard->owner_) guard->owner_->poll_sample();
+        });
+        dispatch_source_set_timer(pump_->timer_, DISPATCH_TIME_NOW, interval, interval / 10);
+        dispatch_resume(pump_->timer_);
+    }
+
+    void sensor_driver_ios::poll_sample() {
+        std::array<double, 3> acceleration;
+        std::array<double, 3> gravity;
+        int rotation;
+        {
+            const std::lock_guard<std::mutex> hold(list_lock_);
+            if (paused_ || listening_list_.empty()) return;
+            GCMotion *motion = pump_->controller_.motion;
+            if (motion) {
+                const GCAcceleration a = motion.acceleration;
+                const GCAcceleration g = motion.hasGravityAndUserAcceleration ? motion.gravity : a;
+                acceleration = { a.x, a.y, a.z };
+                gravity = { g.x, g.y, g.z };
+                rotation = controller_rotation_deg_.load(std::memory_order_relaxed);
+            } else {
+                CMAccelerometerData *data = pump_->manager_.accelerometerData;
+                if (!data) return;
+                acceleration = { data.acceleration.x, data.acceleration.y, data.acceleration.z };
+                gravity = acceleration;
+                rotation = motion_rotation_deg_.load(std::memory_order_relaxed);
             }
-
-            // CoreMotion reports in g with gravity measured along the negative
-            // axis (flat, screen up: z ~= -1). Symbian/Android channels report
-            // the reaction force in m/s^2 (flat, screen up: z ~= +9.81) with
-            // the same axis orientation — negate and rescale.
-            guard->owner_->dispatch_sample(
-                -data.acceleration.x * STANDARD_GRAVITY_MS2,
-                -data.acceleration.y * STANDARD_GRAVITY_MS2,
-                -data.acceleration.z * STANDARD_GRAVITY_MS2);
-        }];
-
-        pump_->running_ = true;
-        pump_->running_rate_hz_ = rate_hz;
+        }
+        // Apple reports gravity in g; Symbian reports reaction force in m/s².
+        for (int axis = 0; axis < 3; ++axis) {
+            acceleration[axis] *= -STANDARD_GRAVITY_MS2;
+            gravity[axis] *= -STANDARD_GRAVITY_MS2;
+            if (!std::isfinite(acceleration[axis]) || !std::isfinite(gravity[axis])) return;
+        }
+        dispatch_sample(acceleration, gravity, rotation);
     }
 
     void sensor_driver_ios::refresh_pump() {
@@ -431,34 +474,20 @@ namespace eka2l1::drivers {
         motion_rotation_deg_.store(((degrees % 360) + 360) % 360, std::memory_order_relaxed);
     }
 
-    void sensor_driver_ios::dispatch_sample(const double x_raw_ms2, const double y_raw_ms2, const double z_ms2) {
-        // CoreMotion reports in the iPhone's fixed frame, but the guest reads
-        // the emulated device's frame — the two coincide only when the player
-        // holds the iPhone the way the Symbian phone would be held for the
-        // current guest screen mode. Rotate X/Y into the emulated frame
-        // (components of a vector in a frame rotated CCW by θ pick up R(-θ)).
-        double x_ms2 = x_raw_ms2;
-        double y_ms2 = y_raw_ms2;
-
-        switch (motion_rotation_deg_.load(std::memory_order_relaxed)) {
-        case 90:
-            x_ms2 = y_raw_ms2;
-            y_ms2 = -x_raw_ms2;
-            break;
-
-        case 180:
-            x_ms2 = -x_raw_ms2;
-            y_ms2 = -y_raw_ms2;
-            break;
-
-        case 270:
-            x_ms2 = -y_raw_ms2;
-            y_ms2 = x_raw_ms2;
-            break;
-
-        default:
-            break;
-        }
+    void sensor_driver_ios::dispatch_sample(std::array<double, 3> acceleration,
+        std::array<double, 3> gravity, int rotation) {
+        auto rotate = [rotation](std::array<double, 3> &v) {
+            const double x = v[0];
+            const double y = v[1];
+            switch (rotation) {
+            case 90: v[0] = y; v[1] = -x; break;
+            case 180: v[0] = -x; v[1] = -y; break;
+            case 270: v[0] = -y; v[1] = x; break;
+            default: break;
+            }
+        };
+        rotate(acceleration);
+        rotate(gravity);
 
         // Collect completed batches under the list lock, but invoke the guest
         // callbacks outside it: they take the kernel lock, and SVC handlers
@@ -475,13 +504,14 @@ namespace eka2l1::drivers {
         {
             const std::lock_guard<std::mutex> hold(list_lock_);
 
-            if (!listening_list_.empty()) {
+            if (!paused_ && !listening_list_.empty()) {
                 common::double_linked_queue_element *first = listening_list_.first();
                 common::double_linked_queue_element *end = listening_list_.end();
 
                 do {
                     sensor_ios *sensor_obj = E_LOFF(first, sensor_ios, listening_link_);
-                    sensor_obj->push_sample(x_ms2, y_ms2, z_ms2);
+                    const auto &sample = sensor_obj->type_ == SENSOR_TYPE_ROTATION ? gravity : acceleration;
+                    sensor_obj->push_sample(sample[0], sample[1], sample[2]);
 
                     ready_batch batch;
                     if (sensor_obj->take_ready_batch(batch.callback_, batch.data_, batch.packet_count_)) {
@@ -559,7 +589,7 @@ namespace eka2l1::drivers {
             refresh_pump_locked();
         }
 
-        // Barrier: wait out a handler that already left the operation queue,
+        // Barrier: wait out a handler that already left the sampling queue,
         // so callers can tear down guest state (system reboot, backgrounding)
         // knowing no sensor callback is still in flight.
         const std::lock_guard<std::mutex> barrier(pump_->guard_->lock_);

--- a/src/emu/ios/App/ControllerMapping.swift
+++ b/src/emu/ios/App/ControllerMapping.swift
@@ -15,18 +15,16 @@ import UIKit
 // Key mappings are per device. Storage is a nested UserDefaults dict
 // [device key: [host token: guest scan]] — keyboards share the "keyboard"
 // device key, controllers use their vendor name so the same model keeps its
-// mapping across reconnects. Within a device the relation is one-to-one:
+// mapping across reconnects:
 // a host input drives at most one guest key (re-capturing steals it, last
-// edit wins) and each guest key holds at most one binding.
+// edit wins). Rebinding a guest key replaces its previous bindings; the
+// default directions accept both the d-pad and the left stick.
 //
 // Host tokens: controller buttons use HostButton raw values; keyboard keys
 // use "kb.<HID usage>", the raw value GCKeyCode carries at both capture and
 // runtime input time.
 
-// Every bindable controller button on an extended gamepad. The left
-// thumbstick is deliberately not listed: it aliases the d-pad tokens at both
-// capture and input time, so a stick flick and a d-pad press are the same
-// binding.
+// Each stick direction has its own binding, independent of the d-pad.
 enum HostButton: String, CaseIterable {
     case buttonA, buttonB, buttonX, buttonY
     case leftShoulder, rightShoulder, leftTrigger, rightTrigger
@@ -36,6 +34,14 @@ enum HostButton: String, CaseIterable {
     case dpadDown = "dpad.down"
     case dpadLeft = "dpad.left"
     case dpadRight = "dpad.right"
+    case leftStickUp = "leftStick.up"
+    case rightStickUp = "rightStick.up"
+    case leftStickDown = "leftStick.down"
+    case rightStickDown = "rightStick.down"
+    case leftStickLeft = "leftStick.left"
+    case rightStickLeft = "rightStick.left"
+    case leftStickRight = "leftStick.right"
+    case rightStickRight = "rightStick.right"
 
     var genericName: String {
         switch self {
@@ -55,12 +61,26 @@ enum HostButton: String, CaseIterable {
         case .dpadDown: return "D-pad Down"
         case .dpadLeft: return "D-pad Left"
         case .dpadRight: return "D-pad Right"
+        case .leftStickUp: return String(localized: "controllerMapping.leftStickUp")
+        case .rightStickUp: return String(localized: "controllerMapping.rightStickUp")
+        case .leftStickDown: return String(localized: "controllerMapping.leftStickDown")
+        case .rightStickDown: return String(localized: "controllerMapping.rightStickDown")
+        case .leftStickLeft: return String(localized: "controllerMapping.leftStickLeft")
+        case .rightStickLeft: return String(localized: "controllerMapping.rightStickLeft")
+        case .leftStickRight: return String(localized: "controllerMapping.leftStickRight")
+        case .rightStickRight: return String(localized: "controllerMapping.rightStickRight")
         }
     }
 
     // Controller-specific name when a gamepad is available (e.g. "Cross
     // Button" on DualSense, "A Button" on Xbox), generic name otherwise.
     func displayName(on gamepad: GCExtendedGamepad?) -> String {
+        switch self {
+        case .leftStickUp, .leftStickDown, .leftStickLeft, .leftStickRight,
+             .rightStickUp, .rightStickDown, .rightStickLeft, .rightStickRight:
+            return genericName
+        default: break
+        }
         guard let gamepad, let name = buttonInput(on: gamepad)?.localizedName,
               !name.isEmpty else {
             return genericName
@@ -86,6 +106,14 @@ enum HostButton: String, CaseIterable {
         case .dpadDown: return gamepad.dpad.down
         case .dpadLeft: return gamepad.dpad.left
         case .dpadRight: return gamepad.dpad.right
+        case .leftStickUp: return gamepad.leftThumbstick.up
+        case .rightStickUp: return gamepad.rightThumbstick.up
+        case .leftStickDown: return gamepad.leftThumbstick.down
+        case .rightStickDown: return gamepad.rightThumbstick.down
+        case .leftStickLeft: return gamepad.leftThumbstick.left
+        case .rightStickLeft: return gamepad.rightThumbstick.left
+        case .leftStickRight: return gamepad.leftThumbstick.right
+        case .rightStickRight: return gamepad.rightThumbstick.right
         }
     }
 
@@ -95,6 +123,14 @@ enum HostButton: String, CaseIterable {
         // system's notion of "pressed".
         case .leftTrigger: return gamepad.leftTrigger.value > threshold
         case .rightTrigger: return gamepad.rightTrigger.value > threshold
+        case .leftStickUp: return gamepad.leftThumbstick.yAxis.value > threshold
+        case .rightStickUp: return gamepad.rightThumbstick.yAxis.value > threshold
+        case .leftStickDown: return gamepad.leftThumbstick.yAxis.value < -threshold
+        case .rightStickDown: return gamepad.rightThumbstick.yAxis.value < -threshold
+        case .leftStickLeft: return gamepad.leftThumbstick.xAxis.value < -threshold
+        case .rightStickLeft: return gamepad.rightThumbstick.xAxis.value < -threshold
+        case .leftStickRight: return gamepad.leftThumbstick.xAxis.value > threshold
+        case .rightStickRight: return gamepad.rightThumbstick.xAxis.value > threshold
         default: return buttonInput(on: gamepad)?.isPressed ?? false
         }
     }
@@ -359,12 +395,21 @@ final class PeripheralManager: ObservableObject, @unchecked Sendable {
 
 enum PeripheralMappingStore {
     static let storageKey = "ios.peripheralKeyMappings"
+    private static let independentSticksKey = "independentSticks"
 
     static let controllerDefaults: [String: UInt32] = [
         HostButton.dpadUp.rawValue: Scan.up,
+        HostButton.leftStickUp.rawValue: Scan.up,
         HostButton.dpadDown.rawValue: Scan.down,
+        HostButton.leftStickDown.rawValue: Scan.down,
         HostButton.dpadLeft.rawValue: Scan.left,
+        HostButton.leftStickLeft.rawValue: Scan.left,
         HostButton.dpadRight.rawValue: Scan.right,
+        HostButton.leftStickRight.rawValue: Scan.right,
+        HostButton.rightStickUp.rawValue: 0x32,
+        HostButton.rightStickDown.rawValue: 0x38,
+        HostButton.rightStickLeft.rawValue: 0x34,
+        HostButton.rightStickRight.rawValue: 0x36,
         HostButton.buttonA.rawValue: Scan.select,
         HostButton.buttonB.rawValue: Scan.clear,
         HostButton.buttonX.rawValue: 0x35,   // digit 5, common game action key
@@ -416,12 +461,23 @@ enum PeripheralMappingStore {
             }
             mapping[token] = scan
         }
+        // Unversioned layouts encode left-stick bindings through the d-pad entries.
+        if kind == .controller, stored[independentSticksKey] == nil {
+            for (stick, dpad) in [(HostButton.leftStickUp, HostButton.dpadUp),
+                                  (.leftStickDown, .dpadDown),
+                                  (.leftStickLeft, .dpadLeft),
+                                  (.leftStickRight, .dpadRight)] {
+                mapping[stick.rawValue] = mapping[dpad.rawValue]
+            }
+        }
         return mapping
     }
 
     static func save(_ mapping: [String: UInt32], forDeviceKey deviceKey: String) {
         var all = UserDefaults.standard.dictionary(forKey: storageKey) ?? [:]
-        all[deviceKey] = mapping.mapValues { Int($0) }
+        var stored = mapping.mapValues { Int($0) }
+        stored[independentSticksKey] = 1
+        all[deviceKey] = stored
         UserDefaults.standard.set(all, forKey: storageKey)
     }
 
@@ -442,9 +498,8 @@ enum PeripheralMappingStore {
         return result
     }
 
-    // Keeps the relation one-to-one: the captured host input is stolen from
-    // whatever guest key held it (last edit wins), and this guest key's old
-    // binding is dropped.
+    // Rebinding replaces this guest key's bindings and moves the host input
+    // away from any other guest key.
     static func bind(hostToken: String, toScan scan: UInt32, in mapping: inout [String: UInt32]) {
         unbind(scan: scan, in: &mapping)
         mapping[hostToken] = scan
@@ -576,34 +631,61 @@ private final class CaptureMonitor: ObservableObject {
 
     private nonisolated static func pressedTokens(on gamepad: GCExtendedGamepad,
                                                   threshold: Float) -> Set<String> {
-        var tokens = Set(
+        Set(
             HostButton.allCases
                 .filter { $0.isPressed(on: gamepad, threshold: threshold) }
                 .map(\.rawValue)
         )
-        // The left thumbstick captures as the d-pad, mirroring runtime input.
-        if gamepad.leftThumbstick.yAxis.value > threshold { tokens.insert(HostButton.dpadUp.rawValue) }
-        if gamepad.leftThumbstick.yAxis.value < -threshold { tokens.insert(HostButton.dpadDown.rawValue) }
-        if gamepad.leftThumbstick.xAxis.value < -threshold { tokens.insert(HostButton.dpadLeft.rawValue) }
-        if gamepad.leftThumbstick.xAxis.value > threshold { tokens.insert(HostButton.dpadRight.rawValue) }
-        return tokens
     }
 }
 
 // MARK: - Key mapping editor
+
+private enum MappingCaptureTarget: Identifiable {
+    case guest(GuestKey)
+    case pointer(ControllerPointerAction)
+
+    var id: String {
+        switch self {
+        case .guest(let key): return "guest.\(key.scan)"
+        case .pointer(let action): return "pointer.\(action.rawValue)"
+        }
+    }
+
+    var name: String {
+        switch self {
+        case .guest(let key): return key.name
+        case .pointer(let action): return action.name
+        }
+    }
+
+    var symbol: String? {
+        switch self {
+        case .guest(let key): return key.symbol
+        case .pointer(let action): return action.symbol
+        }
+    }
+
+    var symbolColor: Color? {
+        if case .guest(let key) = self { return key.symbolColor }
+        return nil
+    }
+}
 
 struct KeyMappingView: View {
     let peripheral: PeripheralManager.Peripheral
 
     @State private var mapping: [String: UInt32]
     @StateObject private var monitor: CaptureMonitor
-    @State private var captureTarget: GuestKey?
+    @State private var captureTarget: MappingCaptureTarget?
+    @State private var features: ControllerFeatures
 
     init(peripheral: PeripheralManager.Peripheral) {
         self.peripheral = peripheral
         _mapping = State(initialValue: PeripheralMappingStore.mapping(
             forDeviceKey: peripheral.deviceKey, kind: peripheral.kind))
         _monitor = StateObject(wrappedValue: CaptureMonitor(peripheral: peripheral))
+        _features = State(initialValue: ControllerFeatures.load(deviceKey: peripheral.deviceKey))
     }
 
     var body: some View {
@@ -627,10 +709,42 @@ struct KeyMappingView: View {
                 Button("controllerMapping.reset", role: .destructive) {
                     PeripheralMappingStore.reset(deviceKey: peripheral.deviceKey)
                     mapping = PeripheralMappingStore.defaults(for: peripheral.kind)
+                    features = ControllerFeatures()
                 }
             } footer: {
                 if !monitor.deviceConnected {
                     Text("controllerMapping.deviceDisconnected")
+                }
+            }
+            if peripheral.kind == .controller {
+                Section {
+                    Toggle("controllerPointer.enabled", isOn: $features.pointerEnabled)
+                    if features.pointerEnabled {
+                        ForEach(ControllerPointerAction.allCases) { action in
+                            Button {
+                                monitor.beginCapture()
+                                captureTarget = .pointer(action)
+                            } label: {
+                                Label {
+                                    HStack {
+                                        Text(action.name).foregroundStyle(Color.primary)
+                                        Spacer()
+                                        Text(pointerBindingText(for: action) ?? String(localized: "key.none"))
+                                            .foregroundStyle(Color.secondary)
+                                            .multilineTextAlignment(.trailing)
+                                    }
+                                } icon: {
+                                    Image(systemName: action.symbol)
+                                }
+                            }
+                        }
+                    }
+                    Toggle("controllerPointer.motion", isOn: $features.motionEnabled)
+                    Toggle("controllerPointer.vibration", isOn: $features.vibrationEnabled)
+                } header: {
+                    Text("controllerPointer.section")
+                } footer: {
+                    Text("controllerPointer.hint")
                 }
             }
         }
@@ -638,15 +752,26 @@ struct KeyMappingView: View {
         .hapticImpact(.medium, trigger: monitor.captures)
         .onAppear(perform: monitor.start)
         .onDisappear(perform: monitor.stop)
-        .sheet(item: $captureTarget, onDismiss: monitor.cancelCapture) { key in
+        .onChange(of: features) { value in
+            guard peripheral.kind == .controller else { return }
+            value.save(deviceKey: peripheral.deviceKey)
+        }
+        .sheet(item: $captureTarget, onDismiss: monitor.cancelCapture) { target in
             CaptureSheet(
-                key: key,
+                title: target.name,
+                symbol: target.symbol,
+                symbolColor: target.symbolColor,
                 kind: peripheral.kind,
-                currentBinding: bindingText(for: key),
+                currentBinding: bindingText(for: target),
                 monitor: monitor,
                 onClear: {
-                    PeripheralMappingStore.unbind(scan: key.scan, in: &mapping)
-                    PeripheralMappingStore.save(mapping, forDeviceKey: peripheral.deviceKey)
+                    switch target {
+                    case .guest(let key):
+                        PeripheralMappingStore.unbind(scan: key.scan, in: &mapping)
+                        PeripheralMappingStore.save(mapping, forDeviceKey: peripheral.deviceKey)
+                    case .pointer(let action):
+                        features.unbind(action)
+                    }
                     captureTarget = nil
                 },
                 onCancel: { captureTarget = nil }
@@ -654,16 +779,35 @@ struct KeyMappingView: View {
         }
         .onChange(of: monitor.capturedToken) { token in
             guard let token, let target = captureTarget else { return }
-            PeripheralMappingStore.bind(hostToken: token, toScan: target.scan, in: &mapping)
-            PeripheralMappingStore.save(mapping, forDeviceKey: peripheral.deviceKey)
+            switch target {
+            case .guest(let key):
+                PeripheralMappingStore.bind(hostToken: token, toScan: key.scan, in: &mapping)
+                PeripheralMappingStore.save(mapping, forDeviceKey: peripheral.deviceKey)
+            case .pointer(let action):
+                features.bind(token: token, to: action)
+            }
             captureTarget = nil
         }
+    }
+
+    private func bindingText(for target: MappingCaptureTarget) -> String? {
+        switch target {
+        case .guest(let key): return bindingText(for: key)
+        case .pointer(let action): return pointerBindingText(for: action)
+        }
+    }
+
+    private func pointerBindingText(for action: ControllerPointerAction) -> String? {
+        let tokens = HostButton.allCases.filter { features.pointerBindings[$0.rawValue] == action }
+        guard !tokens.isEmpty else { return nil }
+        let gamepad = PeripheralManager.shared.controller(peripheralID: peripheral.id)?.extendedGamepad
+        return tokens.map { $0.displayName(on: gamepad) }.joined(separator: " · ")
     }
 
     private func row(_ key: GuestKey) -> some View {
         Button {
             monitor.beginCapture()
-            captureTarget = key
+            captureTarget = .guest(key)
         } label: {
             Label {
                 HStack {
@@ -707,7 +851,9 @@ struct KeyMappingView: View {
 }
 
 private struct CaptureSheet: View {
-    let key: GuestKey
+    let title: String
+    let symbol: String?
+    let symbolColor: Color?
     let kind: PeripheralManager.Peripheral.Kind
     let currentBinding: String?
     @ObservedObject var monitor: CaptureMonitor
@@ -717,11 +863,11 @@ private struct CaptureSheet: View {
     var body: some View {
         VStack(spacing: 20) {
             Label {
-                Text(key.name)
+                Text(title)
             } icon: {
-                if let symbol = key.symbol {
+                if let symbol {
                     Image(systemName: symbol)
-                        .foregroundStyle(key.symbolColor ?? Color.accentColor)
+                        .foregroundStyle(symbolColor ?? Color.accentColor)
                 }
             }
             .font(.title3.weight(.semibold))

--- a/src/emu/ios/App/ControllerPointer.swift
+++ b/src/emu/ios/App/ControllerPointer.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+enum ControllerPointerAction: String, CaseIterable, Codable, Identifiable {
+    case toggle, touch, up, down, left, right
+
+    var id: String { rawValue }
+
+    var name: String {
+        switch self {
+        case .toggle: return String(localized: "controllerPointer.toggle")
+        case .touch: return String(localized: "controllerPointer.touch")
+        case .up: return String(localized: "controllerPointer.up")
+        case .down: return String(localized: "controllerPointer.down")
+        case .left: return String(localized: "controllerPointer.left")
+        case .right: return String(localized: "controllerPointer.right")
+        }
+    }
+
+    var symbol: String {
+        switch self {
+        case .toggle: return "cursorarrow"
+        case .touch: return "hand.tap"
+        case .up: return "arrow.up"
+        case .down: return "arrow.down"
+        case .left: return "arrow.left"
+        case .right: return "arrow.right"
+        }
+    }
+}
+
+struct ControllerFeatures: Codable, Equatable {
+    var pointerEnabled = true
+    var motionEnabled = true
+    var vibrationEnabled = true
+    var pointerBindings: [String: ControllerPointerAction] = [
+        HostButton.rightThumbstickButton.rawValue: .toggle,
+        HostButton.buttonA.rawValue: .touch,
+        HostButton.dpadUp.rawValue: .up,
+        HostButton.dpadDown.rawValue: .down,
+        HostButton.dpadLeft.rawValue: .left,
+        HostButton.dpadRight.rawValue: .right,
+        HostButton.leftStickUp.rawValue: .up,
+        HostButton.leftStickDown.rawValue: .down,
+        HostButton.leftStickLeft.rawValue: .left,
+        HostButton.leftStickRight.rawValue: .right,
+    ]
+
+    private static let storageKey = "ios.controllerFeatures"
+
+    static func load(deviceKey: String) -> Self {
+        guard let data = UserDefaults.standard.dictionary(forKey: storageKey)?[deviceKey] as? Data,
+              var features = try? JSONDecoder().decode(Self.self, from: data) else {
+            return Self()
+        }
+        features.pointerBindings = features.pointerBindings.filter { HostButton(rawValue: $0.key) != nil }
+        return features
+    }
+
+    func save(deviceKey: String) {
+        guard let data = try? JSONEncoder().encode(self) else { return }
+        var all = UserDefaults.standard.dictionary(forKey: Self.storageKey) ?? [:]
+        all[deviceKey] = data
+        UserDefaults.standard.set(all, forKey: Self.storageKey)
+    }
+
+    mutating func bind(token: String, to action: ControllerPointerAction) {
+        unbind(action)
+        pointerBindings[token] = action
+    }
+
+    mutating func unbind(_ action: ControllerPointerAction) {
+        pointerBindings = pointerBindings.filter { $0.value != action }
+    }
+
+    func actions(for tokens: Set<String>) -> Set<ControllerPointerAction> {
+        Set(tokens.compactMap { pointerBindings[$0] })
+    }
+}
+
+struct ControllerPointerState {
+    enum TouchPhase: Equatable { case began, moved, ended, cancelled }
+
+    private(set) var position = CGPoint(x: 0.5, y: 0.5)
+    private(set) var isVisible = false
+    private(set) var isTouching = false
+    private var actions: Set<ControllerPointerAction> = []
+    private var touchNeedsRelease = false
+
+    mutating func prime(actions: Set<ControllerPointerAction>) {
+        self.actions = actions
+        touchNeedsRelease = actions.contains(.touch)
+    }
+
+    mutating func update(actions next: Set<ControllerPointerAction>) -> [TouchPhase] {
+        let newlyPressed = next.subtracting(actions)
+        actions = next
+        if !next.contains(.touch) { touchNeedsRelease = false }
+
+        if newlyPressed.contains(.toggle) {
+            let events = cancelTouch()
+            isVisible.toggle()
+            touchNeedsRelease = next.contains(.touch)
+            return events
+        }
+        guard isVisible else { return [] }
+        if isTouching, !next.contains(.touch) {
+            isTouching = false
+            return [.ended]
+        }
+        if newlyPressed.contains(.touch), !touchNeedsRelease {
+            isTouching = true
+            return [.began]
+        }
+        return []
+    }
+
+    mutating func move(elapsed: TimeInterval, size: CGSize) -> [TouchPhase] {
+        guard isVisible, size.width > 1, size.height > 1 else { return [] }
+        var x: CGFloat = (actions.contains(.right) ? 1 : 0) - (actions.contains(.left) ? 1 : 0)
+        var y: CGFloat = (actions.contains(.down) ? 1 : 0) - (actions.contains(.up) ? 1 : 0)
+        let length = hypot(x, y)
+        guard length > 0 else { return [] }
+        let distance = min(size.width, size.height) * 0.7 * min(max(elapsed, 0), 0.05)
+        x = x / length * distance / (size.width - 1)
+        y = y / length * distance / (size.height - 1)
+        let next = CGPoint(x: min(max(position.x + x, 0), 1),
+                           y: min(max(position.y + y, 0), 1))
+        guard next != position else { return [] }
+        position = next
+        return isTouching ? [.moved] : []
+    }
+
+    mutating func cancelTouch() -> [TouchPhase] {
+        touchNeedsRelease = actions.contains(.touch)
+        guard isTouching else { return [] }
+        isTouching = false
+        return [.cancelled]
+    }
+
+    mutating func reset() -> [TouchPhase] {
+        let events = cancelTouch()
+        isVisible = false
+        actions.removeAll()
+        return events
+    }
+
+    func location(in rect: CGRect) -> CGPoint {
+        CGPoint(x: rect.minX + position.x * max(rect.width - 1, 0),
+                y: rect.minY + position.y * max(rect.height - 1, 0))
+    }
+
+    static func fittedRect(size: CGSize, in bounds: CGRect) -> CGRect {
+        guard size.width > 0, size.height > 0 else { return .zero }
+        let scale = min(bounds.width / size.width, bounds.height / size.height)
+        let fitted = CGSize(width: size.width * scale, height: size.height * scale)
+        return CGRect(x: bounds.midX - fitted.width / 2, y: bounds.midY - fitted.height / 2,
+                      width: fitted.width, height: fitted.height)
+    }
+}

--- a/src/emu/ios/App/ControllerPointerDriver.swift
+++ b/src/emu/ios/App/ControllerPointerDriver.swift
@@ -1,0 +1,95 @@
+import QuartzCore
+import UIKit
+
+@MainActor
+final class ControllerPointerDriver: NSObject {
+    var configuration = ControllerFeatures()
+    private var state = ControllerPointerState()
+    private var enabled = false
+    private var pressedTokens: Set<String> = []
+    private var displayLink: CADisplayLink?
+    private var lastTimestamp: CFTimeInterval = 0
+    private var displayRect = CGRect.zero
+    // UITouch objects are aligned pointers; this identity cannot collide with one.
+    private let pointerID: UInt = 1
+
+    var consumedTokens: Set<String> {
+        guard enabled else { return [] }
+        return Set(configuration.pointerBindings.compactMap { token, action in
+            action == .toggle || state.isVisible ? token : nil
+        })
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        guard enabled != self.enabled else { return }
+        self.enabled = enabled
+        emit(state.reset())
+        state.prime(actions: configuration.actions(for: pressedTokens))
+        updateDisplayLink()
+        updateCursor()
+    }
+
+    func handle(pressed: Set<String>) {
+        pressedTokens = pressed
+        guard enabled else { return }
+        refreshGeometry()
+        guard !displayRect.isEmpty else {
+            state.prime(actions: configuration.actions(for: pressed))
+            return
+        }
+        emit(state.update(actions: configuration.actions(for: pressed)))
+        updateDisplayLink()
+        updateCursor()
+    }
+
+    private func refreshGeometry() {
+        let rect = EKA2L1Bridge.shared.guestDisplayRect
+        if rect != displayRect {
+            emit(state.cancelTouch())
+            displayRect = rect
+        }
+    }
+
+    private func updateDisplayLink() {
+        if enabled && state.isVisible {
+            guard displayLink == nil else { return }
+            let link = CADisplayLink(target: self, selector: #selector(tick(_:)))
+            link.preferredFrameRateRange = CAFrameRateRange(minimum: 30, maximum: 60, preferred: 60)
+            link.add(to: .main, forMode: .common)
+            displayLink = link
+        } else {
+            displayLink?.invalidate()
+            displayLink = nil
+            lastTimestamp = 0
+        }
+    }
+
+    @objc private func tick(_ link: CADisplayLink) {
+        refreshGeometry()
+        let elapsed = lastTimestamp == 0 ? link.duration : link.timestamp - lastTimestamp
+        lastTimestamp = link.timestamp
+        emit(state.move(elapsed: elapsed, size: displayRect.size))
+        updateCursor()
+    }
+
+    private func emit(_ events: [ControllerPointerState.TouchPhase]) {
+        guard !displayRect.isEmpty else { return }
+        let point = state.location(in: displayRect)
+        for event in events {
+            let phase: EKA2L1PointerPhase
+            switch event {
+            case .began: phase = .began
+            case .moved: phase = .moved
+            case .ended: phase = .ended
+            case .cancelled: phase = .cancelled
+            }
+            EKA2L1Bridge.shared.submitPointer(x: point.x, y: point.y, phase: phase, pointerId: pointerID)
+        }
+    }
+
+    private func updateCursor() {
+        ExternalDisplay.shared.setPointer(
+            position: enabled && state.isVisible && !displayRect.isEmpty ? state.position : nil,
+            pictureSize: displayRect.size, touching: state.isTouching)
+    }
+}

--- a/src/emu/ios/App/EKA2L1Bridge.swift
+++ b/src/emu/ios/App/EKA2L1Bridge.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GameController
 import QuartzCore
 
 // Sandbox Documents directory hosting the emulator's file tree (roms/, data/,
@@ -209,6 +210,12 @@ final class EKA2L1Bridge {
 
     func setExternalDisplay(layer: CAEAGLLayer?, enabled: Bool) {
         emulator.setExternalDisplay(layer: layer, enabled: enabled)
+    }
+
+    var guestDisplayRect: CGRect { emulator.guestDisplayRect() }
+
+    func setGameController(_ controller: GCController?, motion: Bool, vibration: Bool) {
+        emulator.setGameController(controller, motion: motion, vibration: vibration)
     }
 
     func detachLayer() {

--- a/src/emu/ios/App/EmulatorViewController.swift
+++ b/src/emu/ios/App/EmulatorViewController.swift
@@ -2,11 +2,20 @@ import GameController
 import QuartzCore
 import UIKit
 
-private final class PeripheralInputBridge: @unchecked Sendable {
+@MainActor
+private final class PeripheralInputBridge {
     private let threshold: Float = 0.45
     private let lock = NSLock()
     private var activeScansByToken: [String: UInt32] = [:]
     private var observers: [NSObjectProtocol] = []
+    private var controllers: [GCController] = []
+    private let pointer = ControllerPointerDriver()
+    private var running = false
+    private var foreground = false
+    private var fullscreen = false
+    private var pressedTokens: Set<String> = []
+    private var suppressedUntilRelease: Set<String> = []
+    private var features = ControllerFeatures()
     // Mapping of the active controller peripheral; empty when the keyboard
     // (or nothing) is active. Refreshed whenever the peripheral set changes —
     // that is the only time the active selection can move while the emulator
@@ -19,6 +28,9 @@ private final class PeripheralInputBridge: @unchecked Sendable {
     private var keyboardEnabled = true
 
     func start() {
+        guard !running else { return }
+        running = true
+        foreground = UIApplication.shared.applicationState == .active
         keyboardMapping = PeripheralMappingStore.keyboardScanMapping()
         // Touch the manager first so its connect/disconnect observers are
         // registered ahead of ours and refresh() reads updated state.
@@ -28,17 +40,42 @@ private final class PeripheralInputBridge: @unchecked Sendable {
                                         .GCKeyboardDidConnect, .GCKeyboardDidDisconnect] {
             observers.append(center.addObserver(forName: name, object: nil,
                                                 queue: .main) { [weak self] _ in
-                self?.refresh()
+                MainActor.assumeIsolated { self?.refresh() }
+            })
+        }
+        observers.append(center.addObserver(forName: .externalGameDisplayChanged, object: nil,
+                                            queue: .main) { [weak self] _ in
+            MainActor.assumeIsolated { self?.refreshPointerAvailability() }
+        })
+        for name in [UIApplication.willResignActiveNotification, UIApplication.didBecomeActiveNotification] {
+            observers.append(center.addObserver(forName: name, object: nil, queue: .main) { [weak self] note in
+                let active = note.name == UIApplication.didBecomeActiveNotification
+                MainActor.assumeIsolated {
+                    self?.foreground = active
+                    self?.refresh()
+                }
             })
         }
     }
 
     func stop() {
+        running = false
+        pointer.setEnabled(false)
         observers.forEach(NotificationCenter.default.removeObserver)
         observers.removeAll()
-        GCController.controllers().forEach { $0.extendedGamepad?.valueChangedHandler = nil }
+        controllers.forEach { $0.extendedGamepad?.valueChangedHandler = nil }
+        controllers.removeAll()
         GCKeyboard.coalesced?.keyboardInput?.keyChangedHandler = nil
         releaseAll()
+        EKA2L1Bridge.shared.setGameController(nil, motion: false, vibration: false)
+        pressedTokens.removeAll()
+        suppressedUntilRelease.removeAll()
+    }
+
+    func setFullscreen(_ fullscreen: Bool) {
+        guard self.fullscreen != fullscreen else { return }
+        self.fullscreen = fullscreen
+        refreshPointerAvailability()
     }
 
     // GameController delivers key events app-wide rather than through the
@@ -50,30 +87,63 @@ private final class PeripheralInputBridge: @unchecked Sendable {
         if !enabled {
             releaseKeyboard()
         }
+        refresh()
     }
 
     private func refresh() {
+        guard running else { return }
         // The active peripheral may have changed; drop held keys so a key
         // pressed on the previous device can't stay stuck down.
         releaseAll()
+        pointer.setEnabled(false)
         mapping = PeripheralManager.shared.activeControllerMapping()
-        for controller in GCController.controllers() {
+        features = PeripheralManager.shared.activeController.map {
+            ControllerFeatures.load(deviceKey: PeripheralManager.deviceKey(for: $0))
+        } ?? ControllerFeatures()
+        pointer.configuration = features
+        suppressedUntilRelease.formUnion(pressedTokens)
+        controllers.forEach { $0.extendedGamepad?.valueChangedHandler = nil }
+        controllers = GCController.controllers()
+        for controller in controllers {
             attach(controller)
         }
+        let controller = foreground && keyboardEnabled ? PeripheralManager.shared.activeController : nil
+        EKA2L1Bridge.shared.setGameController(controller, motion: features.motionEnabled,
+                                            vibration: features.vibrationEnabled)
+        if let gamepad = PeripheralManager.shared.activeController?.extendedGamepad {
+            pressedTokens = Set(HostButton.allCases
+                .filter { $0.isPressed(on: gamepad, threshold: threshold) }.map(\.rawValue))
+        } else {
+            pressedTokens.removeAll()
+        }
+        pointer.handle(pressed: pressedTokens)
+        refreshPointerAvailability()
         if let controller = PeripheralManager.shared.activeController,
            let gamepad = controller.extendedGamepad {
             handleAll(gamepad, from: controller)
         }
+        GCKeyboard.coalesced?.handlerQueue = .main
         GCKeyboard.coalesced?.keyboardInput?.keyChangedHandler = { [weak self] _, _, keyCode, pressed in
-            self?.handleKey(usage: Int(keyCode.rawValue), pressed: pressed)
+            MainActor.assumeIsolated {
+                self?.handleKey(usage: Int(keyCode.rawValue), pressed: pressed)
+            }
         }
+    }
+
+    private func refreshPointerAvailability() {
+        pointer.setEnabled(running && foreground && keyboardEnabled && fullscreen && features.pointerEnabled
+            && ExternalDisplay.shared.isDisplayingGame && PeripheralManager.shared.activeController != nil)
+        applyControllerKeys()
     }
 
     private func attach(_ controller: GCController) {
         guard let gamepad = controller.extendedGamepad else { return }
+        controller.handlerQueue = .main
         gamepad.valueChangedHandler = { [weak self, weak controller] pad, _ in
-            guard let controller else { return }
-            self?.handleAll(pad, from: controller)
+            MainActor.assumeIsolated {
+                guard let controller else { return }
+                self?.handleAll(pad, from: controller)
+            }
         }
     }
 
@@ -83,21 +153,22 @@ private final class PeripheralInputBridge: @unchecked Sendable {
     // active peripheral drives the guest; refresh() releases anything a
     // previously active pad still held.
     private func handleAll(_ gamepad: GCExtendedGamepad, from controller: GCController) {
-        guard PeripheralManager.shared.isActive(controller) else { return }
+        guard running, PeripheralManager.shared.isActive(controller) else { return }
+        pressedTokens = Set(HostButton.allCases
+            .filter { $0.isPressed(on: gamepad, threshold: threshold) }.map(\.rawValue))
+        pointer.handle(pressed: pressedTokens)
+        applyControllerKeys()
+    }
+
+    private func applyControllerKeys() {
+        suppressedUntilRelease.formIntersection(pressedTokens)
+        suppressedUntilRelease.formUnion(pointer.consumedTokens.intersection(pressedTokens))
         for button in HostButton.allCases {
             updateButton(token: button.rawValue,
-                         pressed: button.isPressed(on: gamepad, threshold: threshold))
+                         pressed: running && foreground && keyboardEnabled
+                            && pressedTokens.contains(button.rawValue)
+                            && !suppressedUntilRelease.contains(button.rawValue))
         }
-        // The left thumbstick drives the d-pad bindings; separate state
-        // tokens so releasing the stick doesn't drop a still-held d-pad key.
-        updateButton(token: "leftStick.up", mappingToken: HostButton.dpadUp.rawValue,
-                     pressed: gamepad.leftThumbstick.yAxis.value > threshold)
-        updateButton(token: "leftStick.down", mappingToken: HostButton.dpadDown.rawValue,
-                     pressed: gamepad.leftThumbstick.yAxis.value < -threshold)
-        updateButton(token: "leftStick.left", mappingToken: HostButton.dpadLeft.rawValue,
-                     pressed: gamepad.leftThumbstick.xAxis.value < -threshold)
-        updateButton(token: "leftStick.right", mappingToken: HostButton.dpadRight.rawValue,
-                     pressed: gamepad.leftThumbstick.xAxis.value > threshold)
     }
 
     // Hardware keyboard. Only presses are gated: a key held across a suspend
@@ -105,7 +176,7 @@ private final class PeripheralInputBridge: @unchecked Sendable {
     // releaseAll(), and its release must still be forwarded if it arrives
     // later, so it cannot stay stuck down in the guest.
     private func handleKey(usage: Int, pressed: Bool) {
-        if pressed, !keyboardEnabled || !PeripheralManager.shared.keyboardCanDrive {
+        if pressed, !running || !foreground || !keyboardEnabled || !PeripheralManager.shared.keyboardCanDrive {
             return
         }
         updateInput(token: KeyboardKey.token(forUsage: usage),
@@ -142,10 +213,8 @@ private final class PeripheralInputBridge: @unchecked Sendable {
         }
     }
 
-    // `token` keys the press state (d-pad and left stick track separately),
-    // `mappingToken` keys the user mapping (both share one direction entry).
-    private func updateButton(token: String, mappingToken: String? = nil, pressed: Bool) {
-        updateInput(token: token, scan: mapping[mappingToken ?? token] ?? 0, pressed: pressed)
+    private func updateButton(token: String, pressed: Bool) {
+        updateInput(token: token, scan: mapping[token] ?? 0, pressed: pressed)
     }
 
     private func updateInput(token: String, scan: UInt32, pressed: Bool) {
@@ -354,6 +423,7 @@ final class EmulatorViewController: UIViewController {
     // Forwarded to the render view; see EKA2L1RenderView.anchorsDisplayTop.
     var anchorsDisplayTop = false {
         didSet {
+            peripheralInput.setFullscreen(!anchorsDisplayTop)
             if isViewLoaded {
                 gameView.anchorsDisplayTop = anchorsDisplayTop
             }

--- a/src/emu/ios/App/ExternalDisplay.swift
+++ b/src/emu/ios/App/ExternalDisplay.swift
@@ -1,6 +1,10 @@
 import QuartzCore
 import UIKit
 
+extension Notification.Name {
+    static let externalGameDisplayChanged = Notification.Name("EKA2L1ExternalGameDisplayChanged")
+}
+
 @MainActor
 final class ExternalDisplay {
     static let shared = ExternalDisplay()
@@ -8,6 +12,7 @@ final class ExternalDisplay {
     private weak var outputView: ExternalGameView?
     private var gameVisible = false
     private var foreground = false
+    private(set) var isDisplayingGame = false
     var onSurfaceChange: (() -> Void)?
 
     func connect(_ view: ExternalGameView) {
@@ -32,16 +37,28 @@ final class ExternalDisplay {
         refresh()
     }
 
+    func setPointer(position: CGPoint?, pictureSize: CGSize, touching: Bool) {
+        outputView?.setPointer(position: position, pictureSize: pictureSize, touching: touching)
+    }
+
     func refresh() {
         let phase = outputView?.window?.windowScene?.activationState
         let enabled = gameVisible && foreground && (phase == .foregroundActive || phase == .foregroundInactive)
         outputView?.isHidden = !enabled
         EKA2L1Bridge.shared.setExternalDisplay(layer: outputView?.renderLayer, enabled: enabled)
+        if isDisplayingGame != enabled {
+            isDisplayingGame = enabled
+            NotificationCenter.default.post(name: .externalGameDisplayChanged, object: nil)
+        }
         if enabled { onSurfaceChange?() }
     }
 }
 
 final class ExternalGameView: UIView {
+    private let cursor = CAShapeLayer()
+    private var pointerPosition: CGPoint?
+    private var pictureSize = CGSize.zero
+
     override class var layerClass: AnyClass { CAEAGLLayer.self }
     var renderLayer: CAEAGLLayer { layer as! CAEAGLLayer }
 
@@ -55,6 +72,27 @@ final class ExternalGameView: UIView {
             kEAGLDrawablePropertyRetainedBacking: false,
             kEAGLDrawablePropertyColorFormat: kEAGLColorFormatRGBA8
         ]
+        let path = UIBezierPath()
+        path.move(to: .zero)
+        path.addLine(to: CGPoint(x: 0, y: 29))
+        path.addLine(to: CGPoint(x: 8, y: 22))
+        path.addLine(to: CGPoint(x: 14, y: 34))
+        path.addLine(to: CGPoint(x: 20, y: 31))
+        path.addLine(to: CGPoint(x: 14, y: 19))
+        path.addLine(to: CGPoint(x: 25, y: 19))
+        path.close()
+        cursor.path = path.cgPath
+        cursor.bounds = CGRect(x: 0, y: 0, width: 26, height: 35)
+        cursor.anchorPoint = .zero
+        cursor.strokeColor = UIColor.black.cgColor
+        cursor.lineWidth = 2
+        cursor.lineJoin = .round
+        cursor.shadowColor = UIColor.black.cgColor
+        cursor.shadowOpacity = 0.6
+        cursor.shadowRadius = 2
+        cursor.shadowOffset = CGSize(width: 0, height: 1)
+        cursor.isHidden = true
+        layer.addSublayer(cursor)
     }
 
     @available(*, unavailable)
@@ -63,7 +101,31 @@ final class ExternalGameView: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
         contentScaleFactor = window?.windowScene?.screen.scale ?? 1
+        cursor.contentsScale = contentScaleFactor
         ExternalDisplay.shared.refresh()
+        layoutPointer()
+    }
+
+    func setPointer(position: CGPoint?, pictureSize: CGSize, touching: Bool) {
+        pointerPosition = position
+        self.pictureSize = pictureSize
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        cursor.fillColor = touching ? UIColor.systemCyan.cgColor : UIColor.white.cgColor
+        layoutPointer()
+        CATransaction.commit()
+    }
+
+    private func layoutPointer() {
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        cursor.isHidden = pointerPosition == nil || pictureSize.width <= 0 || pictureSize.height <= 0
+        if let point = pointerPosition {
+            let rect = ControllerPointerState.fittedRect(size: pictureSize, in: bounds)
+            cursor.position = CGPoint(x: rect.minX + point.x * max(rect.width - 1, 0),
+                                      y: rect.minY + point.y * max(rect.height - 1, 0))
+        }
+        CATransaction.commit()
     }
 }
 

--- a/src/emu/ios/Bridge/IosEmulator.h
+++ b/src/emu/ios/Bridge/IosEmulator.h
@@ -8,6 +8,8 @@
 // yet. Implemented on top of the C++ `eka2l1::ios::emulator` in IosEmulator.mm.
 
 #import <Foundation/Foundation.h>
+
+@class GCController;
 #import <QuartzCore/CAEAGLLayer.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -231,6 +233,8 @@ typedef NS_ENUM(NSInteger, EKA2L1PointerPhase) {
 
 - (void)submitRawKey:(uint32_t)scanCode pressed:(BOOL)pressed;
 - (void)tapRawKey:(uint32_t)scanCode;
+- (CGRect)guestDisplayRect;
+- (void)setGameController:(nullable GCController *)controller motion:(BOOL)motion vibration:(BOOL)vibration;
 
 // YES when the booted device's Symbian version drives its UI by touch
 // (S60v5 / Symbian^3 and later). The frontend uses it to pick the fullscreen

--- a/src/emu/ios/Bridge/IosEmulator.mm
+++ b/src/emu/ios/Bridge/IosEmulator.mm
@@ -46,8 +46,10 @@
 #include <drivers/input/common.h>
 #include <drivers/itc.h>
 #include <drivers/hwrm/vibration.h>
+#include <drivers/hwrm/backend/vibration_ios.h>
 #include <drivers/camera/camera_collection.h>
 #include <drivers/sensor/sensor.h>
+#include <drivers/sensor/backend/ios/controller_motion.h>
 #include <services/window/screen.h>
 #include <kernel/kernel.h>
 #include <kernel/process.h>
@@ -395,6 +397,8 @@ namespace eka2l1::ios {
         std::recursive_mutex session_mutex;
 
         std::mutex layer_mutex;
+        std::mutex display_geometry_mutex;
+        eka2l1::rect display_rect;
         std::condition_variable layer_cv;
         bool layer_dirty = false;
         void *pending_layer = nullptr;
@@ -694,6 +698,8 @@ namespace eka2l1::ios {
 
             if (state->sensor_driver) {
                 state->sensor_driver->set_motion_rotation(picture_rotation);
+                eka2l1::drivers::set_controller_motion_rotation(state->sensor_driver.get(),
+                    mode.rotation - panel_mount);
             }
 
             // A camera is bolted to the device body, so it needs the mirror of the
@@ -735,6 +741,10 @@ namespace eka2l1::ios {
         }
 
         const eka2l1::rect external_crop = dest;
+        {
+            std::lock_guard<std::mutex> geometry_lock(state->display_geometry_mutex);
+            state->display_rect = external_crop;
+        }
 
         scr->set_native_scale_factor(state->graphics_driver.get(), scale, scale);
         scr->absolute_pos = dest.top;
@@ -2089,6 +2099,10 @@ namespace eka2l1::ios {
         return;
     }
     {
+        std::lock_guard<std::mutex> lock(_state->display_geometry_mutex);
+        _state->display_rect = {};
+    }
+    {
         std::lock_guard<std::mutex> lk(_state->layer_mutex);
         _state->pending_layer = nullptr;
         _state->layer_dirty = true;
@@ -2101,6 +2115,7 @@ namespace eka2l1::ios {
 
 - (void)pause {
     if (!_state) return;
+    eka2l1::drivers::hwrm::set_vibration_suspended(true);
     _state->paused = true;
     // Break the idle wait so a parked loop returns and the os_thread settles on
     // its paused sleep promptly instead of after the next guest timer.
@@ -2127,6 +2142,7 @@ namespace eka2l1::ios {
 
 - (void)resume {
     if (!_state) return;
+    eka2l1::drivers::hwrm::set_vibration_suspended(false);
     NSError *err = nil;
     const BOOL audio_session_active =
         [[AVAudioSession sharedInstance] setActive:YES error:&err];
@@ -2143,6 +2159,20 @@ namespace eka2l1::ios {
     // Resume guest execution only after host devices have been restored, so
     // guest stream start/stop calls cannot race the AudioUnit restart above.
     _state->paused = false;
+}
+
+- (CGRect)guestDisplayRect {
+    if (!_state) return CGRectZero;
+    std::lock_guard<std::mutex> lock(_state->display_geometry_mutex);
+    const auto &rect = _state->display_rect;
+    return CGRectMake(rect.top.x, rect.top.y, rect.size.x, rect.size.y);
+}
+
+- (void)setGameController:(GCController *)controller motion:(BOOL)motion vibration:(BOOL)vibration {
+    if (!_state) return;
+    eka2l1::drivers::set_controller_motion_source(_state->sensor_driver.get(),
+        motion ? (__bridge void *)controller : nullptr);
+    eka2l1::drivers::hwrm::set_controller_haptic_source(vibration ? (__bridge void *)controller : nullptr);
 }
 
 - (void)submitPointerEventAtX:(CGFloat)x

--- a/src/emu/ios/CMakeLists.txt
+++ b/src/emu/ios/CMakeLists.txt
@@ -47,6 +47,8 @@ set(EKA2L1_IOS_SOURCES
     "${EKA2L1_IOS_APP_DIR}/Haptics.swift"
     "${EKA2L1_IOS_APP_DIR}/EmulatorViewController.swift"
     "${EKA2L1_IOS_APP_DIR}/ControllerMapping.swift"
+    "${EKA2L1_IOS_APP_DIR}/ControllerPointer.swift"
+    "${EKA2L1_IOS_APP_DIR}/ControllerPointerDriver.swift"
     "${EKA2L1_IOS_APP_DIR}/SettingsView.swift"
     "${EKA2L1_IOS_APP_DIR}/Toast.swift"
     "${EKA2L1_IOS_BRIDGE_DIR}/IosEmulator.h"

--- a/src/emu/ios/Resources/Localizable.xcstrings
+++ b/src/emu/ios/Resources/Localizable.xcstrings
@@ -116,7 +116,47 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "The left thumbstick works the same as the d-pad."
+            "value" : "The d-pad and both thumbsticks can be mapped independently."
+          }
+        }
+      }
+    },
+    "controllerMapping.leftStickDown" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Left Stick Down"
+          }
+        }
+      }
+    },
+    "controllerMapping.leftStickLeft" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Left Stick Left"
+          }
+        }
+      }
+    },
+    "controllerMapping.leftStickRight" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Left Stick Right"
+          }
+        }
+      }
+    },
+    "controllerMapping.leftStickUp" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Left Stick Up"
           }
         }
       }
@@ -167,6 +207,156 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reset to Defaults"
+          }
+        }
+      }
+    },
+    "controllerMapping.rightStickDown" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Right Stick Down"
+          }
+        }
+      }
+    },
+    "controllerMapping.rightStickLeft" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Right Stick Left"
+          }
+        }
+      }
+    },
+    "controllerMapping.rightStickRight" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Right Stick Right"
+          }
+        }
+      }
+    },
+    "controllerMapping.rightStickUp" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Right Stick Up"
+          }
+        }
+      }
+    },
+    "controllerPointer.down" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pointer down"
+          }
+        }
+      }
+    },
+    "controllerPointer.enabled" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Controller pointer"
+          }
+        }
+      }
+    },
+    "controllerPointer.hint" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pointer controls require an external display and Full Screen. Hold Touch while moving to drag. Hidden pointers restore game key bindings. Motion and vibration use the controller when supported."
+          }
+        }
+      }
+    },
+    "controllerPointer.left" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pointer left"
+          }
+        }
+      }
+    },
+    "controllerPointer.motion" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Controller motion"
+          }
+        }
+      }
+    },
+    "controllerPointer.right" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pointer right"
+          }
+        }
+      }
+    },
+    "controllerPointer.section" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AirPlay & Full Screen"
+          }
+        }
+      }
+    },
+    "controllerPointer.toggle" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show / hide pointer"
+          }
+        }
+      }
+    },
+    "controllerPointer.touch" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Touch / drag"
+          }
+        }
+      }
+    },
+    "controllerPointer.up" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pointer up"
+          }
+        }
+      }
+    },
+    "controllerPointer.vibration" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Controller vibration"
           }
         }
       }


### PR DESCRIPTION
A Pro Controller's right stick was ignored by both input dispatch and binding capture, while the left stick shared its d-pad bindings. AirPlay's game-only output also had no controller-driven touch input, and motion/vibration always used the phone.

This adds independent bindings for both sticks and the d-pad, preserving existing saved layouts. The right stick defaults to 2/8/4/6. A new **AirPlay & Full Screen** section at the bottom of the controller binding editor stores per-controller settings for:

- An external-display pointer: R3 toggles visibility, d-pad/left stick moves it, and holding A while moving performs a touch drag. All six pointer actions are rebindable.
- Motion through the selected controller's GCMotion, with phone CoreMotion fallback. Acceleration and absolute Rotation retain the guest sensor contract.
- Vibration through controller Core Haptics when supported, with phone fallback.

Pointer input uses the displayed framebuffer crop and existing touch/rotation path. Hiding the pointer, disconnecting, suspending, or leaving Full Screen cancels touch; controls held across transitions stay suppressed until released. Sensor sampling and haptic routing handle pause, replacement and teardown without callbacks retaining a destroyed C++ driver. Changes are confined to iOS and its build configuration.

Validation performed during development: Release simulator and device builds; Final Battle, Calculator, N95 Calculator and Angry Birds touch checks; GameController snapshot tests for bindings, pointer transitions and dragging; motion and haptic tests covering pause/resume, source switching and teardown. Physical Pro Controller testing on iPhone Air confirmed independent bindings and the new controller features.
