### PR TITLE
fix(gles1): restore deleted texture bindings and ignore zero-axis rotations

### DIFF
--- a/src/emu/dispatch/src/libraries/gles1/gles1.cpp
+++ b/src/emu/dispatch/src/libraries/gles1/gles1.cpp
@@ -843,7 +843,12 @@ namespace eka2l1::dispatch {
 
     std::uint32_t egl_context_es1::bind_texture(const std::uint32_t target, const std::uint32_t tex) {
         auto *obj = objects_.get(tex);
-        if (obj && (*obj).get()) {
+        if (obj && !obj->get()) {
+            // Reviving a deleted name here rather than on first use is what gives the object its target.
+            *obj = std::make_unique<gles_driver_texture>(*this);
+        }
+
+        if (obj && (*obj).get() && ((*obj)->object_type() == GLES_OBJECT_TEXTURE)) {
             std::uint32_t bind_res = reinterpret_cast<gles_driver_texture*>((*obj).get())->try_bind(target);
             if (bind_res != 0) {
                 return bind_res;
@@ -1142,6 +1147,11 @@ namespace eka2l1::dispatch {
             return;
         }
 
+        // Avoid normalising a zero axis into NaNs; nonzero axes need not have unit length.
+        if (x == 0.0f && y == 0.0f && z == 0.0f) {
+            return;
+        }
+
         ctx->active_matrix() = glm::rotate(ctx->active_matrix(), glm::radians(angles), glm::vec3(x, y, z));
     }
 
@@ -1151,7 +1161,15 @@ namespace eka2l1::dispatch {
             return;
         }
 
-        ctx->active_matrix() = glm::rotate(ctx->active_matrix(), glm::radians(FIXED_32_TO_FLOAT(angles)), glm::vec3(FIXED_32_TO_FLOAT(x), FIXED_32_TO_FLOAT(y), FIXED_32_TO_FLOAT(z)));
+        if (x == 0 && y == 0 && z == 0) {
+            return;
+        }
+
+        const float xf = FIXED_32_TO_FLOAT(x);
+        const float yf = FIXED_32_TO_FLOAT(y);
+        const float zf = FIXED_32_TO_FLOAT(z);
+
+        ctx->active_matrix() = glm::rotate(ctx->active_matrix(), glm::radians(FIXED_32_TO_FLOAT(angles)), glm::vec3(xf, yf, zf));
     }
     
     BRIDGE_FUNC_LIBRARY(void, gl_frustumf_emu, float left, float right, float bottom, float top, float near, float far) {


### PR DESCRIPTION
Block Breaker Deluxe 2 (Gameloft, S60v5/Symbian^3) reaches level 1 but never draws its
paddle: the ball hangs in mid-air at the bottom of the playfield and the level is
unplayable. Two independent GLES1 defects stack up here, and the first one hides the
second.

### 1. A zero rotation axis poisons the matrix stack

The game issues `glRotatef(0, 0, 0, 0)` while building the paddle transform.
`glm::rotate` normalises the zero vector into NaNs, which spread across the modelview
matrix and prevent the paddle mesh from rasterising. Both rotation entrypoints now
leave the matrix unchanged when all three axis components are exactly zero.

Nonzero axes retain their existing normalisation. GLES 1.1 section 2.10.2 defines
`u = v / ||v||`; for example, `glRotatex(90 * 65536, 0, 0, 1)` must still rotate
90 degrees about Z. An absolute `1e-4` cutoff would incorrectly discard it.

This was checked against actual Symbian binaries:

- **5320 / rm-409:** `libgles_cm.dll` ordinals 109/110 resolve to
  `0x80636720`/`0x80636888`. The fixed entrypoint converts to float and enters the
  same rotation path. Its normaliser at `0x80657f08` checks whether the squared
  mantissa sum is zero, without an absolute axis-length epsilon. Running the ROM's
  original ARM instructions in Unicorn produced identity for angle 0 / axis 0,
  and identical rotations for unit and 1/65536-sized coordinate and diagonal axes.
  Only context and active-matrix lookups were substituted; the ROM's conversions,
  normalisation, trigonometry and rotation construction ran intact.
- **X7 / rm-707:** `libGLESv1_CM` dispatches to `khclient_vc3` ordinals 202/203.
  Those entrypoints send all four argument words unchanged to VideoCore as commands
  `0x1002`/`0x1024`. There is no ARM-side axis filter; this trace does not establish
  the GPU's final zero-axis matrix.

Zero-axis no-op is a compatibility choice, not a claim that all drivers implement
it identically. The 5320 renderer yields a `cos(angle)` diagonal for a nonzero angle
and a zero axis; the GLES normalisation formula does not define that axis. Mesa
provides a no-op precedent, but its small-axis cutoff only runs after single-axis
fast paths and cannot justify an unconditional epsilon.

Sources: [GLES 1.1 specification, §2.10.2](https://registry.khronos.org/OpenGL/specs/es/1.1/es_full_spec_1.1.pdf),
[Symbian GLES export ordinals](https://github.com/SymbianSource/oss.FCL.sf.os.graphics/blob/master/opengles/openglesinterface/eabi/opengles11u.def),
[Mesa rotation implementation](https://github.com/intel/external-mesa/blob/master/src/mesa/math/m_matrix.c#L741-L807).

### 2. Binding a deleted texture name silently dropped the next upload

The game's loader does this for its first few textures:

```c
glGenTextures(4)          /* -> 6 7 8 9 */
glDeleteTextures(1, {6});
glBindTexture(GL_TEXTURE_2D, 6);
glTexImage2D(..., 128, 128, GL_RGB, GL_UNSIGNED_SHORT_5_6_5, data);
```

Binding a deleted name is legal — it creates a new texture object bound to that target.
`egl_context_es1::bind_texture` only recorded the name and skipped `try_bind` because the
slot was empty, leaving the object to be created lazily by `binded_texture()` inside
`glTexImage2D`. That path does not know which target was bound, so the object stayed
`GLES_DRIVER_TEXTURE_TYPE_NONE`; `target_matched()` then rejected it with
`GL_INVALID_OPERATION` and `glTexImage2D` returned before uploading anything or
allocating a driver handle. The paddle sampled an empty texture unit and came out as
noise. Textures 1–9 of this game all ended up as `0x0`/format `0` objects this way.

`egl_context_es2::bind_texture` already revives an empty slot before calling `try_bind`;
ES1 was the one missing it. The `try_bind` call is now also guarded by an object-type
check, since ES1 keeps textures and buffers in the same identity container and the
`reinterpret_cast` was unguarded.

The existing `Texture name N was previously deleted, generate a new one` warning is a
symptom of this gap rather than a harmless quirk — it fires four times during this
game's boot.

### Effect of each fix on its own

Reverted one at a time on top of the other, level 1 of Block Breaker Deluxe 2:

| Build | Paddle |
|---|---|
| neither fix (current master) | not drawn at all |
| zero-axis fix only | geometry drawn, but textured with garbage |
| `bind_texture` fix only | still not drawn at all (matrix is still NaN) |
| both | correct |

### Testing

- Block Breaker Deluxe 2 on the X7 (rm-707): paddle renders as the intended chrome bar,
  follows touch input, and the ball rests on it.
- Asphalt 6 on the same device, as a GLES1-heavy control: intro movie and the menu car's
  3D material still render correctly.
- Full iOS simulator regression suite (Final Battle, Calculator, N95 Calculator) and the
  Symbian^3 touch suite (Angry Birds) stay green.

- Temporary extracted-bridge C++ harness using the repository GLM and fixed-point
  conversion, with ASan/UBSan: **38 checks pass**. Mathematical fixtures cover
  zero axes, nonidentity matrices, signed/small coordinate axes, small diagonal
  axes, float/fixed paths and missing contexts. The blanket-epsilon version
  fails 20 of the same checks.
- Release simulator rebuild confirmed `gles1.cpp` recompiled; default regression
  **12/12**, Angry Birds touch regression **5/5**, Asphalt 6 through a Nassau race
  **9/9**. Block Breaker level 1 paddle rendering and touch movement were also
  rechecked visually.
- After moving the fixed-point zero check before conversion for clarity, all 38
  bridge checks still pass and the final Release rebuild succeeds.
