### PR TITLE
fix(qt): stop indexing touch points by pointer slot

### DIFF
--- a/src/emu/qt/src/displaywidget.cpp
+++ b/src/emu/qt/src/displaywidget.cpp
@@ -244,13 +244,17 @@ bool display_widget::event(QEvent *event) {
 
         const qreal pixel_ratio = devicePixelRatioF();
 
-        for (std::size_t i = 0; i < active_pointers_.size(); i++) {
-            if (active_pointers_[i] == 0) {
-                active_pointers_[i] = points[i].id() + 1;
-                raw_mouse_event(userdata_, eka2l1::vec3(static_cast<int>(points[i].pos().x() * pixel_ratio),
-                    static_cast<int>(points[i].pos().y() * pixel_ratio),
-                    static_cast<int>(points[i].pressure() * eka2l1::PRESSURE_MAX_NUM)),
-                    0, 0, static_cast<int>(i));
+        for (std::size_t i = 0; i < static_cast<std::size_t>(points.size()); i++) {
+            for (std::size_t j = 0; j < active_pointers_.size(); j++) {
+                if (active_pointers_[j] == 0) {
+                    active_pointers_[j] = points[i].id() + 1;
+                    raw_mouse_event(userdata_, eka2l1::vec3(static_cast<int>(points[i].pos().x() * pixel_ratio),
+                        static_cast<int>(points[i].pos().y() * pixel_ratio),
+                        static_cast<int>(points[i].pressure() * eka2l1::PRESSURE_MAX_NUM)),
+                        0, 0, static_cast<int>(j));
+
+                    break;
+                }
             }
         }
 
@@ -286,12 +290,18 @@ bool display_widget::event(QEvent *event) {
                             static_cast<int>(points[i].pos().y() * pixel_ratio),
                             static_cast<int>(points[i].pressure() * eka2l1::PRESSURE_MAX_NUM)),
                             0, 0, static_cast<int>(j));
+
+                        break;
                     }
                 }
             }
         }
 
         for (std::size_t i = 0; i < active_pointers_.size(); i++) {
+            if (active_pointers_[i] == 0) {
+                continue;
+            }
+
             bool found = false;
             for (std::size_t j = 0; j < points.size(); j++) {
                 if (active_pointers_[i] == (points[j].id() + 1)) {


### PR DESCRIPTION
Any touch event delivered to the render widget can take the emulator down. Two crash reports collected on a MacBook (macOS 26.6.1, arm64, 0.0.4.2) — one per trackpad contact, seconds apart — share the same stack:

```
AppKit    _routeTouchEvent
QtGui     QWindowSystemInterface::handleTouchEvent
QtWidgets QApplicationPrivate::translateRawTouchEvent
EKA2L1    display_widget::event(QEvent*)  + 1564
QtGui     QEventPoint::id()                        <- EXC_BAD_ACCESS
```

The faulting instruction is `LDR W0, [X8, #0xD8]`, with `X8` loaded from the `QEventPoint` itself. The two faulting addresses are `0xffff97178dfa22cf` and `0x425355206e69782c`; the latter is the ASCII text `,xin USB`. macOS labels that "possible pointer authentication failure", but it is simply random heap memory being read as a `QEventPoint`.

## Cause

`TouchBegin` bounded its loop by `active_pointers_` (`MAX_SYMBIAN_SUPPORTED_POINTERS`, 8 slots) and indexed `points` with the same counter:

```cpp
for (std::size_t i = 0; i < active_pointers_.size(); i++) {
    if (active_pointers_[i] == 0) {
        active_pointers_[i] = points[i].id() + 1;   // points usually holds one item
```

A trackpad `TouchBegin` carries one or two points, and every slot is free at that moment, so iteration 1 already reads past the end of the list. Any Mac with a trackpad hits this the moment a finger lands on the widget; a mouse-only setup never does, which is why it survived this long. Touchscreen desktops and any other platform delivering real touch events are equally affected.

## Changes

* `TouchBegin` now walks the points and takes a free slot for each, the way `TouchUpdate` does.
* `TouchUpdate`'s "find a free slot" loop breaks once it has claimed one. Without it, a single new point took every free slot and reported itself once per slot.
* The release loop skips slots that hold no pointer. Without that guard every update released all unused slots. `TouchEnd` already guarded this way.

## Verification

A harness links `displaywidget.cpp` on its own and feeds synthetic `QTouchEvent`s to `display_widget::event`: a one-point `TouchBegin`, then a `TouchUpdate` holding that point plus a new one, then `TouchEnd`. Reverting each change alone:

| state | TouchBegin (1 point) | TouchUpdate (2 points, 1 new) | TouchEnd |
| --- | --- | --- | --- |
| all three applied | 1 press | 1 move, 1 press | 2 releases |
| `TouchBegin` bounds reverted | **SIGSEGV** | — | — |
| `TouchUpdate` break reverted | 1 press | 1 move, **7 presses** (slots 1-7) | **8 releases** |
| release-loop guard reverted | 1 press | 1 move, 1 press, **6 stray releases** (slots 2-7) | 2 releases |

The Qt frontend was also rebuilt and run on macOS afterwards; a guest title boots and takes input as before.
