### PR TITLE
fix(kernel): Key ROM rebasing on the ROM base rather than the OS version (fixes #685) - #686

### DIFF
--- a/src/emu/kernel/src/kernel.cpp
+++ b/src/emu/kernel/src/kernel.cpp
@@ -1381,7 +1381,7 @@ namespace eka2l1 {
         mem::vm_address chunk_base = addr;
         std::size_t rebase_offset = 0;
 
-        if ((kern_ver_ == epocver::epoc91) && (mem_->get_model_type() == mem::mem_model_type::multiple)) {
+        if (mem_->get_model_type() == mem::mem_model_type::multiple) {
             chunk_base = addr & ~mem_->get_control()->chunk_mask_;
             rebase_offset = addr - chunk_base;
         }


### PR DESCRIPTION
The Nokia 5500 Sport ROM declares base 0xF80F1000, which is not chunk aligned. The multiple model can only place a chunk on a chunk-span boundary and aligns a forced address down, so such a ROM has to be mapped at its in-chunk offset inside a buffer starting at the aligned base.

https://github.com/EKA2L1/EKA2L1/commit/3206f543029931abf1aeb53a06e18f9862fd2756 tied that rebasing to epocver::epoc91 along with the rest of the 9.1 compatibility work. The version comes from devices.yml, which is written once when the device is installed and never revisited afterwards. The same commit also changed how it is detected: the 5500 ships no platform.txt, so detection falls back to scanning series60v*.sis, and series60v3.0.sis resolved to epoc93fp1 before the epoc91 tier existed. Devices installed before that commit therefore carry epoc93fp1, miss the gate, and get their ROM mapped 0xF1000 too low. Every guest-to-host translation inside the ROM comes out shifted, image headers decode as garbage, and the loader segfaults copying from a null pointer with a nonsense length.

Whether a ROM needs rebasing is a property of its base address, not of the OS version it carries, so key the condition on the memory model and the address alone. An aligned base leaves rebase_offset at zero and takes the file-mapping path below unchanged.

This stops the crash but not its cause: a device whose platver predates https://github.com/EKA2L1/EKA2L1/commit/3206f543029931abf1aeb53a06e18f9862fd2756 still misses the 9.1 ABI paths, and needs its devices.yml entry corrected or the device reinstalled.

Verified on the 5500 under both platver values, neither of which crashes now; with epoc91 the emulator boots and enumerates the ROM app list. The same run maps the four other installed devices (RM-320, RM-356, RAE-6, RH-29) at their declared bases, unchanged.

---

This is cleaner version of #686