### PR TITLE
iOS: Separate device model and friendly phone name editing

### DIFF
--- a/src/emu/ios/App/ContentView.swift
+++ b/src/emu/ios/App/ContentView.swift
@@ -235,11 +235,6 @@ struct ContentView: View {
             guard booted else { return }
             store.reloadApps()
         }
-        .onReceive(NotificationCenter.default.publisher(for: .eka2l1DevicesChanged)) { _ in
-            // A device was renamed in Settings: only the titles changed, so
-            // re-read the list to refresh the nav title and device switcher.
-            store.reloadDevices()
-        }
         .onReceive(NotificationCenter.default.publisher(for: AVAudioSession.interruptionNotification)) { note in
             guard let rawType = note.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt,
                   let type = AVAudioSession.InterruptionType(rawValue: rawType) else {

--- a/src/emu/ios/App/DeviceManagerView.swift
+++ b/src/emu/ios/App/DeviceManagerView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 // Device management surface, pushed from the home title menu ("Manage
 // devices"): switch to a device by tapping it, add one through the shared
-// import sheet, remove one by swiping, or rebuild the list from drive Z
+// import sheet, rename or remove one by swiping, or rebuild the list from drive Z
 // ("Rescan devices", mirroring the Android device-list screen).
 //
 // The page holds no device state of its own: it observes the same DeviceStore
@@ -14,6 +14,11 @@ struct DeviceManagerView: View {
     @ObservedObject var store: DeviceStore
     let onInstall: () -> Void
 
+    @State private var renameTarget: EKA2L1DeviceItem?
+    @State private var deviceName = ""
+    @State private var showingRename = false
+    @State private var renameFailed = false
+
     var body: some View {
         List {
             Section {
@@ -24,10 +29,6 @@ struct DeviceManagerView: View {
                     ForEach(store.devices) { device in
                         deviceRow(device)
                     }
-                    .onDelete { offsets in
-                        Task { await store.deleteDevices(at: offsets) }
-                    }
-                    .deleteDisabled(store.busy)
                 }
             } header: {
                 Text("devices.installed")
@@ -60,6 +61,22 @@ struct DeviceManagerView: View {
         }
         .navigationTitle("devices.title")
         .navigationBarTitleDisplayMode(.inline)
+        .alert("devices.rename", isPresented: $showingRename) {
+            TextField("devices.name", text: $deviceName)
+            Button("common.cancel", role: .cancel) { renameTarget = nil }
+            Button("devices.rename") {
+                if let target = renameTarget {
+                    renameFailed = !store.renameDevice(target, to: deviceName)
+                }
+                renameTarget = nil
+            }
+            .disabled(store.busy || deviceName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        }
+        .alert("common.error", isPresented: $renameFailed) {
+            Button("common.done", role: .cancel) {}
+        } message: {
+            Text("devices.renameFailed")
+        }
     }
 
     // Tapping a row boots that device. The plain button style keeps the row
@@ -86,5 +103,23 @@ struct DeviceManagerView: View {
         }
         .buttonStyle(.plain)
         .disabled(store.busy)
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            Button(role: .destructive) {
+                guard let offset = store.devices.firstIndex(where: { $0.firmwareCode == device.firmwareCode }) else { return }
+                Task { await store.deleteDevices(at: IndexSet(integer: offset)) }
+            } label: {
+                Label("devices.delete", systemImage: "trash")
+            }
+            .disabled(store.busy)
+            Button {
+                renameTarget = device
+                deviceName = device.model
+                showingRename = true
+            } label: {
+                Label("devices.rename", systemImage: "pencil")
+            }
+            .tint(.blue)
+            .disabled(store.busy)
+        }
     }
 }

--- a/src/emu/ios/App/DeviceStore.swift
+++ b/src/emu/ios/App/DeviceStore.swift
@@ -59,10 +59,19 @@ final class DeviceStore: ObservableObject {
         }
     }
 
-    // Titles only (a rename in Settings): the device set and booted device are
+    // Titles only (after a rename): the device set and booted device are
     // unchanged, so neither a reboot nor an app re-scan is needed.
     func reloadDevices() {
         devices = EKA2L1Bridge.shared.installedDevices()
+    }
+
+    func renameDevice(_ device: EKA2L1DeviceItem, to name: String) -> Bool {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !busy, !trimmed.isEmpty,
+              let current = self.device(withFirmwareCode: device.firmwareCode) else { return false }
+        guard EKA2L1Bridge.shared.renameDevice(at: current.index, to: trimmed) else { return false }
+        reloadDevices()
+        return true
     }
 
     // Run a blocking emulator operation off the main thread with the busy flag

--- a/src/emu/ios/App/EKA2L1Bridge.swift
+++ b/src/emu/ios/App/EKA2L1Bridge.swift
@@ -48,14 +48,9 @@ struct EKA2L1LanguageItem: Identifiable, Hashable {
     var id: Int { code }
 }
 
-// Cross-view frontend signals. Posted by the settings page when it mutates
-// emulator state the home surface owns, so ContentView can refresh without a
-// shared store: the app list after a system-language switch, and the device
-// list after a device rename. (The device-manager page needs neither — it runs
-// on the home surface's own state and actions.)
+// Settings signals the home surface to reload captions after a language change.
 extension Notification.Name {
     static let eka2l1AppListInvalidated = Notification.Name("eka2l1AppListInvalidated")
-    static let eka2l1DevicesChanged = Notification.Name("eka2l1DevicesChanged")
 }
 
 @MainActor
@@ -88,9 +83,7 @@ final class EKA2L1Bridge {
         emulator.currentDeviceIndex()
     }
 
-    // Rename an installed device (updates its model + devices.yml). The home
-    // surface refreshes its title / device list off the eka2l1DevicesChanged
-    // notification the caller posts on success.
+    // Rename an installed device (updates its model + devices.yml).
     @discardableResult
     func renameDevice(at index: Int, to name: String) -> Bool {
         emulator.renameDevice(at: UInt(index), to: name)

--- a/src/emu/ios/App/SettingsView.swift
+++ b/src/emu/ios/App/SettingsView.swift
@@ -19,12 +19,7 @@ struct SettingsView: View {
     @State private var availableLanguages: [EKA2L1LanguageItem] = []
     @State private var systemLanguageCode = -1
 
-    // Editable name of the currently-booted device. Committed to
-    // device_manager when the settings page closes (mirrors the Android
-    // rename dialog, but applied on dismiss). -1 = no device booted yet.
-    @State private var currentDeviceIndex = -1
-    @State private var deviceName = ""
-    @State private var originalDeviceName = ""
+    @State private var friendlyPhoneName = ""
 
     // BT netplay. Mirrors the Android BTNetplaySettingsFragment surface; the
     // bluetooth midman reads these at device boot, so edits apply from the
@@ -44,15 +39,13 @@ struct SettingsView: View {
     var body: some View {
         Form {
             Section("settings.device") {
-                if currentDeviceIndex >= 0 {
-                    HStack {
-                        Text("settings.deviceName")
-                        Spacer()
-                        TextField("settings.deviceName", text: $deviceName)
-                            .multilineTextAlignment(.trailing)
-                            .foregroundStyle(.secondary)
-                            .submitLabel(.done)
-                    }
+                HStack {
+                    Text("settings.friendlyPhoneName")
+                    Spacer()
+                    TextField("settings.friendlyPhoneName", text: $friendlyPhoneName)
+                        .multilineTextAlignment(.trailing)
+                        .foregroundStyle(.secondary)
+                        .submitLabel(.done)
                 }
                 if !availableLanguages.isEmpty {
                     Picker("settings.systemLanguage", selection: $systemLanguageCode) {
@@ -200,11 +193,8 @@ struct SettingsView: View {
         }
         .onAppear {
             load()
-            loadDeviceName()
         }
-        .onDisappear {
-            commitDeviceRename()
-        }
+        .onChange(of: friendlyPhoneName) { _ in save() }
         .onChange(of: useJIT) { _ in save() }
         .onChange(of: integerScaling) { _ in save() }
         .onChange(of: nearestNeighborFiltering) { _ in save() }
@@ -266,6 +256,7 @@ struct SettingsView: View {
         if let value = snapshot["jitEnabled"] as? NSNumber {
             useJIT = value.boolValue
         }
+        friendlyPhoneName = snapshot["deviceDisplayName"] as? String ?? ""
         availableLanguages = EKA2L1Bridge.shared.availableLanguages()
         systemLanguageCode = EKA2L1Bridge.shared.currentLanguageCode()
         if let value = snapshot["btnetDiscoveryMode"] as? NSNumber {
@@ -289,30 +280,9 @@ struct SettingsView: View {
         }
     }
 
-    // Seed the device-name field from the booted device's current title, so
-    // the field shows exactly what the home surface displays.
-    private func loadDeviceName() {
-        currentDeviceIndex = EKA2L1Bridge.shared.currentDeviceIndex()
-        let current = EKA2L1Bridge.shared.installedDevices()
-            .first { $0.index == currentDeviceIndex }
-        deviceName = current?.displayName ?? ""
-        originalDeviceName = deviceName
-    }
-
-    // Persist a device rename on page close. Skips no-ops and blank names so a
-    // device never ends up with an empty title.
-    private func commitDeviceRename() {
-        guard currentDeviceIndex >= 0 else { return }
-        let trimmed = deviceName.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty, trimmed != originalDeviceName else { return }
-        guard EKA2L1Bridge.shared.renameDevice(at: currentDeviceIndex, to: trimmed) else { return }
-        originalDeviceName = trimmed
-        // Tell the home surface to refresh its title / device switcher.
-        NotificationCenter.default.post(name: .eka2l1DevicesChanged, object: nil)
-    }
-
     private func save() {
         let snapshot: [String: Any] = [
+            "deviceDisplayName": friendlyPhoneName,
             "integerScaling": integerScaling,
             "nearestNeighborFiltering": nearestNeighborFiltering,
             "hideSystemApps": hideSystemApps,

--- a/src/emu/ios/Bridge/IosEmulator.mm
+++ b/src/emu/ios/Bridge/IosEmulator.mm
@@ -58,6 +58,7 @@
 #include <loader/mif.h>
 #include <package/manager.h>
 #include <services/applist/applist.h>
+#include <services/bluetooth/btman.h>
 #include <services/fbs/bitmap.h>
 #include <services/fbs/fbs.h>
 #include <services/window/window.h>
@@ -2465,7 +2466,17 @@ static constexpr std::uint8_t k_unlimited_refresh_rate = 240;
     }
     NSString *deviceDisplayName = snapshot[@"deviceDisplayName"];
     if ([deviceDisplayName isKindOfClass:NSString.class]) {
+        std::lock_guard<std::recursive_mutex> session_lock(_state->session_mutex);
         _state->conf.device_display_name = deviceDisplayName.UTF8String;
+        if (_state->symsys && _state->mounted) {
+            auto *kern = _state->symsys->get_kernel_system();
+            eka2l1::kernel_lock lock(kern);
+            auto *server = kern->get_by_name<eka2l1::btman_server>(
+                eka2l1::get_btman_server_name_by_epocver(kern->get_epoc_version()));
+            if (server) {
+                server->device_name(eka2l1::common::utf8_to_ucs2(_state->conf.device_display_name));
+            }
+        }
     }
     NSString *logFilter = snapshot[@"logFilter"];
     if ([logFilter isKindOfClass:NSString.class]) {

--- a/src/emu/ios/Resources/Localizable.xcstrings
+++ b/src/emu/ios/Resources/Localizable.xcstrings
@@ -371,12 +371,22 @@
         }
       }
     },
+    "devices.delete" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete"
+          }
+        }
+      }
+    },
     "devices.hint" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tap a device to switch to it. Swipe left to remove it along with its data."
+            "value" : "Tap a device to switch to it. Swipe left to rename it or remove it along with its data."
           }
         }
       }
@@ -391,12 +401,42 @@
         }
       }
     },
+    "devices.name" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Device name"
+          }
+        }
+      }
+    },
     "devices.none" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "No devices installed."
+          }
+        }
+      }
+    },
+    "devices.rename" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rename"
+          }
+        }
+      }
+    },
+    "devices.renameFailed" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Could not rename the device. Please try again."
           }
         }
       }
@@ -1693,16 +1733,6 @@
         }
       }
     },
-    "settings.deviceName" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Device name"
-          }
-        }
-      }
-    },
     "settings.discord" : {
       "localizations" : {
         "en" : {
@@ -1729,6 +1759,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "FPS overlay"
+          }
+        }
+      }
+    },
+    "settings.friendlyPhoneName" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Friendly phone name"
           }
         }
       }


### PR DESCRIPTION
The iOS Settings “Device name” field currently renames the installed device model and only appears after a device has booted. Separate the two names to match the desktop frontend:

- Add a Rename swipe action beside Delete in Manage Devices. The dialog edits `device::model`, saves `devices.yml`, and refreshes the shared device list and navigation title.
- Replace the Settings field with “Friendly phone name”, backed by `config.device_display_name`. It can be edited before boot and updates the running Bluetooth server under the session and kernel locks.
- Remove the obsolete cross-view device-rename notification and update the string catalog.

Validated both a reverted baseline and this commit in a clean worktree based on upstream `master` (`0ed6fd1f6`), using Release simulator builds. Confirmed the Swift pages and Objective-C++ bridge recompiled after restoring the change.

| Revert check | Observed Settings behavior |
| --- | --- |
| This commit reverted | “Device name” shows the current installed device model (`Nokia 5320d-1`). |
| This commit restored | “Friendly phone name” shows the independent configured name (`EKA2L1`). |

The final upstream-based Release build passed the complete simulator regression suite: **12 PASS, 0 FAIL**, covering Final Battle (including the 90-second in-game dwell), Calculator input and softkeys, N95 Calculator, and string-catalog reconciliation. The regression script was copied into the worktree for local validation only and is excluded from this PR.

On the fork's Release build, also verified the rename dialog, model persistence, immediate list/title refresh, and independent friendly-name persistence; test names were restored afterward. The initial Final Battle launch there hit one host PNG-decoder crash; the unchanged binary passed a full rerun. That initial crash remains unexplained.
