### PR TITLE
fix(bluetooth): recover discovery sockets across host suspension

### DIFF
--- a/src/emu/ios/App/EKA2L1App.swift
+++ b/src/emu/ios/App/EKA2L1App.swift
@@ -43,6 +43,7 @@ private struct MainSceneContent: View {
         .onChange(of: scenePhase) { newPhase in
             switch newPhase {
             case .active:
+                EKA2L1Bridge.shared.resumeNetworking()
                 EKA2L1Bridge.shared.resume()
                 ExternalDisplay.shared.setForeground(true)
             case .inactive, .background:
@@ -52,6 +53,12 @@ private struct MainSceneContent: View {
                 // shares; don't keep the iOS 16 fallback's generators alive
                 // across that. SwiftUI handles this itself on iOS 17+.
                 Haptics.release()
+                // Only .background gets the process suspended, and a suspended
+                // app's sockets come back defunct. A passing .inactive (control
+                // centre, a call banner) must not drop a live netplay search.
+                if newPhase == .background {
+                    EKA2L1Bridge.shared.suspendNetworking()
+                }
             @unknown default:
                 break
             }

--- a/src/emu/ios/App/EKA2L1Bridge.swift
+++ b/src/emu/ios/App/EKA2L1Bridge.swift
@@ -223,6 +223,14 @@ final class EKA2L1Bridge {
         emulator.resume()
     }
 
+    func suspendNetworking() {
+        emulator.suspendNetworking()
+    }
+
+    func resumeNetworking() {
+        emulator.resumeNetworking()
+    }
+
     func guestScreenModeSnapshot() -> (modes: [Int], current: Int) {
         let snapshot = emulator.guestScreenModeSnapshot()
         let modes = (snapshot["modes"] as? [NSNumber])?.map(\.intValue) ?? []

--- a/src/emu/ios/Bridge/IosEmulator.h
+++ b/src/emu/ios/Bridge/IosEmulator.h
@@ -217,6 +217,11 @@ typedef NS_ENUM(NSInteger, EKA2L1InstallResult) {
 - (void)pause;
 - (void)resume;
 
+// Sockets do not survive the process being suspended, so the app reports a real
+// background transition (not a passing .inactive) around rebuilding them.
+- (void)suspendNetworking;
+- (void)resumeNetworking;
+
 // Input -------------------------------------------------------------------
 // Single-touch dispatch from EAGLView.
 typedef NS_ENUM(NSInteger, EKA2L1PointerPhase) {

--- a/src/emu/ios/Bridge/IosEmulator.mm
+++ b/src/emu/ios/Bridge/IosEmulator.mm
@@ -395,7 +395,11 @@ namespace eka2l1::ios {
         // Main-thread readers must try_lock only: while a boot holds this
         // lock the graphics thread dispatch_syncs onto the main queue, so a
         // blocked main thread would deadlock the boot.
-        std::recursive_mutex session_mutex;
+        std::recursive_mutex &session_mutex;
+
+        explicit emulator(std::recursive_mutex &session_mutex)
+            : session_mutex(session_mutex) {
+        }
 
         std::mutex layer_mutex;
         std::mutex display_geometry_mutex;
@@ -858,6 +862,7 @@ namespace eka2l1::ios {
                                fatalDetails:(nullable NSString *)fatalDetails;
 // Synchronous launch body, run off the main thread by launchAppWithUID:completion:.
 - (BOOL)runLaunchAppWithUID:(uint32_t)uid;
+- (void)applyNetworkingSuspended:(BOOL)suspended;
 // Uninstall path for apps with no package registry (N-Gage game cards).
 - (BOOL)removeUnpackagedAppWithUID:(uint32_t)uid;
 // Post-uninstall cleanup for a registration the package did not own.
@@ -865,7 +870,10 @@ namespace eka2l1::ios {
 @end
 
 @implementation EKA2L1Emulator {
+    // Queued work must be able to lock before reading a possibly torn-down state.
+    std::recursive_mutex _sessionMutex;
     std::unique_ptr<eka2l1::ios::emulator> _state;
+    std::atomic<bool> _networkingSuspended;
     // Host pointer identity (UITouch address) → guest pointer number. The guest
     // event's ptr_num is a uint8_t indexed pointer slot on Symbian^3 (advanced
     // pointers), so raw UITouch identities must be mapped to small stable
@@ -886,12 +894,23 @@ namespace eka2l1::ios {
     return instance;
 }
 
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _networkingSuspended = false;
+    }
+    return self;
+}
+
 - (BOOL)startWithDocumentsPath:(NSString *)documentsPath {
     if (_state && _state->running) {
         return YES;
     }
 
-    _state = std::make_unique<eka2l1::ios::emulator>();
+    {
+        std::lock_guard<std::recursive_mutex> session_lock(_sessionMutex);
+        _state = std::make_unique<eka2l1::ios::emulator>(_sessionMutex);
+    }
     _state->documents_root = documentsPath.UTF8String;
 
     // Build the sandbox layout up front so later steps can rely on it.
@@ -1174,12 +1193,10 @@ namespace eka2l1::ios {
 }
 
 - (void)shutdown {
+    std::lock_guard<std::recursive_mutex> session_lock(_sessionMutex);
     if (!_state) {
         return;
     }
-    // Wait out any in-flight rescan/boot before tearing the whole state down.
-    // Released just before _state.reset() — the mutex lives inside _state.
-    std::unique_lock<std::recursive_mutex> session_lock(_state->session_mutex);
     // Quiesce sensor callbacks (pause doubles as an in-flight barrier) before
     // the kernel they complete into goes away below.
     if (_state->sensor_driver) {
@@ -1208,7 +1225,6 @@ namespace eka2l1::ios {
     _state->sensor_driver.reset();
     _state->window.reset();
     _state->settings.reset();
-    session_lock.unlock();
     _state.reset();
 }
 
@@ -1481,6 +1497,7 @@ namespace eka2l1::ios {
     _state->winserv = eka2l1::ios::get_window_server(sys->get_kernel_system());
 
     _state->mounted = true;
+    [self applyNetworkingSuspended:_networkingSuspended.load()];
     eka2l1::ios::bind_graphics_driver(_state.get());
 
     // Register a per-screen redraw callback so each frame produced by the
@@ -2160,6 +2177,46 @@ namespace eka2l1::ios {
     // Resume guest execution only after host devices have been restored, so
     // guest stream start/stop calls cannot race the AudioUnit restart above.
     _state->paused = false;
+}
+
+// Call with session_mutex held; the kernel and midman belong to that session.
+- (void)applyNetworkingSuspended:(BOOL)suspended {
+    if (!_state || !_state->mounted || !_state->symsys) {
+        return;
+    }
+
+    auto *kern = _state->symsys->get_kernel_system();
+    if (!kern) {
+        return;
+    }
+
+    eka2l1::kernel_lock lock(kern);
+    auto *server = kern->get_by_name<eka2l1::btman_server>(
+        eka2l1::get_btman_server_name_by_epocver(kern->get_epoc_version()));
+
+    if (auto *midman = server ? server->get_midman() : nullptr) {
+        if (suspended) {
+            midman->suspend();
+        } else {
+            midman->resume();
+        }
+    }
+}
+
+- (void)suspendNetworking {
+    _networkingSuspended = true;
+    dispatch_async(eka2l1::ios::emulator_control_queue(), ^{
+        std::lock_guard<std::recursive_mutex> session_lock(self->_sessionMutex);
+        [self applyNetworkingSuspended:YES];
+    });
+}
+
+- (void)resumeNetworking {
+    _networkingSuspended = false;
+    dispatch_async(eka2l1::ios::emulator_control_queue(), ^{
+        std::lock_guard<std::recursive_mutex> session_lock(self->_sessionMutex);
+        [self applyNetworkingSuspended:NO];
+    });
 }
 
 - (CGRect)guestDisplayRect {

--- a/src/emu/ios/Resources/Info.plist
+++ b/src/emu/ios/Resources/Info.plist
@@ -17,9 +17,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>26.9.0</string>
+    <string>26.9.1</string>
     <key>CFBundleVersion</key>
-    <string>260940</string>
+    <string>260952</string>
     <key>CFBundleIcons</key>
     <dict>
         <key>CFBundlePrimaryIcon</key>

--- a/src/emu/services/include/services/bluetooth/btmidman.h
+++ b/src/emu/services/include/services/bluetooth/btmidman.h
@@ -58,6 +58,14 @@ namespace eka2l1::epoc::bt {
         }
 
         virtual midman_type type() const = 0;
+
+        // Host suspension can invalidate sockets. The session owner reports each
+        // transition; implementations must not wait for network callbacks here.
+        virtual void suspend() {
+        }
+
+        virtual void resume() {
+        }
     };
 
     std::unique_ptr<midman> make_bluetooth_midman(const eka2l1::config::state &conf, const std::uint32_t reserved_stack_type = 0);

--- a/src/emu/services/include/services/bluetooth/protocols/asker_inet.h
+++ b/src/emu/services/include/services/bluetooth/protocols/asker_inet.h
@@ -63,6 +63,7 @@ namespace eka2l1::epoc::bt {
         common::event request_done_evt_;
 
         bool in_transfer_data_callback_;
+        bool asker_dead_;
         std::uint32_t asker_id_;
         std::shared_ptr<std::atomic<bool>> alive_;
 

--- a/src/emu/services/include/services/bluetooth/protocols/btmidman_inet.h
+++ b/src/emu/services/include/services/bluetooth/protocols/btmidman_inet.h
@@ -129,7 +129,9 @@ namespace eka2l1::epoc::bt {
         std::vector<inet_stranger_call_observer*> pending_observers_;
 
         std::string password_;
+        std::string central_server_url_;
         discovery_mode discovery_mode_;
+        bool suspended_; // Loop thread only.
 
         epoc::socket::saddress server_addr_{};
         epoc::socket::saddress local_addr_{};
@@ -140,6 +142,11 @@ namespace eka2l1::epoc::bt {
         std::uint32_t asker_counter_;
 
         void send_call_for_strangers();
+
+        void start_discovery(const bool first_start);
+        // Both of these must run on the loop thread.
+        void setup_discovery_sockets(const bool first_start);
+        void shutdown_discovery_sockets();
 
         // LAN
 #ifdef __APPLE__
@@ -156,7 +163,7 @@ namespace eka2l1::epoc::bt {
         // Server handler
         void handle_matching_server_msg(std::int64_t nread, const char *buf_ptr);
         void send_login();
-        void send_logout(const bool close_and_reset = true);
+        void send_logout();
         void read_and_add_friend(const char *buf, std::int64_t nread, std::int64_t &buf_pointer);
         void add_friend(epoc::bt::friend_info &info);
         void on_timeout_friend_search();
@@ -222,6 +229,9 @@ namespace eka2l1::epoc::bt {
         midman_type type() const override {
             return MIDMAN_INET_BT;
         }
+
+        void suspend() override;
+        void resume() override;
 
         discovery_mode get_discovery_mode() const {
             return discovery_mode_;

--- a/src/emu/services/include/services/bluetooth/protocols/common_inet.h
+++ b/src/emu/services/include/services/bluetooth/protocols/common_inet.h
@@ -4,7 +4,24 @@
 #include <cstring>
 #include <memory>
 
+#include <uv.h>
+
 namespace eka2l1::epoc::bt {
+    // libuv leaves UDP reads armed after errors. Stop invalid sockets to avoid a
+    // busy loop, but keep receiving after transient network or per-send failures.
+    inline bool is_socket_dead_error(const int libuv_error) {
+        switch (libuv_error) {
+        case UV_EBADF:
+        case UV_ENOTCONN:
+        case UV_ENOTSOCK:
+        case UV_EPIPE:
+            return true;
+
+        default:
+            return false;
+        }
+    }
+
     // uvw raw-pointer sends borrow the bytes until asynchronous completion.
     inline std::unique_ptr<char[]> copy_control_packet(const char *data, const std::size_t size) {
         auto packet = std::make_unique<char[]>(size);

--- a/src/emu/services/src/bluetooth/protocols/asker_inet.cpp
+++ b/src/emu/services/src/bluetooth/protocols/asker_inet.cpp
@@ -36,6 +36,7 @@ namespace eka2l1::epoc::bt {
         , retry_times_(0)
         , callback_(nullptr)
         , in_transfer_data_callback_(true)
+        , asker_dead_(false)
         , asker_id_(midman->new_asker_id())
         , alive_(std::make_shared<std::atomic<bool>>(true)) {
         request_done_evt_.set();
@@ -115,6 +116,14 @@ namespace eka2l1::epoc::bt {
                 return;
             }
 
+            // Retrying on a dead socket never recovers. Fail now and let the next
+            // request rebuild; closing here would destroy the listener we are in.
+            if (is_socket_dead_error(event.code())) {
+                handle.stop();
+                retry_times_ = MAX_RETRY_ATTEMPT;
+                asker_dead_ = true;
+            }
+
             handle_request_failure();
         });
 
@@ -179,6 +188,11 @@ namespace eka2l1::epoc::bt {
                 }
 
                 auto default_loop = uvw::loop::get_default();
+
+                if (asker_dead_) {
+                    asker_dead_ = false;
+                    shutdown_uv_handle(asker_);
+                }
 
                 if (!asker_) {
                     asker_ = default_loop->resource<uvw::udp_handle>();

--- a/src/emu/services/src/bluetooth/protocols/btmidman_inet.cpp
+++ b/src/emu/services/src/bluetooth/protocols/btmidman_inet.cpp
@@ -53,7 +53,9 @@ namespace eka2l1::epoc::bt {
         , device_addr_asker_(this)
         , current_active_observer_(nullptr)
         , password_(conf.btnet_password)
+        , central_server_url_(conf.bt_central_server_url)
         , discovery_mode_(static_cast<discovery_mode>(conf.btnet_discovery_mode))
+        , suspended_(false)
         , asker_counter_(0) {
         // Local state the guest still reaches with discovery off.
         std::fill(port_refs_.begin(), port_refs_.end(), 0);
@@ -82,55 +84,110 @@ namespace eka2l1::epoc::bt {
             }
         }
 
+        start_discovery(true);
+    }
+
+    void midman_inet::start_discovery(const bool first_start) {
         auto looper = libuv::default_looper;
-        std::string bt_server_url = conf.bt_central_server_url;
 
         if (!looper->started()) {
             looper->set_loop_thread_prepare_callback([]() { common::set_thread_priority(common::thread_priority_very_high); });
             looper->start();
         }
 
-        looper->one_shot([this, bt_server_url]() {
-            auto loop = uvw::loop::get_default();
+        looper->one_shot([this, first_start]() {
+            setup_discovery_sockets(first_start);
+        });
+    }
 
-            bluetooth_queries_server_socket_ = loop->resource<uvw::udp_handle>();
+    void midman_inet::setup_discovery_sockets(const bool first_start) {
+        auto loop = uvw::loop::get_default();
+
+        bluetooth_queries_server_socket_ = loop->resource<uvw::udp_handle>();
+
+        // Not a socket, so it survives a suspension and keeps a pending stranger
+        // search's timeout running across one.
+        if (!hearing_timeout_timer_) {
             hearing_timeout_timer_ = loop->resource<uvw::timer_handle>();
+        }
 
-            if (discovery_mode_ == DISCOVERY_MODE_LAN) {
-                setup_lan_discovery();
-            } else if (discovery_mode_ == DISCOVERY_MODE_PROXY_SERVER) {
-                setup_proxy_server_discovery(bt_server_url);
+        if (discovery_mode_ == DISCOVERY_MODE_LAN) {
+            setup_lan_discovery();
+        } else if (discovery_mode_ == DISCOVERY_MODE_PROXY_SERVER) {
+            setup_proxy_server_discovery(central_server_url_);
+        }
+
+        sockaddr_in6 addr_bind;
+        std::memset(&addr_bind, 0, sizeof(sockaddr_in6));
+        addr_bind.sin6_family = (discovery_mode_ == DISCOVERY_MODE_LAN) ? AF_INET : AF_INET6;
+        addr_bind.sin6_port = htons(static_cast<std::uint16_t>(port_));
+
+        // Nothing else reports on this socket, so an unchecked failure here
+        // leaves the whole discovery side dead with nothing in the log.
+        if (const int bind_err = bluetooth_queries_server_socket_->bind(*reinterpret_cast<sockaddr*>(&addr_bind)); bind_err < 0) {
+            LOG_ERROR(SERVICE_BLUETOOTH, "Can't bind the Bluetooth queries socket to port {}! Libuv error code={}", port_, bind_err);
+        }
+
+        // A resume rebuilds the socket behind the same port, which the router kept
+        // mapped while we were away.
+        if (first_start && should_upnp_apply_to_port()) {
+            UPnP::TryPortmapping(static_cast<std::uint16_t>(port_), true);
+        }
+
+        bluetooth_queries_server_socket_->on<uvw::udp_data_event>([this](const uvw::udp_data_event &event, uvw::udp_handle &handle) {
+            std::optional<sockaddr_in6> sender_ced = libuv::from_ip_string(event.sender.ip.data(), event.sender.port);
+            if (!sender_ced.has_value()) {
+                LOG_ERROR(SERVICE_BLUETOOTH, "Invalid sender address passed to callback!");
+                return;
             }
+            handle_queries_request(reinterpret_cast<sockaddr*>(&sender_ced.value()), event.data.get(), event.length);
+        });
 
-            sockaddr_in6 addr_bind;
-            std::memset(&addr_bind, 0, sizeof(sockaddr_in6));
-            addr_bind.sin6_family = (discovery_mode_ == DISCOVERY_MODE_LAN) ? AF_INET : AF_INET6;
-            addr_bind.sin6_port = htons(static_cast<std::uint16_t>(port_));
+        bluetooth_queries_server_socket_->on<uvw::error_event>([](const uvw::error_event &event, uvw::udp_handle &handle) {
+            LOG_ERROR(SERVICE_BLUETOOTH, "Error on the Bluetooth queries socket! Libuv error code={}", event.code());
 
-            // Nothing else reports on this socket, so an unchecked failure here
-            // leaves the whole discovery side dead with nothing in the log.
-            if (const int bind_err = bluetooth_queries_server_socket_->bind(*reinterpret_cast<sockaddr*>(&addr_bind)); bind_err < 0) {
-                LOG_ERROR(SERVICE_BLUETOOTH, "Can't bind the Bluetooth queries socket to port {}! Libuv error code={}", port_, bind_err);
+            if (is_socket_dead_error(event.code())) {
+                handle.stop();
             }
+        });
 
-            if (should_upnp_apply_to_port()) {
-                UPnP::TryPortmapping(static_cast<std::uint16_t>(port_), true);
-            }
+        bluetooth_queries_server_socket_->recv();
+    }
 
-            bluetooth_queries_server_socket_->on<uvw::udp_data_event>([this](const uvw::udp_data_event &event, uvw::udp_handle &handle) {
-                std::optional<sockaddr_in6> sender_ced = libuv::from_ip_string(event.sender.ip.data(), event.sender.port);
-                if (!sender_ced.has_value()) {
-                    LOG_ERROR(SERVICE_BLUETOOTH, "Invalid sender address passed to callback!");
-                    return;
-                }
-                handle_queries_request(reinterpret_cast<sockaddr*>(&sender_ced.value()), event.data.get(), event.length);
-            });
+    // The asker is left out on purpose: closing it would strand a synchronous
+    // requester waiting on a completion that can no longer arrive.
+    void midman_inet::shutdown_discovery_sockets() {
+#ifdef __APPLE__
+        bonjour_.reset();
+#endif
+        shutdown_uv_handle(lan_discovery_call_listener_socket_);
+        shutdown_uv_handle(bluetooth_queries_server_socket_);
+        shutdown_uv_handle(matching_server_socket_);
+        matching_server_receive_buffer_.clear();
+    }
 
-            bluetooth_queries_server_socket_->on<uvw::error_event>([](const uvw::error_event &event, uvw::udp_handle &handle) {
-                LOG_ERROR(SERVICE_BLUETOOTH, "Error on the Bluetooth queries socket! Libuv error code={}", event.code());
-            });
+    // Keep the transition and all handle changes together on the loop thread.
+    void midman_inet::suspend() {
+        if ((discovery_mode_ == DISCOVERY_MODE_OFF) || !libuv::default_looper->started()) {
+            return;
+        }
 
-            bluetooth_queries_server_socket_->recv();
+        libuv::default_looper->one_shot([this]() {
+            if (suspended_) return;
+            suspended_ = true;
+            shutdown_discovery_sockets();
+        });
+    }
+
+    void midman_inet::resume() {
+        if ((discovery_mode_ == DISCOVERY_MODE_OFF) || !libuv::default_looper->started()) {
+            return;
+        }
+
+        libuv::default_looper->one_shot([this]() {
+            if (!suspended_) return;
+            suspended_ = false;
+            setup_discovery_sockets(false);
         });
     }
 
@@ -149,8 +206,6 @@ namespace eka2l1::epoc::bt {
             }
         }
 
-        send_logout(true);
-
         if (!libuv::default_looper->started()) {
             return;
         }
@@ -162,16 +217,12 @@ namespace eka2l1::epoc::bt {
         common::event teardown_done;
 
         libuv::default_looper->one_shot([this, &teardown_done]() {
+            send_logout();
             // The asker goes first: its retry timer completes requests through a callback
             // that reaches back into this object, which is already half torn down.
             device_addr_asker_.shutdown_handles();
 
-#ifdef __APPLE__
-            bonjour_.reset();
-#endif
-            shutdown_uv_handle(lan_discovery_call_listener_socket_);
-            shutdown_uv_handle(bluetooth_queries_server_socket_);
-            shutdown_uv_handle(matching_server_socket_);
+            shutdown_discovery_sockets();
             shutdown_uv_handle(hearing_timeout_timer_);
 
             teardown_done.set();
@@ -773,9 +824,15 @@ lookup:
                     broadcast_buf.push_back(static_cast<char>(password_.length()));
                     broadcast_buf.insert(broadcast_buf.end(), password_.begin(), password_.end());
 
+                    // uvw keeps one listener per event type, so this replaces the one
+                    // the socket was set up with and has to stop a dead socket too.
                     lan_discovery_call_listener_socket_->on<uvw::error_event>([](const uvw::error_event &event, uvw::udp_handle &handle) {
                         if (event.code() < 0) {
                             LOG_ERROR(SERVICE_BLUETOOTH, "Fail to send broadcast message to find nearby playable devices! Libuv error code={}", event.code());
+                        }
+
+                        if (is_socket_dead_error(event.code())) {
+                            handle.stop();
                         }
                     });
 

--- a/src/emu/services/src/bluetooth/protocols/btmidman_lan_matching.cpp
+++ b/src/emu/services/src/bluetooth/protocols/btmidman_lan_matching.cpp
@@ -96,30 +96,32 @@ namespace eka2l1::epoc::bt {
         local_addr_.port_ = static_cast<std::uint16_t>(LAN_DISCOVERY_PORT);
         lan_discovery_call_listener_socket_ = loop->resource<uvw::udp_handle>();
 
-        libuv::default_looper->one_shot([this]() {
-            sockaddr_in6 addr_bind;
-            std::memset(&addr_bind, 0, sizeof(sockaddr_in6));
-            addr_bind.sin6_family = AF_INET;
-            addr_bind.sin6_port = htons(static_cast<std::uint16_t>(LAN_DISCOVERY_PORT));
+        sockaddr_in6 addr_bind;
+        std::memset(&addr_bind, 0, sizeof(sockaddr_in6));
+        addr_bind.sin6_family = AF_INET;
+        addr_bind.sin6_port = htons(static_cast<std::uint16_t>(LAN_DISCOVERY_PORT));
 
-            if (const int bind_err = lan_discovery_call_listener_socket_->bind(*reinterpret_cast<sockaddr*>(&addr_bind)); bind_err < 0) {
-                LOG_ERROR(SERVICE_BLUETOOTH, "Can't bind the LAN discovery socket to port {}! Libuv error code={}", LAN_DISCOVERY_PORT, bind_err);
+        if (const int bind_err = lan_discovery_call_listener_socket_->bind(*reinterpret_cast<sockaddr*>(&addr_bind)); bind_err < 0) {
+            LOG_ERROR(SERVICE_BLUETOOTH, "Can't bind the LAN discovery socket to port {}! Libuv error code={}", LAN_DISCOVERY_PORT, bind_err);
+        }
+        lan_discovery_call_listener_socket_->on<uvw::error_event>([](const uvw::error_event &event, uvw::udp_handle &handle) {
+            LOG_ERROR(SERVICE_BLUETOOTH, "Error on the LAN discovery listener socket! Libuv error code={}", event.code());
+
+            if (is_socket_dead_error(event.code())) {
+                handle.stop();
             }
-            lan_discovery_call_listener_socket_->on<uvw::error_event>([](const uvw::error_event &event, uvw::udp_handle &handle) {
-                LOG_ERROR(SERVICE_BLUETOOTH, "Error on the LAN discovery listener socket! Libuv error code={}", event.code());
-            });
-
-            lan_discovery_call_listener_socket_->on<uvw::udp_data_event>([this](const uvw::udp_data_event &event, uvw::udp_handle &handle) {
-                std::optional<sockaddr_in6> sender_ced = libuv::from_ip_string(event.sender.ip.data(), event.sender.port);
-                if (!sender_ced.has_value()) {
-                    LOG_ERROR(SERVICE_BLUETOOTH, "Invalid sender address passed to callback!");
-                    return;
-                }
-                handle_lan_discovery_receive(event.data.get(), event.length, reinterpret_cast<sockaddr*>(&sender_ced.value()));
-            });
-
-            lan_discovery_call_listener_socket_->recv();
         });
+
+        lan_discovery_call_listener_socket_->on<uvw::udp_data_event>([this](const uvw::udp_data_event &event, uvw::udp_handle &handle) {
+            std::optional<sockaddr_in6> sender_ced = libuv::from_ip_string(event.sender.ip.data(), event.sender.port);
+            if (!sender_ced.has_value()) {
+                LOG_ERROR(SERVICE_BLUETOOTH, "Invalid sender address passed to callback!");
+                return;
+            }
+            handle_lan_discovery_receive(event.data.get(), event.length, reinterpret_cast<sockaddr*>(&sender_ced.value()));
+        });
+
+        lan_discovery_call_listener_socket_->recv();
 #endif
     }
 

--- a/src/emu/services/src/bluetooth/protocols/btmidman_proxserv_matching.cpp
+++ b/src/emu/services/src/bluetooth/protocols/btmidman_proxserv_matching.cpp
@@ -70,39 +70,26 @@ namespace eka2l1::epoc::bt {
         std::memcpy(&meta_server_addr, ideal_result_info->ai_addr, sizeof(sockaddr_in6));
         meta_server_addr.sin6_port = htons(CENTRAL_SERVER_STANDARD_PORT);
 
-        auto matching_server_socket_copy = matching_server_socket_;
+        sockaddr_in6 addr_temp{};
+        addr_temp.sin6_family = meta_server_addr.sin6_family;
+        matching_server_socket_->bind(*reinterpret_cast<sockaddr*>(&addr_temp));
 
-        libuv::default_looper->one_shot([matching_server_socket_copy, meta_server_addr, this]() {
-            auto matching_server_socket_copy_copy = matching_server_socket_copy;
-
-            sockaddr_in6 addr_temp;
-            std::memset(&addr_temp, 0, sizeof(sockaddr_in6));
-            addr_temp.sin6_family = meta_server_addr.sin6_family;
-
-            matching_server_socket_copy_copy->bind(*reinterpret_cast<sockaddr*>(&addr_temp));
-
-            matching_server_socket_copy_copy->on<uvw::error_event>([](const uvw::error_event &event, uvw::tcp_handle &handle) {
-                LOG_ERROR(SERVICE_BLUETOOTH, "Error on the central Bluetooth Netplay server socket! Libuv error code={}", event.code());
-            });
-
-            matching_server_socket_copy_copy->on<uvw::connect_event>([matching_server_socket_copy_copy, this](const uvw::connect_event &event, uvw::tcp_handle &handle) {
-                matching_server_socket_copy_copy->on<uvw::data_event>([this](const uvw::data_event &event, uvw::tcp_handle &handle) {
-                    handle_matching_server_msg(static_cast<std::int64_t>(event.length), event.data.get());
-                });
-
-                matching_server_socket_copy_copy->read();
-
-                // The server puts us in the room named by our password, so it has to
-                // hear the login before it can answer any player query.
-                send_login();
-            });
-
-            int err = matching_server_socket_copy_copy->connect(*reinterpret_cast<const sockaddr *>(&meta_server_addr));
-
-            if (err < 0) {
-                LOG_ERROR(SERVICE_BLUETOOTH, "Fail to connect to central Bluetooth Netplay server! Libuv's error code {}", err);
-            }
+        matching_server_socket_->on<uvw::error_event>([](const uvw::error_event &event, uvw::tcp_handle &handle) {
+            LOG_ERROR(SERVICE_BLUETOOTH, "Error on the central Bluetooth Netplay server socket! Libuv error code={}", event.code());
         });
+
+        matching_server_socket_->on<uvw::connect_event>([this](const uvw::connect_event &event, uvw::tcp_handle &handle) {
+            handle.on<uvw::data_event>([this](const uvw::data_event &event, uvw::tcp_handle &handle) {
+                handle_matching_server_msg(static_cast<std::int64_t>(event.length), event.data.get());
+            });
+            handle.read();
+            send_login();
+        });
+
+        const int err = matching_server_socket_->connect(*reinterpret_cast<const sockaddr *>(&meta_server_addr));
+        if (err < 0) {
+            LOG_ERROR(SERVICE_BLUETOOTH, "Fail to connect to central Bluetooth Netplay server! Libuv's error code {}", err);
+        }
 
         freeaddrinfo(result_info);
     }
@@ -124,7 +111,7 @@ namespace eka2l1::epoc::bt {
         }
     }
 
-    void midman_inet::send_logout(const bool close_and_reset) {
+    void midman_inet::send_logout() {
         if (!matching_server_socket_) {
             return;
         }
@@ -139,12 +126,6 @@ namespace eka2l1::epoc::bt {
 
         if (err < 0) {
             LOG_ERROR(SERVICE_BLUETOOTH, "Fail to send logout request to server! Libuv's error code {}", err);
-        }
-
-        if (close_and_reset) {
-            auto matching_server_socket_copy = matching_server_socket_;
-            libuv::default_looper->one_shot([matching_server_socket_copy]() {
-            });
         }
     }
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -33,11 +33,19 @@ add_test(
   WORKING_DIRECTORY $<TARGET_FILE_DIR:ekatests>
 )
 
+# Discovery owns the default libuv loop on a worker thread for this process.
+add_test(
+  NAME bluetooth_netplay
+  COMMAND ekatests "[.btinet]"
+  WORKING_DIRECTORY $<TARGET_FILE_DIR:ekatests>
+)
+set_tests_properties(bluetooth_netplay PROPERTIES TIMEOUT 30 RUN_SERIAL TRUE)
+
 if (WIN32)
     # SDL2 and the other runtime DLLs are copied next to the frontend, which is
     # not where the test executable is built, so the loader has to be told.
     file(TO_NATIVE_PATH "${CMAKE_BINARY_DIR}/bin" EKATESTS_RUNTIME_DLL_DIR)
-    set_tests_properties(ekatests PROPERTIES
+    set_tests_properties(ekatests bluetooth_netplay PROPERTIES
         ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:${EKATESTS_RUNTIME_DLL_DIR}")
 endif()
 

--- a/src/tests/epoc/CMakeLists.txt
+++ b/src/tests/epoc/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(CORE_TEST_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/services/bluetooth/bonjour.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/services/bluetooth/suspend.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/devices.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/drivers/audio.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/graphics/openvg.cpp

--- a/src/tests/epoc/services/bluetooth/suspend.cpp
+++ b/src/tests/epoc/services/bluetooth/suspend.cpp
@@ -1,0 +1,202 @@
+#include <catch2/catch.hpp>
+#include <services/bluetooth/protocols/btmidman_inet.h>
+#include <services/bluetooth/protocols/common_inet.h>
+
+#include <chrono>
+#include <future>
+#include <stdexcept>
+#include <thread>
+#include <type_traits>
+
+namespace {
+    using namespace eka2l1::epoc::bt;
+    using namespace std::chrono_literals;
+
+    template <typename F>
+    auto on_loop(F fn) {
+        using result_type = std::invoke_result_t<F>;
+        auto task = std::make_shared<std::packaged_task<result_type()>>(std::move(fn));
+        auto result = task->get_future();
+        libuv::default_looper->one_shot([task]() { (*task)(); });
+        if (result.wait_for(5s) != std::future_status::ready) {
+            throw std::runtime_error("Bluetooth loop did not respond");
+        }
+        return result.get();
+    }
+
+    template <typename F>
+    bool eventually(F fn) {
+        const auto deadline = std::chrono::steady_clock::now() + 5s;
+        do {
+            if (on_loop(fn)) return true;
+            std::this_thread::sleep_for(10ms);
+        } while (std::chrono::steady_clock::now() < deadline);
+        return false;
+    }
+
+    std::vector<std::shared_ptr<uvw::udp_handle>> udp_sockets() {
+        std::vector<std::shared_ptr<uvw::udp_handle>> sockets;
+        uv_walk(uv_default_loop(), [](uv_handle_t *handle, void *data) {
+            if (handle->type == UV_UDP && !uv_is_closing(handle)) {
+                auto &sockets = *static_cast<std::vector<std::shared_ptr<uvw::udp_handle>>*>(data);
+                sockets.push_back(static_cast<uvw::udp_handle*>(handle->data)->shared_from_this());
+            }
+        }, &sockets);
+        return sockets;
+    }
+
+    struct configuration : eka2l1::config::state {
+        explicit configuration(discovery_mode mode) {
+            btnet_discovery_mode = mode;
+            internet_bluetooth_port = 0;
+            enable_upnp = false;
+            bt_central_server_url = "::1";
+        }
+    };
+
+    void receive_error(uvw::udp_handle &socket, int error) {
+        const uv_buf_t buffer = uv_buf_init(nullptr, 0);
+        socket.raw()->recv_cb(socket.raw(), error, &buffer, nullptr, 0);
+    }
+
+    sockaddr_in6 loopback(unsigned int port) {
+        sockaddr_in6 address{};
+        uv_ip6_addr("::1", port, &address);
+        return address;
+    }
+
+    std::vector<char> query_address(unsigned int port) {
+        auto response = std::make_shared<std::promise<std::vector<char>>>();
+        auto result = response->get_future();
+        auto client = on_loop([=]() {
+            auto client = uvw::loop::get_default()->resource<uvw::udp_handle>();
+            const auto address = loopback(0);
+            client->bind(reinterpret_cast<const sockaddr&>(address));
+            client->on<uvw::udp_data_event>([response](const auto &event, auto &handle) {
+                handle.stop();
+                response->set_value({event.data.get(), event.data.get() + event.length});
+            });
+            client->recv();
+            // Four-byte opaque asker ID, then the virtual-address query opcode.
+            const char request[] = {1, 0, 0, 0, 1};
+            const auto destination = loopback(port);
+            client->send(reinterpret_cast<const sockaddr&>(destination),
+                copy_control_packet(request, sizeof(request)), sizeof(request));
+            return client;
+        });
+        const bool ready = result.wait_for(2s) == std::future_status::ready;
+        on_loop([&]() { shutdown_uv_handle(client); });
+        return ready ? result.get() : std::vector<char>{};
+    }
+
+    struct proxy_server {
+        std::shared_ptr<uvw::tcp_handle> listener;
+        std::vector<std::shared_ptr<uvw::tcp_handle>> peers;
+        unsigned int logins = 0;
+
+        proxy_server() {
+            if (!libuv::default_looper->started()) libuv::default_looper->start();
+            on_loop([this]() {
+                listener = uvw::loop::get_default()->resource<uvw::tcp_handle>();
+                const auto address = loopback(CENTRAL_SERVER_STANDARD_PORT);
+                if (listener->bind(reinterpret_cast<const sockaddr&>(address)) < 0 || listener->listen() < 0) {
+                    shutdown_uv_handle(listener);
+                    throw std::runtime_error("Test proxy port is unavailable");
+                }
+                listener->on<uvw::listen_event>([this](const auto &, auto &server) {
+                    auto peer = server.parent().template resource<uvw::tcp_handle>();
+                    server.accept(*peer);
+                    peer->template on<uvw::data_event>([this](const auto &event, auto &) {
+                        if (event.length >= 2 && event.data[0] == 9) ++logins;
+                    });
+                    peer->read();
+                    peers.push_back(peer);
+                });
+            });
+        }
+
+        ~proxy_server() {
+            on_loop([this]() {
+                for (auto &peer : peers) shutdown_uv_handle(peer);
+                shutdown_uv_handle(listener);
+            });
+        }
+
+        // Inject at uvw's receive boundary so the half-packet is processed before suspension.
+        void deliver(std::vector<char> bytes) {
+            on_loop([&]() {
+                uv_walk(uv_default_loop(), [](uv_handle_t *handle, void *data) {
+                    if (handle->type != UV_TCP || uv_is_closing(handle)) return;
+                    sockaddr_in6 peer{};
+                    int size = sizeof(peer);
+                    if (uv_tcp_getpeername(reinterpret_cast<uv_tcp_t*>(handle),
+                            reinterpret_cast<sockaddr*>(&peer), &size) != 0 ||
+                        ntohs(peer.sin6_port) != CENTRAL_SERVER_STANDARD_PORT) return;
+                    auto &bytes = *static_cast<std::vector<char>*>(data);
+                    auto *stream = reinterpret_cast<uv_stream_t*>(handle);
+                    const uv_buf_t buffer = uv_buf_init(copy_control_packet(bytes.data(), bytes.size()).release(),
+                        static_cast<unsigned int>(bytes.size()));
+                    stream->read_cb(stream, bytes.size(), &buffer);
+                }, &bytes);
+            });
+        }
+    };
+
+    struct observer : inet_stranger_call_observer {
+        std::vector<eka2l1::epoc::socket::saddress> found;
+        unsigned int completions = 0;
+        void on_stranger_call(eka2l1::epoc::socket::saddress &address, std::uint32_t) override {
+            found.push_back(address);
+        }
+        void on_no_more_strangers() override { ++completions; }
+    };
+}
+
+TEST_CASE("Bluetooth discovery survives transient UDP errors and rebuilds dead sockets", "[.btinet]") {
+    midman_inet midman{configuration{DISCOVERY_MODE_DIRECT_IP}};
+    auto sockets = on_loop(udp_sockets);
+    REQUIRE(sockets.size() == 1);
+    auto socket = sockets.front();
+    for (const int error : {UV_ENETDOWN, UV_EINVAL}) {
+        on_loop([&]() { receive_error(*socket, error); });
+        REQUIRE(on_loop([&]() { return socket->active(); }));
+        const auto response = query_address(on_loop([&]() { return socket->sock().port; }));
+        REQUIRE(response.size() == 5 + sizeof(device_address));
+        CHECK(response[4] == 101);
+    }
+
+    on_loop([&]() { receive_error(*socket, UV_ENOTCONN); });
+    CHECK_FALSE(on_loop([&]() { return socket->active(); }));
+    for (int cycle = 0; cycle < 10; ++cycle) {
+        midman.suspend();
+        midman.suspend();
+        REQUIRE(on_loop(udp_sockets).empty());
+        midman.resume();
+        midman.resume();
+        REQUIRE(on_loop(udp_sockets).size() == 1);
+    }
+    sockets = on_loop(udp_sockets);
+    const auto response = query_address(on_loop([&]() { return sockets.front()->sock().port; }));
+    REQUIRE(response.size() == 5 + sizeof(device_address));
+}
+
+TEST_CASE("Bluetooth proxy reconnect discards a partial reply from the old connection", "[.btinet]") {
+    proxy_server proxy;
+    observer search;
+    midman_inet midman{configuration{DISCOVERY_MODE_PROXY_SERVER}};
+    REQUIRE(eventually([&]() { return proxy.logins == 1; }));
+    // Player-list reply: one IPv4 endpoint with explicit port, interrupted mid-address.
+    proxy.deliver({5, 1, 2, 127});
+    midman.suspend();
+    midman.resume();
+    REQUIRE(eventually([&]() { return proxy.logins == 2; }));
+    midman.begin_hearing_stranger_call(&search);
+    proxy.deliver({5, 1, 2, 127, 0, 0, 1, 0x12, 0x34});
+    const auto found = on_loop([&]() { return search.found; });
+    REQUIRE(found.size() == 1);
+    CHECK(found[0].port_ == 0x1234);
+    const auto &address = reinterpret_cast<const eka2l1::epoc::internet::sinet6_address&>(found[0]);
+    CHECK(address.get_address_32x4()[3] == htonl(0x7F000001));
+    CHECK(on_loop([&]() { return search.completions; }) == 1);
+    midman.unregister_stranger_call_observer(&search);
+}


### PR DESCRIPTION
## Problem

After iOS suspends the host process, a defunct Bluetooth discovery socket can repeatedly return `UV_ENOTCONN`. Libuv leaves UDP reception armed after reporting the error, so merely logging it produces a busy loop and can fill the log with gigabytes of repeated errors while starving emulation.

## Changes

- Stop reception on invalid sockets. The asker marks a dead socket for replacement on its next request. Keep `ENETDOWN` and per-operation `EINVAL` out of this classification: uvw shares one error listener between sends and receives, and a temporary interface outage must not permanently disable discovery.
- Add host suspension notifications to the midman. iOS reports `.background` and `.active`; a transient `.inactive` leaves discovery intact.
- Record the desired host state and apply each transition from the control queue. Main never waits for the session lock, which can be held by a boot waiting for graphics work that dispatches synchronously to main. The bridge owns the mutex so a queued callback can safely check for a state removed by shutdown; newly booted systems inherit the current host state.
- Keep discovery setup, suspension and logout on the libuv thread. LAN and proxy setup finish in the same task, preventing a nested setup callback from running after suspension or teardown. Clear TCP reassembly when closing the proxy connection, so a new connection cannot complete an old partial reply.
- Preserve the outstanding search timeout and asker completion path across suspension.

The iOS version remains 26.9.1 (260952), as in the original PR.

## Validation

- Release simulator build succeeds, including an independent worktree based on this PR's upstream base.
- The isolated `bluetooth_netplay` CTest passes on the PR branch: 35 assertions in two cases. It checks real loopback UDP replies after transient errors, dead-socket shutdown, repeated suspend/resume, and the peer address/port parsed after proxy reconnection.
- The iOS regression suite passed 12/12 on both the fork and the independently built PR branch: Final Battle, Calculator, N95 Calculator and string catalog. Screenshots were inspected.
- Manual validation was also confirmed by the requester.

Each reviewed fix was removed independently and the affected code rebuilt:

| Correction removed | Observed failure |
| --- | --- |
| Asynchronous bridge dispatch | Holding the session mutex on another thread blocks the lifecycle calls for the holder's five-second safety timeout; with dispatch, they return in about 12 microseconds. |
| Nonfatal classification for `ENETDOWN` / `EINVAL` | The UDP listener stops after the injected interface error. |
| Clearing the proxy receive buffer | The new response is parsed with port 32512 instead of 4660 and the wrong IP address. |

Socket errors and TCP fragmentation are injected at libuv's receive boundary into the production listeners. These tests do not claim to reproduce iOS's kernel-only defunct-socket state on the simulator.
