### PR TITLE
kernel: honor tick queues for relative timers

### DIFF
--- a/src/emu/kernel/CMakeLists.txt
+++ b/src/emu/kernel/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(epockern
         include/kernel/session.h
         include/kernel/server.h
         include/kernel/thread.h
+        include/kernel/timer_deadline.h
         include/kernel/timer.h
         include/kernel/kernel.h
         include/kernel/reg.h

--- a/src/emu/kernel/include/kernel/timer.h
+++ b/src/emu/kernel/include/kernel/timer.h
@@ -53,6 +53,9 @@ namespace eka2l1 {
             // yet made it active.
             bool fire_or_defer();
 
+            bool schedule_at(kernel::thread *requester, eka2l1::ptr<epoc::request_status> sts,
+                std::uint64_t deadline);
+
         public:
             timer(kernel_system *kern, ntimer *timing, std::string name,
                 kernel::access_type access = access_type::local_access);
@@ -61,8 +64,14 @@ namespace eka2l1 {
             bool after(kernel::thread *requester, eka2l1::ptr<epoc::request_status> sts,
                 std::uint64_t us_signal);
 
+            bool after_tick_queue(kernel::thread *requester, eka2l1::ptr<epoc::request_status> sts,
+                std::int32_t interval);
+
+            bool after_high_res(kernel::thread *requester, eka2l1::ptr<epoc::request_status> sts,
+                std::uint32_t us_signal);
+
             bool after_ticks(kernel::thread *requester, eka2l1::ptr<epoc::request_status> sts,
-                std::uint64_t tick_count);
+                std::uint32_t tick_count);
 
             bool request_finish();
             bool cancel_request();

--- a/src/emu/kernel/include/kernel/timer_deadline.h
+++ b/src/emu/kernel/include/kernel/timer_deadline.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ * 
+ * This file is part of EKA2L1 project.
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <common/common.h>
+
+#include <limits>
+
+namespace eka2l1::kernel {
+    // Model the nominal 64 Hz queue; hardware also has nanokernel rounding jitter.
+    constexpr std::uint64_t tick_timer_deadline(std::uint64_t now, std::uint64_t interval_us) {
+        constexpr std::uint64_t period = 1000000 / epoc::TICK_TIMER_HZ;
+        const std::uint64_t deadline = now + (interval_us ? interval_us : 1);
+        return (deadline + period - 1) / period * period;
+    }
+
+    constexpr std::uint64_t tick_count_timer_deadline(std::uint64_t now, std::uint32_t tick_count) {
+        if (tick_count == 0) {
+            return tick_timer_deadline(now, 0);
+        }
+
+        constexpr std::uint64_t period = 1000000 / epoc::TICK_TIMER_HZ;
+        constexpr std::uint64_t max_ticks = std::numeric_limits<std::int32_t>::max();
+        const std::uint64_t adjusted = static_cast<std::uint64_t>(tick_count) + (now % period != 0);
+        // MicroSecondsToTicks saturates the adjusted tick count at KMaxTInt.
+        return now / period * period + (adjusted > max_ticks ? max_ticks : adjusted) * period;
+    }
+
+    // EKA2 RTimer::AfterTicks passes -aTicks through Exec::TimerAfter.
+    constexpr std::uint64_t timer_after_deadline(std::uint64_t now, std::int32_t interval) {
+        if (interval < 0) {
+            return tick_count_timer_deadline(now, static_cast<std::uint32_t>(-static_cast<std::int64_t>(interval)));
+        }
+        return tick_timer_deadline(now, static_cast<std::uint64_t>(interval));
+    }
+
+    constexpr std::uint64_t high_res_timer_deadline(std::uint64_t now, std::uint32_t interval_us) {
+        constexpr std::uint64_t period = 1000000 / epoc::NANOKERNEL_HZ;
+        const std::uint64_t ticks = (static_cast<std::uint64_t>(interval_us) + period - 1) / period;
+        // NTimer::OneShot counts from the next nanokernel tick, including for zero.
+        return (now / period + 1 + ticks) * period;
+    }
+}

--- a/src/emu/kernel/include/kernel/timing.h
+++ b/src/emu/kernel/include/kernel/timing.h
@@ -161,6 +161,7 @@ namespace eka2l1 {
         void remove_event(int event_type);
 
         void schedule_event(int64_t us_into_future, int event_type, std::uint64_t userdata);
+        void schedule_event_at(std::uint64_t deadline, int event_type, std::uint64_t userdata);
         bool unschedule_event(int event_type, uint64_t userdata);
 
         bool set_clock_frequency_mhz(const std::uint32_t cpu_mhz);

--- a/src/emu/kernel/src/svc.cpp
+++ b/src/emu/kernel/src/svc.cpp
@@ -2891,7 +2891,17 @@ namespace eka2l1::epoc {
             return;
         }
 
-        timer->after(kern->crr_thread(), req_sts, us_after);
+        timer->after_tick_queue(kern->crr_thread(), req_sts, us_after);
+    }
+
+    BRIDGE_FUNC(void, timer_after_high_res, kernel::handle h, eka2l1::ptr<epoc::request_status> req_sts, std::int32_t us_after) {
+        timer_ptr timer = kern->get<kernel::timer>(h);
+
+        if (!timer) {
+            return;
+        }
+
+        timer->after_high_res(kern->crr_thread(), req_sts, us_after);
     }
 
     BRIDGE_FUNC(void, timer_lock, kernel::handle h, eka2l1::ptr<epoc::request_status> req_sts, std::uint32_t second_fraction_enum) {
@@ -2917,7 +2927,7 @@ namespace eka2l1::epoc {
             return;
         }
 
-        timer->after(kern->crr_thread(), req_sts, us_after);
+        timer->after_tick_queue(kern->crr_thread(), req_sts, us_after);
     }
     
     BRIDGE_FUNC(void, timer_after_ticks_eka1, eka2l1::ptr<epoc::request_status> req_sts, std::int32_t ticks_after, kernel::handle h) {
@@ -6017,7 +6027,7 @@ namespace eka2l1::epoc {
         BRIDGE_REGISTER(0x83, logical_device_free),
         BRIDGE_REGISTER(0x84, logical_channel_create),
         BRIDGE_REGISTER(0x85, timer_create),
-        BRIDGE_REGISTER(0x86, timer_after), // Actually TimerHighRes
+        BRIDGE_REGISTER(0x86, timer_after_high_res), // Actually TimerHighRes
         BRIDGE_REGISTER(0x87, after), // Actually AfterHighRes
         BRIDGE_REGISTER(0x88, change_notifier_create),
         BRIDGE_REGISTER(0x8D, thread_get_cpu_time),
@@ -6199,7 +6209,7 @@ namespace eka2l1::epoc {
         BRIDGE_REGISTER(0x7F, session_create),
         BRIDGE_REGISTER(0x80, session_create_from_handle),
         BRIDGE_REGISTER(0x84, timer_create),
-        BRIDGE_REGISTER(0x85, timer_after), // Actually TimerHighRes
+        BRIDGE_REGISTER(0x85, timer_after_high_res), // Actually TimerHighRes
         BRIDGE_REGISTER(0x86, after), // Actually AfterHighRes
         BRIDGE_REGISTER(0x87, change_notifier_create),
         BRIDGE_REGISTER(0x9C, wait_dll_lock),
@@ -6379,7 +6389,7 @@ namespace eka2l1::epoc {
         BRIDGE_REGISTER(0x7E, session_create),
         BRIDGE_REGISTER(0x7F, session_create_from_handle),
         BRIDGE_REGISTER(0x83, timer_create),
-        BRIDGE_REGISTER(0x84, timer_after), // Actually TimerHighRes
+        BRIDGE_REGISTER(0x84, timer_after_high_res), // Actually TimerHighRes
         BRIDGE_REGISTER(0x85, after), // Actually AfterHighRes
         BRIDGE_REGISTER(0x86, change_notifier_create),
         BRIDGE_REGISTER(0x9B, wait_dll_lock),

--- a/src/emu/kernel/src/timer.cpp
+++ b/src/emu/kernel/src/timer.cpp
@@ -25,6 +25,7 @@
 #include <kernel/kernel.h>
 #include <kernel/thread.h>
 #include <kernel/timer.h>
+#include <kernel/timer_deadline.h>
 #include <utils/err.h>
 #include <utils/reqsts.h>
 
@@ -72,31 +73,39 @@ namespace eka2l1 {
             timing->unschedule_event(callback_type, static_cast<std::uint64_t>(unique_id()));
         }
 
-        bool timer::after(kernel::thread *requester, eka2l1::ptr<epoc::request_status> sts, std::uint64_t us_signal) {
+        bool timer::schedule_at(kernel::thread *requester, eka2l1::ptr<epoc::request_status> sts,
+            std::uint64_t deadline) {
             if (outstanding) {
                 return false;
             }
 
             outstanding = true;
             activate_defer_count_ = 0;
-
             info.done_nof = epoc::notify_info(sts, requester);
             info.own_timer = this;
-
-            static constexpr std::uint64_t MINIMUM_US_AFTER = 30;
-
-            // Simulate some timeslice delay, and not finish immediately
-            // Some games just set the microseconds to signal to 1, and then when it's report superfast, it acts weird!
-            // For example: DDragon, which signals an object that has not yet been set to active in time! (cancel was called but ineffective cause finish got to it first)
-            timing->schedule_event(common::max<std::uint64_t>(MINIMUM_US_AFTER, us_signal),
-                callback_type, static_cast<std::uint64_t>(unique_id()));
+            timing->schedule_event_at(deadline, callback_type, static_cast<std::uint64_t>(unique_id()));
             return true;
         }
-        
+
+        bool timer::after(kernel::thread *requester, eka2l1::ptr<epoc::request_status> sts, std::uint64_t us_signal) {
+            static constexpr std::uint64_t MINIMUM_US_AFTER = 30;
+            return schedule_at(requester, sts,
+                timing->microseconds() + common::max<std::uint64_t>(MINIMUM_US_AFTER, us_signal));
+        }
+
+        bool timer::after_tick_queue(kernel::thread *requester, eka2l1::ptr<epoc::request_status> sts,
+            std::int32_t interval) {
+            return schedule_at(requester, sts, timer_after_deadline(timing->microseconds(), interval));
+        }
+
+        bool timer::after_high_res(kernel::thread *requester, eka2l1::ptr<epoc::request_status> sts,
+            std::uint32_t us_signal) {
+            return schedule_at(requester, sts, high_res_timer_deadline(timing->microseconds(), us_signal));
+        }
+
         bool timer::after_ticks(kernel::thread *requester, eka2l1::ptr<epoc::request_status> sts,
-            std::uint64_t tick_count) {
-            const std::uint64_t us_per_ticks = (common::microsecs_per_sec / epoc::TICK_TIMER_HZ);
-            return after(requester, sts, us_per_ticks * tick_count);
+            std::uint32_t tick_count) {
+            return schedule_at(requester, sts, tick_count_timer_deadline(timing->microseconds(), tick_count));
         }
 
         bool timer::request_finish() {

--- a/src/emu/kernel/src/timing.cpp
+++ b/src/emu/kernel/src/timing.cpp
@@ -181,11 +181,15 @@ namespace eka2l1 {
     }
 
     void ntimer::schedule_event(int64_t us_into_future, int event_type, std::uint64_t userdata) {
+        schedule_event_at(teletimer_->microseconds() + us_into_future, event_type, userdata);
+    }
+
+    void ntimer::schedule_event_at(std::uint64_t deadline, int event_type, std::uint64_t userdata) {
         const std::lock_guard<std::mutex> guard(lock_);
 
         event evt;
 
-        evt.event_time = teletimer_->microseconds() + us_into_future;
+        evt.event_time = deadline;
         evt.event_type = event_type;
         evt.event_user_data = userdata;
 

--- a/src/tests/epoc/CMakeLists.txt
+++ b/src/tests/epoc/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CORE_TEST_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/mem.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/vfs.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/kernel/ipc_arg.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/kernel/timer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/e32img.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/gdr.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/loader/mbm.cpp

--- a/src/tests/epoc/kernel/timer.cpp
+++ b/src/tests/epoc/kernel/timer.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ * 
+ * This file is part of EKA2L1 project.
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch.hpp>
+#include <kernel/timer_deadline.h>
+#include <kernel/timing.h>
+
+#include <limits>
+
+using namespace eka2l1::kernel;
+
+// Symbian stimer.cpp fixes the nominal kernel tick at 15625 us. These fixtures
+// describe that grid, not the hardware's additional nanokernel rounding jitter.
+TEST_CASE("relative timers use the nominal global tick queue", "[timer]") {
+    REQUIRE(timer_after_deadline(0, 0) == 15625);
+    REQUIRE(timer_after_deadline(0, 1) == 15625);
+    REQUIRE(timer_after_deadline(15624, 0) == 15625);
+    REQUIRE(timer_after_deadline(15624, 1) == 15625);
+    REQUIRE(timer_after_deadline(15625, 0) == 31250);
+    REQUIRE(timer_after_deadline(15625, 1) == 31250);
+    REQUIRE(timer_after_deadline(1000, 14625) == 15625);
+    REQUIRE(timer_after_deadline(1000, 14626) == 31250);
+    REQUIRE(timer_after_deadline(1000, 33000) == 46875);
+}
+
+// us_exec.cpp: RTimer::AfterTicks(n) calls Exec::TimerAfter(..., -n).
+TEST_CASE("EKA2 TimerAfter decodes negative intervals as tick counts", "[timer]") {
+    REQUIRE(timer_after_deadline(0, -1) == 15625);
+    REQUIRE(timer_after_deadline(1000, -1) == 31250);
+    REQUIRE(timer_after_deadline(1000, -64) == 1015625);
+    REQUIRE(timer_after_deadline(1000000, -64) == 2000000);
+    REQUIRE(timer_after_deadline(0, -2147483647) == 33554431984375ULL);
+    REQUIRE(timer_after_deadline(0, std::numeric_limits<std::int32_t>::min()) == 33554431984375ULL);
+    REQUIRE(timer_after_deadline(0, 2147483647) == 2147484375ULL);
+    REQUIRE(timer_after_deadline(1000, -2147483647) == 33554431984375ULL);
+    REQUIRE(tick_count_timer_deadline(1000, 64) == 1015625);
+    REQUIRE(tick_count_timer_deadline(0, 0) == 15625);
+    REQUIRE(tick_count_timer_deadline(15625, 0) == 31250);
+}
+
+// stimer.cpp rounds up the interval; nk_timer.cpp OneShot counts from the next tick.
+TEST_CASE("high resolution timers wait on nanokernel tick boundaries", "[timer]") {
+    REQUIRE(high_res_timer_deadline(0, 0) == 1000);
+    REQUIRE(high_res_timer_deadline(999, 0) == 1000);
+    REQUIRE(high_res_timer_deadline(1000, 0) == 2000);
+    REQUIRE(high_res_timer_deadline(1001, 0) == 2000);
+    REQUIRE(high_res_timer_deadline(250, 1) == 2000);
+    REQUIRE(high_res_timer_deadline(250, 1000) == 2000);
+    REQUIRE(high_res_timer_deadline(250, 1001) == 3000);
+    REQUIRE(high_res_timer_deadline(999, 1000) == 2000);
+    REQUIRE(high_res_timer_deadline(1000, 1000) == 3000);
+    REQUIRE(high_res_timer_deadline(0, 2147483647) == 2147485000ULL);
+}
+
+TEST_CASE("absolute timer deadlines survive queue insertion", "[timer]") {
+    eka2l1::ntimer timing(1000000);
+    timing.reset();
+    timing.stop();
+    // Freeze the initialized clock and drive the event queue without a worker.
+    const std::uint64_t now = timing.microseconds();
+    std::uint64_t completed = 0;
+    const int event = timing.register_event("absolute deadline test",
+        [&completed](std::uint64_t data, int) { completed = data; });
+
+    timing.schedule_event_at(now + 1000000, event, 42);
+    REQUIRE(timing.advance() == std::optional<std::uint64_t>(1000000));
+    REQUIRE(timing.unschedule_event(event, 42));
+    timing.schedule_event_at(now, event, 42);
+    REQUIRE_FALSE(timing.advance().has_value());
+    REQUIRE(completed == 42);
+}


### PR DESCRIPTION
## Problem

Final Battle's callback-driven subtitle intro repeatedly requests
`RTimer::After(1)`. The emulator's 30us minimum allows the sequence to run far
faster than a kernel tick-queued timer.

## Implementation

- Queue `After` on a nominal 64Hz grid, including zero intervals.
- Preserve EKA2's signed `TimerAfter` argument: the official client implements
  `AfterTicks(n)` by passing `-n`. Saturate the adjusted tick count at `KMaxTInt`.
- Give `HighRes` its own executor and count rounded durations from the next
  nanokernel tick. `HighRes(0)` also waits for that tick.
- Enqueue absolute deadlines without a second clock read or the legacy 30us floor.

The hardware tick queue is driven by nanokernel timers with rounding compensation.
The nominal grid models its coarse timing without reproducing that jitter. EKA1
uses the same model consistently with the emulator's advertised period; exact
EKA1 hardware equivalence is not asserted. Existing `At`, `Lock`, `User::After`,
and completion/cancellation policies are retained.

Contracts checked against the official [client requests](https://github.com/SymbianSource/oss.FCL.sf.os.kernelhwsrv/blob/master/kernel/eka/euser/us_exec.cpp),
[kernel timer queue](https://github.com/SymbianSource/oss.FCL.sf.os.kernelhwsrv/blob/master/kernel/eka/kernel/stimer.cpp),
and [nanokernel queue](https://github.com/SymbianSource/oss.FCL.sf.os.kernelhwsrv/blob/master/kernel/eka/nkern/nk_timer.cpp).

## Validation

The full host suite passes on both ios-next and the upstream-based PR worktree:
220 cases, 5796 assertions. The focused timer suite has 4 cases and 34 assertions.
Each behavior was removed independently and the focused executable recompiled:

| Behavior removed | Result |
| --- | --- |
| Ordinary timer tick grid | 2 cases fail |
| EKA2 signed tick decoding | 1 case fails |
| HighRes nanokernel queue phase | 1 case fails |
| Absolute deadline preserved by queue insertion | 1 case fails |
| All restored | All 4 cases pass |

Release iOS simulator validation of the revised implementation:

- Default regression suite: **12/12** (Final Battle, Calculator, N95 Calculator,
  string catalog). Screenshots confirm the Final Battle choice prompt and
  Calculator input/Options-menu behavior.
- Angry Birds touch suite: **5/5**.
- Dragon World on N-Gage/EKA1: title → menu → difficulty → level selection →
  rendered gameplay. Sampled title/menu FPS is in the mid-twenties; this is a
  functional check, not a claim of measured hardware equivalence.
- The upstream-based PR worktree also passes a clean **Release iOS build**.
  The simulator runtime suites above were run on ios-next with the same changes.

The earlier subtitle-duration and hardware-speed-ratio claims are intentionally
not carried forward as measurements of this revision.
