### PR TITLE
Fix Bluetooth device selection and packet lifetime; use Bonjour on Apple

### DIFF
--- a/src/emu/ios/Bridge/IosEmulator.mm
+++ b/src/emu/ios/Bridge/IosEmulator.mm
@@ -2499,9 +2499,7 @@ static constexpr std::uint8_t k_unlimited_refresh_rate = 240;
     // emulator instances share one machine, which iOS never does. Edit
     // config.yml directly for that case.
     //
-    // Discovery port for direct IP mode (the other modes bind the fixed
-    // harbour port instead). Clamped so a stray value can never make the
-    // midman bind an out-of-range port at boot.
+    // Bonjour advertises this query port; Direct IP peers configure it explicitly.
     NSNumber *btnetListenPort = snapshot[@"btnetListenPort"];
     if (btnetListenPort) {
         _state->conf.internet_bluetooth_port = std::clamp(btnetListenPort.intValue, 1, 65535);

--- a/src/emu/ios/Resources/Info.plist
+++ b/src/emu/ios/Resources/Info.plist
@@ -266,6 +266,10 @@
     <string>Symbian apps running in the emulator can use the camera for their viewfinder and photo capture features.</string>
     <key>NSMicrophoneUsageDescription</key>
     <string>Symbian apps running in the emulator can use the microphone for recording and voice features.</string>
+    <key>NSBonjourServices</key>
+    <array>
+        <string>_eka2l1._udp</string>
+    </array>
     <key>NSLocalNetworkUsageDescription</key>
     <string>Bluetooth Netplay emulates Symbian Bluetooth multiplayer over your local network to find and connect to other EKA2L1 players.</string>
 </dict>

--- a/src/emu/qt/CMakeLists.txt
+++ b/src/emu/qt/CMakeLists.txt
@@ -313,8 +313,6 @@ if(APPLE)
        MACOSX_BUNDLE_BUNDLE_VERSION 0.0.4.2
        MACOSX_BUNDLE_SHORT_VERSION_STRING 0.0.4.2
        MACOSX_BUNDLE_ICON_FILE duck.icns
-       # Carries NSCameraUsageDescription; without it macOS kills the process
-       # the moment the camera backend reaches AVFoundation.
        MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/macos/Info.plist.in"
        XCODE_ATTRIBUTE_CODE_SIGN_ENTITLEMENTS "${CMAKE_CURRENT_SOURCE_DIR}/EKA2L1.entitlements"
        XCODE_ATTRIBUTE_OTHER_CODE_SIGN_FLAGS "--deep --options=runtime"

--- a/src/emu/qt/macos/Info.plist.in
+++ b/src/emu/qt/macos/Info.plist.in
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<!--
-	Reproduces the bundle keys CMake and Qt would generate on their own, plus
-	NSCameraUsageDescription: macOS terminates a process that reaches
-	AVFoundation without a usage string, so the camera backend needs one to
-	work at all.
--->
+
 <plist version="1.0">
 <dict>
 	<key>CFBundleInfoDictionaryVersion</key>
@@ -44,6 +39,13 @@
 
 	<key>NSSupportsAutomaticGraphicsSwitching</key>
 	<true/>
+
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_eka2l1._udp</string>
+	</array>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>EKA2L1 discovers and connects to nearby players for Bluetooth Netplay.</string>
 
 	<key>NSCameraUsageDescription</key>
 	<string>EKA2L1 passes the camera through to camera applications running on the emulated phone.</string>

--- a/src/emu/services/CMakeLists.txt
+++ b/src/emu/services/CMakeLists.txt
@@ -364,3 +364,7 @@ target_link_libraries(epocservs PRIVATE
 if (WIN32)
         target_link_libraries(epocservs PRIVATE Ws2_32.lib)
 endif()
+
+if (APPLE)
+        target_sources(epocservs PRIVATE src/bluetooth/protocols/bonjour.cpp)
+endif()

--- a/src/emu/services/include/services/bluetooth/protocols/bonjour.h
+++ b/src/emu/services/include/services/bluetooth/protocols/bonjour.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <services/bluetooth/protocols/common.h>
+#include <memory>
+#include <string>
+#include <vector>
+#include <services/socket/common.h>
+
+namespace eka2l1::epoc::bt {
+    struct bonjour_peer {
+        epoc::socket::saddress endpoint{};
+        device_address address{};
+    };
+
+    // All operations, including destruction, run on the libuv loop thread.
+    class bonjour_discovery {
+        struct impl;
+        std::unique_ptr<impl> impl_;
+
+    public:
+        bonjour_discovery(const device_address &address, const std::string &password, std::uint16_t port, std::function<void()> changed);
+        ~bonjour_discovery();
+        void retry();
+        std::vector<bonjour_peer> peers() const;
+    };
+}

--- a/src/emu/services/include/services/bluetooth/protocols/btmidman_inet.h
+++ b/src/emu/services/include/services/bluetooth/protocols/btmidman_inet.h
@@ -91,6 +91,8 @@ namespace eka2l1::epoc::bt {
         virtual void on_no_more_strangers() = 0;
     };
 
+    class bonjour_discovery;
+
     class midman_inet: public midman {
     private:
         std::map<device_address, std::uint32_t> friend_device_address_mapping_;
@@ -129,8 +131,8 @@ namespace eka2l1::epoc::bt {
         std::string password_;
         discovery_mode discovery_mode_;
 
-        epoc::socket::saddress server_addr_;
-        epoc::socket::saddress local_addr_;
+        epoc::socket::saddress server_addr_{};
+        epoc::socket::saddress local_addr_{};
 
         std::shared_ptr<libuv::task> send_strangers_call_task_;
         std::shared_ptr<libuv::task> reset_timeout_timer_task_;
@@ -140,6 +142,10 @@ namespace eka2l1::epoc::bt {
         void send_call_for_strangers();
 
         // LAN
+#ifdef __APPLE__
+        std::unique_ptr<bonjour_discovery> bonjour_;
+        void sync_bonjour_friends();
+#endif
         void setup_lan_discovery();
         void add_lan_friend(const sockaddr *replier);
         void handle_lan_discovery_receive(const char *buf, std::int64_t nread, const sockaddr *addr);
@@ -171,6 +177,15 @@ namespace eka2l1::epoc::bt {
         std::uint16_t get_free_port();
 
         std::vector<std::uint32_t> get_friend_index_with_address(epoc::socket::saddress &addr);
+        bool get_first_friend_device_address(device_address &result);
+        bool uses_bonjour_discovery() const {
+#ifdef __APPLE__
+            return discovery_mode_ == DISCOVERY_MODE_LAN;
+#else
+            return false;
+#endif
+        }
+
         bool get_friend_device_address(const std::uint32_t index, device_address &result);
         void handle_queries_request(const sockaddr *addr, const char *buf, std::int64_t nread);
 

--- a/src/emu/services/include/services/bluetooth/protocols/common_inet.h
+++ b/src/emu/services/include/services/bluetooth/protocols/common_inet.h
@@ -1,6 +1,17 @@
+#pragma once
+
 #include <cstdint>
+#include <cstring>
+#include <memory>
 
 namespace eka2l1::epoc::bt {
+    // uvw raw-pointer sends borrow the bytes until asynchronous completion.
+    inline std::unique_ptr<char[]> copy_control_packet(const char *data, const std::size_t size) {
+        auto packet = std::make_unique<char[]>(size);
+        std::memcpy(packet.get(), data, size);
+        return packet;
+    }
+
     enum query_opcode : std::uint8_t {
         QUERY_OPCODE_GET_NAME,
         QUERY_OPCODE_GET_VIRTUAL_BLUETOOTH_ADDRESS,

--- a/src/emu/services/include/services/socket/common.h
+++ b/src/emu/services/include/services/socket/common.h
@@ -39,7 +39,7 @@ namespace eka2l1::epoc::socket {
         socket_type_raw ///< Receive raw packet that is wrapped with protocol header, has not been extracted by any network layer.
     };
 
-    enum {
+    enum : std::uint32_t {
         INVALID_FAMILY_ID = 0xFFFFFFFF
     };
 

--- a/src/emu/services/src/bluetooth/protocols/base_inet.cpp
+++ b/src/emu/services/src/bluetooth/protocols/base_inet.cpp
@@ -63,6 +63,8 @@ namespace eka2l1::epoc::bt {
                 uv_tcp_getpeername(reinterpret_cast<uv_tcp_t*>(opaque_handle), reinterpret_cast<sockaddr*>(&addr), &addr_structlen);                
                 uv_tcp_nodelay(reinterpret_cast<uv_tcp_t*>(opaque_handle), 1);
 
+                if (mid->uses_bonjour_discovery()) return;
+
                 epoc::internet::host_sockaddr_to_guest_saddress(reinterpret_cast<const sockaddr*>(&addr), addr_dest);
 
                 addr_dest.port_ = static_cast<std::uint16_t>(mid->get_server_port());

--- a/src/emu/services/src/bluetooth/protocols/bonjour.cpp
+++ b/src/emu/services/src/bluetooth/protocols/bonjour.cpp
@@ -1,0 +1,248 @@
+#include <services/bluetooth/protocols/bonjour.h>
+#include <services/internet/protocols/inet.h>
+#include <common/log.h>
+
+#include <CommonCrypto/CommonDigest.h>
+#include <dns_sd.h>
+#include <uv.h>
+
+#include <array>
+#include <cstring>
+#include <cstdio>
+#include <map>
+#include <tuple>
+
+namespace eka2l1::epoc::bt {
+    namespace {
+        constexpr const char *service_type = "_eka2l1._udp";
+        constexpr std::size_t max_services = 64;
+
+        void release(DNSServiceRef &ref) {
+            if (ref) {
+                DNSServiceRefDeallocate(ref);
+                ref = nullptr;
+            }
+        }
+    }
+
+    struct bonjour_discovery::impl {
+        struct service {
+            impl *owner;
+            DNSServiceRef resolve = nullptr;
+            DNSServiceRef addresses = nullptr;
+            std::uint16_t port = 0;
+            device_address address{};
+            std::map<std::uint32_t, epoc::socket::saddress> endpoints;
+
+            explicit service(impl *owner) : owner(owner) {}
+            ~service() {
+                release(addresses);
+                release(resolve);
+            }
+        };
+
+        using service_key = std::tuple<std::uint32_t, std::string, std::string>;
+        std::map<service_key, std::unique_ptr<service>> services;
+        DNSServiceRef connection = nullptr;
+        DNSServiceRef registration = nullptr;
+        DNSServiceRef browser = nullptr;
+        uv_poll_t *poll = nullptr;
+        std::string name;
+        device_address address;
+        std::function<void()> changed;
+        std::array<unsigned char, CC_SHA256_DIGEST_LENGTH> room;
+        std::uint16_t port;
+        bool failed = false;
+
+        impl(const device_address &address, const std::string &password, std::uint16_t port, std::function<void()> changed)
+            : address(address), changed(std::move(changed)), port(port) {
+            char instance[32];
+            std::snprintf(instance, sizeof(instance), "EKA2L1-%02x%02x%02x%02x%02x%02x",
+                address.addr_[0], address.addr_[1], address.addr_[2], address.addr_[3], address.addr_[4], address.addr_[5]);
+            name = instance;
+            CC_SHA256(password.data(), static_cast<CC_LONG>(password.size()), room.data());
+            start();
+        }
+
+        ~impl() { stop(); }
+
+        void error(const char *operation, int code) {
+            if (!failed) {
+                LOG_ERROR(SERVICE_BLUETOOTH, "Bonjour {} failed: {}", operation, code);
+            }
+            failed = true;
+        }
+
+        void stop() {
+            if (poll) {
+                uv_poll_stop(poll);
+                poll->data = nullptr;
+                uv_close(reinterpret_cast<uv_handle_t *>(poll), [](uv_handle_t *handle) {
+                    delete reinterpret_cast<uv_poll_t *>(handle);
+                });
+                poll = nullptr;
+            }
+            // Children must be released before their shared DNS-SD connection.
+            services.clear();
+            release(browser);
+            release(registration);
+            release(connection);
+        }
+
+        void start() {
+            failed = false;
+            int result = DNSServiceCreateConnection(&connection);
+            if (result) {
+                error("connection", result);
+                return;
+            }
+
+            TXTRecordRef txt;
+            TXTRecordCreate(&txt, 0, nullptr);
+            TXTRecordSetValue(&txt, "version", 1, "1");
+            TXTRecordSetValue(&txt, "room", room.size(), room.data());
+            TXTRecordSetValue(&txt, "address", 6, address.addr_);
+            registration = connection;
+            result = DNSServiceRegister(&registration,
+                kDNSServiceFlagsShareConnection | kDNSServiceFlagsNoAutoRename,
+                kDNSServiceInterfaceIndexAny, name.c_str(), service_type, "local.", nullptr,
+                htons(port), TXTRecordGetLength(&txt), TXTRecordGetBytesPtr(&txt),
+                [](DNSServiceRef, DNSServiceFlags, DNSServiceErrorType error,
+                    const char *, const char *, const char *, void *context) {
+                    if (error) static_cast<impl *>(context)->error("registration", error);
+                }, this);
+            TXTRecordDeallocate(&txt);
+            if (result) {
+                registration = nullptr;
+                error("registration", result);
+                return;
+            }
+
+            browser = connection;
+            result = DNSServiceBrowse(&browser, kDNSServiceFlagsShareConnection,
+                kDNSServiceInterfaceIndexAny, service_type, "local.", browse_reply, this);
+            if (result) {
+                browser = nullptr;
+                error("browse", result);
+                return;
+            }
+
+            auto *handle = new uv_poll_t;
+            result = uv_poll_init_socket(uv_default_loop(), handle, DNSServiceRefSockFD(connection));
+            if (result) {
+                delete handle;
+                error("poll setup", result);
+                return;
+            }
+            poll = handle;
+            poll->data = this;
+            result = uv_poll_start(poll, UV_READABLE, [](uv_poll_t *handle, int status, int events) {
+                auto *self = static_cast<impl *>(handle->data);
+                if (!self) return;
+                if (status < 0) {
+                    self->error("poll", status);
+                    uv_poll_stop(handle);
+                } else if (events & UV_READABLE) {
+                    const int result = DNSServiceProcessResult(self->connection);
+                    if (result) {
+                        self->error("receive", result);
+                        uv_poll_stop(handle);
+                    }
+                    self->changed();
+                }
+            });
+            if (result) error("poll start", result);
+        }
+
+        static void browse_reply(DNSServiceRef, DNSServiceFlags flags, std::uint32_t interface,
+            DNSServiceErrorType error, const char *name, const char *type, const char *domain, void *context) {
+            auto *self = static_cast<impl *>(context);
+            if (error) {
+                self->error("browse", error);
+                return;
+            }
+            if (self->name == name) return;
+            const service_key key{interface, name, domain};
+            if (!(flags & kDNSServiceFlagsAdd)) {
+                self->services.erase(key);
+                return;
+            }
+            if (self->services.count(key) || self->services.size() >= max_services) return;
+
+            auto peer = std::make_unique<service>(self);
+            peer->resolve = self->connection;
+            const int result = DNSServiceResolve(&peer->resolve, kDNSServiceFlagsShareConnection,
+                interface, name, type, domain, resolve_reply, peer.get());
+            if (result) {
+                peer->resolve = nullptr;
+                LOG_ERROR(SERVICE_BLUETOOTH, "Bonjour resolve failed: {}", result);
+                return;
+            }
+            self->services.emplace(key, std::move(peer));
+        }
+
+        static void resolve_reply(DNSServiceRef, DNSServiceFlags, std::uint32_t interface,
+            DNSServiceErrorType error, const char *, const char *host, std::uint16_t port,
+            std::uint16_t txt_size, const unsigned char *txt, void *context) {
+            auto *peer = static_cast<service *>(context);
+            peer->endpoints.clear();
+            release(peer->addresses);
+            if (error) return;
+            std::uint8_t length = 0;
+            const void *version = TXTRecordGetValuePtr(txt_size, txt, "version", &length);
+            if (!version || length != 1 || std::memcmp(version, "1", 1)) return;
+            const void *room = TXTRecordGetValuePtr(txt_size, txt, "room", &length);
+            if (!room || length != peer->owner->room.size()
+                || std::memcmp(room, peer->owner->room.data(), length) || !port) return;
+
+            const void *address = TXTRecordGetValuePtr(txt_size, txt, "address", &length);
+            if (!address || length != 6) return;
+            std::memcpy(peer->address.addr_, address, 6);
+            peer->port = ntohs(port);
+            peer->addresses = peer->owner->connection;
+            const int result = DNSServiceGetAddrInfo(&peer->addresses, kDNSServiceFlagsShareConnection,
+                interface, kDNSServiceProtocol_IPv4, host, address_reply, peer);
+            if (result) {
+                peer->addresses = nullptr;
+                LOG_ERROR(SERVICE_BLUETOOTH, "Bonjour address lookup failed: {}", result);
+            }
+        }
+
+        static void address_reply(DNSServiceRef, DNSServiceFlags flags, std::uint32_t,
+            DNSServiceErrorType error, const char *, const sockaddr *address, std::uint32_t, void *context) {
+            auto *peer = static_cast<service *>(context);
+            if (error || !address || address->sa_family != AF_INET) return;
+            const auto key = reinterpret_cast<const sockaddr_in *>(address)->sin_addr.s_addr;
+            if (!(flags & kDNSServiceFlagsAdd)) {
+                peer->endpoints.erase(key);
+                return;
+            }
+            epoc::socket::saddress endpoint{};
+            internet::host_sockaddr_to_guest_saddress(address, endpoint);
+            endpoint.port_ = peer->port;
+            peer->endpoints[key] = endpoint;
+        }
+    };
+
+    bonjour_discovery::bonjour_discovery(const device_address &address, const std::string &password, std::uint16_t port, std::function<void()> changed)
+        : impl_(std::make_unique<impl>(address, password, port, std::move(changed))) {}
+
+    bonjour_discovery::~bonjour_discovery() = default;
+
+    void bonjour_discovery::retry() {
+        if (impl_->failed) {
+            impl_->stop();
+            impl_->start();
+        }
+    }
+
+    std::vector<bonjour_peer> bonjour_discovery::peers() const {
+        std::vector<bonjour_peer> result;
+        if (!impl_->failed) {
+            for (const auto &entry : impl_->services) {
+                for (const auto &address : entry.second->endpoints) result.push_back({address.second, entry.second->address});
+            }
+        }
+        return result;
+    }
+}

--- a/src/emu/services/src/bluetooth/protocols/btmidman_inet.cpp
+++ b/src/emu/services/src/bluetooth/protocols/btmidman_inet.cpp
@@ -22,6 +22,10 @@
 #include <services/internet/protocols/common.h>
 #include <services/internet/protocols/inet.h>
 
+#ifdef __APPLE__
+#include <services/bluetooth/protocols/bonjour.h>
+#endif
+
 #include <common/random.h>
 #include <common/log.h>
 #include <common/algorithm.h>
@@ -62,7 +66,7 @@ namespace eka2l1::epoc::bt {
             return;
         }
 
-        if (discovery_mode_ == DISCOVERY_MODE_LAN) {
+        if ((discovery_mode_ == DISCOVERY_MODE_LAN) && !uses_bonjour_discovery()) {
             port_ = HARBOUR_PORT;
         }
 
@@ -162,6 +166,9 @@ namespace eka2l1::epoc::bt {
             // that reaches back into this object, which is already half torn down.
             device_addr_asker_.shutdown_handles();
 
+#ifdef __APPLE__
+            bonjour_.reset();
+#endif
             shutdown_uv_handle(lan_discovery_call_listener_socket_);
             shutdown_uv_handle(bluetooth_queries_server_socket_);
             shutdown_uv_handle(matching_server_socket_);
@@ -423,7 +430,7 @@ lookup:
             }
         }
 
-        if (!friend_info_cached_) {
+        if (!friend_info_cached_ && !uses_bonjour_discovery()) {
             // Try to refresh the local cache. It's not really ideal, but anyway resolver always redo
             // a full rescan...
             refresh_friend_infos();
@@ -457,7 +464,7 @@ lookup:
             return;
         }
 
-        if (!friend_info_cached_) {
+        if (!friend_info_cached_ && !uses_bonjour_discovery()) {
             // Try to refresh the local cache. It's not really ideal, but anyway resolver always redo
             // a full rescan...
             refresh_friend_infos_async([this, check_for_friend_and_run_cb]() {
@@ -497,6 +504,10 @@ lookup:
             return;
         }
 
+        if (uses_bonjour_discovery()) {
+            friend_info_cached_ = true;
+            return;
+        }
         if (friend_info_cached_) {
             return;
         }
@@ -688,12 +699,19 @@ lookup:
         return indicies;
     }
 
+    bool midman_inet::get_first_friend_device_address(device_address &result) {
+        for (std::uint32_t i = 0; i < friends_.size(); ++i) {
+            if (friends_[i].real_addr_.family_ != 0 && get_friend_device_address(i, result)) return true;
+        }
+        return false;
+    }
+
     bool midman_inet::get_friend_device_address(const std::uint32_t index, device_address &result) {
         if (index >= friends_.size()) {
             return false;
         }
 
-        if (!friend_info_cached_) {
+        if (!friend_info_cached_ && !uses_bonjour_discovery()) {
             // Try to refresh the local cache. It's not really ideal, but anyway resolver always redo
             // a full rescan...
             refresh_friend_infos();
@@ -737,6 +755,12 @@ lookup:
                 // failed. Only the timeout below must happen unconditionally --
                 // an observer that never gets on_no_more_strangers() leaves its
                 // guest request outstanding forever.
+#ifdef __APPLE__
+                if (uses_bonjour_discovery() && bonjour_) {
+                    if (retried_lan_discovery_times_ == 0) bonjour_->retry();
+                    sync_bonjour_friends();
+                } else
+#endif
                 if ((discovery_mode_ == DISCOVERY_MODE_LAN) && lan_discovery_call_listener_socket_) {
                     sockaddr_in6 server_addr_modded;
 

--- a/src/emu/services/src/bluetooth/protocols/btmidman_inet.cpp
+++ b/src/emu/services/src/bluetooth/protocols/btmidman_inet.cpp
@@ -267,7 +267,7 @@ namespace eka2l1::epoc::bt {
             name_utf8.insert(name_utf8.begin(), opcode_result_signature);
             name_utf8.insert(name_utf8.begin(), reinterpret_cast<const char*>(&asker_id), reinterpret_cast<const char*>(&asker_id + 1));
 
-            bluetooth_queries_server_socket_->send(*sender, name_utf8.data(), static_cast<std::uint32_t>(name_utf8.size()));
+            bluetooth_queries_server_socket_->send(*sender, copy_control_packet(name_utf8.data(), name_utf8.size()), static_cast<std::uint32_t>(name_utf8.size()));
             break;
         }
 
@@ -289,7 +289,7 @@ namespace eka2l1::epoc::bt {
 
             check_result.push_back(final_result);
 
-            bluetooth_queries_server_socket_->send(*sender, check_result.data(), static_cast<std::uint32_t>(check_result.size()));
+            bluetooth_queries_server_socket_->send(*sender, copy_control_packet(check_result.data(), check_result.size()), static_cast<std::uint32_t>(check_result.size()));
             break;
         }
 
@@ -302,7 +302,7 @@ namespace eka2l1::epoc::bt {
             buf_result.push_back(opcode_result_signature);
             buf_result.insert(buf_result.end(), reinterpret_cast<char *>(&temp_uint), reinterpret_cast<char *>(&temp_uint + 1));
 
-            bluetooth_queries_server_socket_->send(*sender, buf_result.data(), static_cast<std::uint32_t>(buf_result.size()));
+            bluetooth_queries_server_socket_->send(*sender, copy_control_packet(buf_result.data(), buf_result.size()), static_cast<std::uint32_t>(buf_result.size()));
             break;
         }
 
@@ -312,7 +312,7 @@ namespace eka2l1::epoc::bt {
             buf_result.push_back(opcode_result_signature);
             buf_result.insert(buf_result.end(), reinterpret_cast<char *>(&random_device_addr_), reinterpret_cast<char *>(&random_device_addr_ + 1));
 
-            bluetooth_queries_server_socket_->send(*sender, buf_result.data(), static_cast<std::uint32_t>(buf_result.size()));
+            bluetooth_queries_server_socket_->send(*sender, copy_control_packet(buf_result.data(), buf_result.size()), static_cast<std::uint32_t>(buf_result.size()));
             break;
         }
 
@@ -760,9 +760,9 @@ lookup:
                     });
 
                     lan_discovery_call_listener_socket_->broadcast(true);
-                    lan_discovery_call_listener_socket_->send(*reinterpret_cast<sockaddr*>(&server_addr_modded), broadcast_buf.data(), static_cast<std::uint32_t>(broadcast_buf.size()));
+                    lan_discovery_call_listener_socket_->send(*reinterpret_cast<sockaddr*>(&server_addr_modded), copy_control_packet(broadcast_buf.data(), broadcast_buf.size()), static_cast<std::uint32_t>(broadcast_buf.size()));
                 } else if ((discovery_mode_ == DISCOVERY_MODE_PROXY_SERVER) && matching_server_socket_) {
-                    matching_server_socket_->write(&request_friends, 1);
+                    matching_server_socket_->write(copy_control_packet(&request_friends, 1), 1);
                 }
 
                 if ((discovery_mode_ != DISCOVERY_MODE_LAN) || (retried_lan_discovery_times_ == 0)) {

--- a/src/emu/services/src/bluetooth/protocols/btmidman_lan_matching.cpp
+++ b/src/emu/services/src/bluetooth/protocols/btmidman_lan_matching.cpp
@@ -20,9 +20,72 @@
 #include <services/bluetooth/protocols/btmidman_inet.h>
 #include <services/bluetooth/protocols/common_inet.h>
 #include <common/log.h>
+#ifdef __APPLE__
+#include <services/bluetooth/protocols/bonjour.h>
+#endif
 
 namespace eka2l1::epoc::bt {
+#ifdef __APPLE__
+    void midman_inet::sync_bonjour_friends() {
+        if (!bonjour_) return;
+        const auto peers = bonjour_->peers();
+        std::vector<friend_info> discovered;
+        for (const auto &peer : peers) {
+            friend_info info{};
+            epoc::internet::sinet6_address endpoint{};
+            endpoint.family_ = epoc::internet::INET6_ADDRESS_FAMILY;
+            endpoint.port_ = peer.endpoint.port_;
+            endpoint.address_32x4()[2] = 0xFFFF0000;
+            endpoint.address_32x4()[3] = htonl(*reinterpret_cast<const std::uint32_t *>(peer.endpoint.user_data_));
+            info.real_addr_ = endpoint;
+            info.dvc_addr_ = peer.address;
+            discovered.push_back(info);
+        }
+
+        const std::lock_guard<std::mutex> guard(friends_lock_);
+        for (auto &friend_entry : friends_) {
+            const auto found = std::find_if(discovered.begin(), discovered.end(), [&](const friend_info &peer) {
+                return std::memcmp(&peer.real_addr_, &friend_entry.real_addr_, sizeof(epoc::socket::saddress)) == 0
+                    && std::memcmp(peer.dvc_addr_.addr_, friend_entry.dvc_addr_.addr_, 6) == 0;
+            });
+            if (found == discovered.end()) {
+                friend_device_address_mapping_.erase(friend_entry.dvc_addr_);
+                friend_entry.real_addr_.family_ = 0;
+            }
+        }
+        for (const auto &peer : discovered) {
+            auto found = std::find_if(friends_.begin(), friends_.end(), [&](const friend_info &entry) {
+                return std::memcmp(&peer.real_addr_, &entry.real_addr_, sizeof(epoc::socket::saddress)) == 0;
+            });
+            if (found == friends_.end()) {
+                found = std::find_if(friends_.begin(), friends_.end(), [](const friend_info &entry) {
+                    return entry.real_addr_.family_ == 0;
+                });
+                if (found == friends_.end()) {
+                    if (friends_.size() >= MAX_INET_DEVICE_AROUND) break;
+                    friends_.push_back(peer);
+                    found = std::prev(friends_.end());
+                } else {
+                    *found = peer;
+                }
+            }
+            const auto index = static_cast<std::uint32_t>(found - friends_.begin());
+            friend_device_address_mapping_[found->dvc_addr_] = index;
+            if (current_active_observer_ && !found->refreshed_) {
+                found->refreshed_ = true;
+                current_active_observer_->on_stranger_call(found->real_addr_, index);
+            }
+        }
+        friend_info_cached_ = true;
+    }
+#endif
+
     void midman_inet::setup_lan_discovery() {
+#ifdef __APPLE__
+        bonjour_ = std::make_unique<bonjour_discovery>(random_device_addr_, password_,
+            static_cast<std::uint16_t>(port_), [this]() { sync_bonjour_friends(); });
+        return;
+#else
         if (!epoc::internet::retrieve_local_ip_info(server_addr_, &local_addr_)) {
             LOG_ERROR(SERVICE_BLUETOOTH, "Can't find local LAN interface for BT netplay!");
             return;
@@ -57,6 +120,7 @@ namespace eka2l1::epoc::bt {
 
             lan_discovery_call_listener_socket_->recv();
         });
+#endif
     }
 
     void midman_inet::handle_lan_discovery_receive(const char *buf, std::int64_t nread, const sockaddr *addr) {

--- a/src/emu/services/src/bluetooth/protocols/btmidman_lan_matching.cpp
+++ b/src/emu/services/src/bluetooth/protocols/btmidman_lan_matching.cpp
@@ -89,7 +89,7 @@ namespace eka2l1::epoc::bt {
 
             if ((password_length == static_cast<std::int64_t>(password_.length())) && (std::memcmp(password_.data(), buf + 2, static_cast<std::size_t>(password_length)) == 0)) {
                 for (std::uint16_t i = 0; i < RETRY_LAN_DISCOVERY_TIME_MAX; i++) {
-                    lan_discovery_call_listener_socket_->send(*addr, &exist_opcode, 1);
+                    lan_discovery_call_listener_socket_->send(*addr, copy_control_packet(&exist_opcode, 1), 1);
                 }
             }
         }

--- a/src/emu/services/src/bluetooth/protocols/btmidman_proxserv_matching.cpp
+++ b/src/emu/services/src/bluetooth/protocols/btmidman_proxserv_matching.cpp
@@ -117,7 +117,7 @@ namespace eka2l1::epoc::bt {
             LOG_ERROR(SERVICE_BLUETOOTH, "Fail to send login request to server! Libuv's error code {}", event.code());
         });
         
-        int err = matching_server_socket_->write(login_package.data(), login_package.size());
+        int err = matching_server_socket_->write(copy_control_packet(login_package.data(), login_package.size()), login_package.size());
         
         if (err < 0) {
             LOG_ERROR(SERVICE_BLUETOOTH, "Fail to send login request to server! Libuv's error code {}", err);
@@ -135,7 +135,7 @@ namespace eka2l1::epoc::bt {
             LOG_ERROR(SERVICE_BLUETOOTH, "Fail to send logout request to server! Libuv's error code {}", event.code());
         });
         
-        int err = matching_server_socket_->write(&package, 1);
+        int err = matching_server_socket_->write(copy_control_packet(&package, 1), 1);
 
         if (err < 0) {
             LOG_ERROR(SERVICE_BLUETOOTH, "Fail to send logout request to server! Libuv's error code {}", err);
@@ -176,7 +176,7 @@ namespace eka2l1::epoc::bt {
                         static_cast<char>(advertised_port >> 8),
                         static_cast<char>(advertised_port & 0xFF)
                     };
-                    matching_server_socket_->write(package, sizeof(package));
+                    matching_server_socket_->write(copy_control_packet(package, sizeof(package)), sizeof(package));
                 }
                 matching_server_receive_buffer_.erase(matching_server_receive_buffer_.begin(),
                     matching_server_receive_buffer_.begin() + 2);

--- a/src/emu/services/src/notifier/bluetooth.cpp
+++ b/src/emu/services/src/notifier/bluetooth.cpp
@@ -28,7 +28,6 @@ namespace eka2l1::epoc::notifier {
     namespace {
         constexpr std::size_t bt_device_response_size = 544;
         constexpr std::size_t bt_device_name_offset = 8;
-        constexpr std::size_t bt_device_class_offset = 512;
 
         int write_selected_device(kernel_system *kern, epoc::des8 *response,
             epoc::notify_info &complete_info, const epoc::bt::device_address &selected_address) {
@@ -38,7 +37,9 @@ namespace eka2l1::epoc::notifier {
             constexpr std::u16string_view peer_name = u"EKA2L1 peer";
             const std::uint32_t name_info = (static_cast<std::uint32_t>(epoc::buf) << 28)
                 | static_cast<std::uint32_t>(peer_name.size());
-            const std::uint32_t name_capacity = 248;
+            // EPOC6 keeps a 256-character name; later ROMs use 248 characters.
+            const std::uint32_t name_capacity = kern->get_epoc_version() == epocver::epoc6 ? 256 : 248;
+            const std::size_t bt_device_class_offset = bt_device_name_offset + 8 + name_capacity * sizeof(char16_t);
             std::memcpy(result.data() + bt_device_name_offset, &name_info, sizeof(name_info));
             std::memcpy(result.data() + bt_device_name_offset + sizeof(name_info), &name_capacity, sizeof(name_capacity));
             std::memcpy(result.data() + bt_device_name_offset + sizeof(name_info) + sizeof(name_capacity),

--- a/src/emu/services/src/notifier/bluetooth.cpp
+++ b/src/emu/services/src/notifier/bluetooth.cpp
@@ -86,7 +86,7 @@ namespace eka2l1::epoc::notifier {
         }
 
         epoc::bt::device_address selected_address{};
-        if (midman->get_friend_device_address(0, selected_address)) {
+        if (!midman->uses_bonjour_discovery() && midman->get_first_friend_device_address(selected_address)) {
             complete_info.complete(write_selected_device(kern_, response, complete_info, selected_address));
             return;
         }
@@ -154,7 +154,7 @@ namespace eka2l1::epoc::notifier {
             }
 
             epoc::bt::device_address selected_address{};
-            if (midman->get_friend_device_address(0, selected_address)) {
+            if (midman->get_first_friend_device_address(selected_address)) {
                 finish_request(state, generation);
                 return;
             }
@@ -179,7 +179,7 @@ namespace eka2l1::epoc::notifier {
         }
 
         epoc::bt::device_address selected_address{};
-        const bool found = state->midman && state->midman->get_friend_device_address(0, selected_address);
+        const bool found = state->midman && state->midman->get_first_friend_device_address(selected_address);
         const int result = found
             ? write_selected_device(state->kern, state->response, state->complete_info, selected_address)
             : epoc::error_not_found;

--- a/src/tests/epoc/CMakeLists.txt
+++ b/src/tests/epoc/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(CORE_TEST_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/services/bluetooth/bonjour.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/devices.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/drivers/audio.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/graphics/openvg.cpp

--- a/src/tests/epoc/services/bluetooth/bonjour.cpp
+++ b/src/tests/epoc/services/bluetooth/bonjour.cpp
@@ -1,0 +1,56 @@
+#ifdef __APPLE__
+#include <catch2/catch.hpp>
+#include <services/bluetooth/protocols/bonjour.h>
+#include <uv.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstring>
+#include <thread>
+
+namespace {
+    template <typename Predicate>
+    bool await_bonjour(Predicate predicate) {
+        const auto end = std::chrono::steady_clock::now() + std::chrono::seconds(12);
+        do {
+            uv_run(uv_default_loop(), UV_RUN_NOWAIT);
+            if (predicate()) return true;
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        } while (std::chrono::steady_clock::now() < end);
+        return false;
+    }
+}
+
+TEST_CASE("Bonjour discovers matching rooms and withdraws departed peers", "[.bonjour]") {
+    using namespace eka2l1::epoc::bt;
+    const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+    const std::string room = "eka2l1-test-" + std::to_string(nonce);
+    device_address first{};
+    std::memcpy(first.addr_, &nonce, 6);
+    device_address second = first;
+    device_address third = first;
+    second.addr_[0] ^= 0x40;
+    third.addr_[0] ^= 0x80;
+    auto observer = std::make_unique<bonjour_discovery>(first, room, 35681, [] {});
+    auto peer = std::make_unique<bonjour_discovery>(second, room, 35682, [] {});
+    auto other_room = std::make_unique<bonjour_discovery>(third, room + "-other", 35683, [] {});
+
+    REQUIRE(await_bonjour([&] { return !observer->peers().empty() && !peer->peers().empty(); }));
+    for (const auto &found : observer->peers()) {
+        CHECK(std::memcmp(found.address.addr_, second.addr_, 6) == 0);
+        CHECK(found.endpoint.port_ == 35682);
+    }
+    CHECK(other_room->peers().empty());
+
+    peer.reset();
+    REQUIRE(await_bonjour([&] { return observer->peers().empty(); }));
+    for (int i = 0; i < 10; ++i) {
+        auto cancelled = std::make_unique<bonjour_discovery>(second, room, 35682, [] {});
+        cancelled.reset();
+        uv_run(uv_default_loop(), UV_RUN_NOWAIT);
+    }
+    other_room.reset();
+    observer.reset();
+    uv_run(uv_default_loop(), UV_RUN_NOWAIT);
+}
+#endif


### PR DESCRIPTION
Dragon World on an EPOC6 N-Gage ROM rejected successful Bluetooth device selection because the notifier wrote validity flags at the later EKA1 offsets. Separately, Bluetooth discovery and query replies passed stack/vector storage to asynchronous uvw sends, producing corrupted control packets. This PR fixes both and moves Apple Local Network discovery to system Bonjour.

- Preserve the EPOC6 `TBuf<256>` response layout (class at 528, validity flags at 532/536/540), retaining the later EKA1 and EKA2 layouts.
- Give queued discovery/query/matching-server control packets ownership until completion.
- Publish and browse `_eka2l1._udp` on Apple platforms, filter rooms using the configured password digest, and retain peer addresses and advertised query ports. Drive DNS-SD and teardown on the libuv loop; invalidate departed peers without shifting their indices.
- Declare the service and local-network usage in both macOS Qt and iOS bundles. Add an explicitly selected Bonjour integration test.

Apple Local Network now uses Bonjour rather than the legacy application UDP broadcast protocol. Automatic Apple/non-Apple discovery therefore needs DNS-SD support on the other platform; Direct IP remains available across platforms. The room digest is a discovery filter, not authentication or encryption. Guest Bluetooth/game transport is unchanged.

Validation on a clean `upstream/master` worktree with this PR applied:

- macOS Qt build and generated bundle plist checks passed.
- All 216 default `ekatests` cases passed (5,762 assertions; count matches `--list-tests`). The explicitly selected Bonjour integration test also passed.
- Focused standalone harnesses compile the production serializer/LAN callback and exercise the linked midman. The packet harness primes libuv's send queue to ensure payloads outlive the callback, and runs with ASan/UBSan.

| Change withdrawn independently | With this PR | With that change withdrawn |
| --- | --- | --- |
| EPOC6 notifier layout | All three response layouts pass | EPOC6 fails; later EKA1/EKA2 still pass |
| Control-packet ownership | Five queued replies, five correct `0x05` payloads | ASan reports stack-use-after-return in the LAN callback's queued send |
| Bonjour discovery integration | Midman receives matching virtual address and advertised port | Search completes with zero sightings of the DNS-SD peer |
| Qt/iOS bundle declarations | Both bundles declare `_eka2l1._udp` | Both declarations are absent |

The Bonjour-revert check recompiles the affected service translation units and relinks the focused executable; it does not reuse the fixed service objects. Response-layout fixtures come from the S60 1st Edition headers and the later EKA1/EKA2 layouts, rather than computing expected offsets from the serializer.

The identical shared-source changes also passed native Bonjour tests under ASan/UBSan, Release simulator and signed-device builds, and all 12 simulator regression checks on the fork. Physical iPhone Air-to-simulator Local Network discovery reached live two-player Dragon World gameplay without the multicast entitlement. The clean upstream-worktree Release simulator build and all 12 regression checks also passed. Two simulators running that build automatically connected through Bonjour and reached the live two-player desert stage; both logs had no guest panics, access violations, graphics halts, or Bonjour failures. CI is still running.

Windows CI follow-up: MSVC rejected aggregate value-initialization of `saddress` with C2397 because the invalid-family enumerator had no explicit underlying type. The follow-up commit declares it as `std::uint32_t`, preserving `0xFFFFFFFF` and the 32-byte address layout. The native build and all 216 tests (5,762 assertions) pass again; Windows CI has been retriggered. All other jobs passed on the preceding revision.
