### PR TITLE
Cap the log file at a line budget and drop its oldest lines

### DIFF
--- a/src/emu/common/include/common/log.h
+++ b/src/emu/common/include/common/log.h
@@ -78,6 +78,17 @@ namespace eka2l1 {
         void setup_log(std::shared_ptr<base_logger> extra_logger);
         void toggle_console();
         bool is_console_enabled();
+
+        /**
+         * \brief Make the log file sink, which drops its oldest lines once it holds
+         *        max_lines of them.
+         *
+         * The budget stands in for a size cap: log lines measure 110-160 bytes, so the
+         * default keeps the file near 100 MB.
+         */
+        std::shared_ptr<spdlog::sinks::sink> make_capped_file_sink(const std::string &filename, const std::size_t max_lines);
+
+        static constexpr std::size_t LOG_FILE_MAX_LINES = 640000;
     }
 }
 

--- a/src/emu/common/src/log.cpp
+++ b/src/emu/common/src/log.cpp
@@ -24,8 +24,13 @@
 
 #include <spdlog/spdlog.h>
 
+#include <algorithm>
+#include <cstdio>
+#include <fstream>
 #include <iostream>
 #include <memory>
+#include <string>
+#include <vector>
 
 #ifdef _MSC_VER
 #include <spdlog/sinks/msvc_sink.h>
@@ -33,6 +38,7 @@
 #include "spdlog/sinks/android_sink.h"
 #endif
 
+#include <spdlog/details/file_helper.h>
 #include <spdlog/sinks/base_sink.h>
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
@@ -166,6 +172,131 @@ namespace eka2l1 {
 
         bool console_shown = false;
 
+        // A file sink that stays within a line budget. Once the budget is reached the
+        // oldest half of the file is dropped: the newest lines are the ones worth
+        // keeping, and halving makes the rewrite rare enough not to matter.
+        class capped_file_sink final : public spdlog::sinks::base_sink<std::mutex> {
+        public:
+            capped_file_sink(const std::string &filename, const std::size_t max_lines)
+                : filename_(filename)
+                , max_lines_(max_lines) {
+                file_.open(filename_, true);
+            }
+
+            ~capped_file_sink() override {
+                file_.close();
+            }
+
+        protected:
+            void sink_it_(const spdlog::details::log_msg &msg) override {
+                spdlog::memory_buf_t formatted;
+                base_sink<std::mutex>::formatter_->format(msg, formatted);
+
+                file_.write(formatted);
+                lines_ += static_cast<std::size_t>(std::count(formatted.begin(), formatted.end(), '\n'));
+
+                if (lines_ >= max_lines_) {
+                    drop_oldest_lines();
+                }
+            }
+
+            void flush_() override {
+                file_.flush();
+            }
+
+        private:
+            std::string trim_notice(const std::size_t dropped_total) const {
+                return "--- log trimmed: " + std::to_string(dropped_total) + " oldest lines dropped so far ---\n";
+            }
+
+            void drop_oldest_lines() {
+                const std::string trimmed_path = filename_ + ".trim";
+
+                std::size_t dropped = lines_;
+                std::size_t kept_lines = 0;
+                bool rewritten = false;
+
+                file_.flush();
+                file_.close();
+
+                {
+                    std::ifstream source(filename_, std::ios::binary);
+
+                    if (source) {
+                        // Counting the dropped lines off rather than seeking to the middle
+                        // of the file keeps the budget exact whatever the lines measure.
+                        const std::size_t to_drop = (lines_ / 2) + 1;
+
+                        std::size_t skipped = 0;
+                        std::string line;
+
+                        while ((skipped < to_drop) && std::getline(source, line)) {
+                            skipped++;
+                        }
+
+                        std::ofstream kept(trimmed_path, std::ios::binary | std::ios::trunc);
+
+                        if (kept) {
+                            const std::string notice = trim_notice(dropped_ + skipped);
+                            kept.write(notice.data(), static_cast<std::streamsize>(notice.size()));
+                            kept_lines = 1;
+
+                            std::vector<char> buffer(64 * 1024);
+
+                            while (source) {
+                                source.read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+
+                                const std::streamsize read_size = source.gcount();
+                                if (read_size <= 0) {
+                                    break;
+                                }
+
+                                kept.write(buffer.data(), read_size);
+                                kept_lines += static_cast<std::size_t>(std::count(buffer.data(), buffer.data() + read_size, '\n'));
+                            }
+
+                            rewritten = kept.good();
+                            dropped = skipped;
+                        }
+                    }
+                }
+
+                dropped_ += dropped;
+
+                if (rewritten) {
+                    std::remove(filename_.c_str());
+                    std::rename(trimmed_path.c_str(), filename_.c_str());
+
+                    file_.open(filename_, false);
+                    lines_ = kept_lines;
+
+                    return;
+                }
+
+                // The rewrite failed, but the budget still has to hold: start the file
+                // over rather than let it grow.
+                std::remove(trimmed_path.c_str());
+                file_.open(filename_, true);
+
+                const std::string notice = trim_notice(dropped_);
+                spdlog::memory_buf_t notice_buf;
+                notice_buf.append(notice.data(), notice.data() + notice.size());
+
+                file_.write(notice_buf);
+                lines_ = 1;
+            }
+
+            spdlog::details::file_helper file_;
+            std::string filename_;
+            std::size_t max_lines_;
+            std::size_t lines_ = 0;
+            std::size_t dropped_ = 0;
+        };
+
+        std::shared_ptr<spdlog::sinks::sink> make_capped_file_sink(const std::string &filename, const std::size_t max_lines) {
+            return std::make_shared<capped_file_sink>(filename, max_lines);
+        }
+
         struct imgui_logger_sink : public spdlog::sinks::base_sink<std::mutex> {
             explicit imgui_logger_sink(std::shared_ptr<base_logger> _logger)
                 : logger(_logger.get()) {}
@@ -215,7 +346,7 @@ namespace eka2l1 {
             color_dist_sink = std::make_shared<spdlog::sinks::dist_sink_mt>();
 
             sinks.push_back(color_dist_sink);
-            sinks.push_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>(log_file_name));
+            sinks.push_back(make_capped_file_sink(log_file_name, LOG_FILE_MAX_LINES));
 
 #ifdef _MSC_VER
             sinks.push_back(std::make_shared<spdlog::sinks::msvc_sink_st>());

--- a/src/tests/common/CMakeLists.txt
+++ b/src/tests/common/CMakeLists.txt
@@ -9,6 +9,7 @@ set(COMMON_TEST_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/flate.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ini.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/linked.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/logsink.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/paint.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/path.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/pystr.cpp

--- a/src/tests/common/logsink.cpp
+++ b/src/tests/common/logsink.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026 EKA2L1 Team.
+ *
+ * This file is part of EKA2L1 project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch.hpp>
+
+#include <common/log.h>
+
+#include <cstdio>
+#include <fstream>
+#include <string>
+#include <vector>
+
+using namespace eka2l1;
+
+namespace {
+    std::vector<std::string> read_lines(const std::string &path) {
+        std::vector<std::string> lines;
+        std::ifstream stream(path, std::ios::binary);
+        std::string line;
+
+        while (std::getline(stream, line)) {
+            lines.push_back(line);
+        }
+
+        return lines;
+    }
+
+    std::shared_ptr<spdlog::logger> make_logger(const std::string &path, const std::size_t max_lines) {
+        auto logger = std::make_shared<spdlog::logger>(path, log::make_capped_file_sink(path, max_lines));
+        logger->set_pattern("%v");
+        logger->set_level(spdlog::level::trace);
+        logger->flush_on(spdlog::level::trace);
+
+        return logger;
+    }
+}
+
+TEST_CASE("capped_log_sink_keeps_the_newest_lines_within_its_budget", "log_sink") {
+    const std::string path = "capped_log_budget.log";
+    const std::size_t max_lines = 100;
+
+    {
+        auto logger = make_logger(path, max_lines);
+
+        for (int i = 0; i < 1000; i++) {
+            logger->info("line {}", i);
+        }
+    }
+
+    const std::vector<std::string> lines = read_lines(path);
+    std::remove(path.c_str());
+
+    REQUIRE(!lines.empty());
+    REQUIRE(lines.size() <= max_lines);
+
+    // The tail is the part worth keeping, and it must survive intact.
+    REQUIRE(lines.back() == "line 999");
+
+    for (std::size_t i = 1; i + 1 < lines.size(); i++) {
+        const int previous = std::stoi(lines[i].substr(5));
+        const int current = std::stoi(lines[i + 1].substr(5));
+
+        REQUIRE(current == previous + 1);
+    }
+}
+
+TEST_CASE("capped_log_sink_reports_how_many_lines_it_dropped", "log_sink") {
+    const std::string path = "capped_log_notice.log";
+    const std::size_t max_lines = 100;
+    const int written = 1000;
+
+    {
+        auto logger = make_logger(path, max_lines);
+
+        for (int i = 0; i < written; i++) {
+            logger->info("line {}", i);
+        }
+    }
+
+    const std::vector<std::string> lines = read_lines(path);
+    std::remove(path.c_str());
+
+    REQUIRE(lines.size() >= 2);
+    REQUIRE(lines.front().rfind("--- log trimmed: ", 0) == 0);
+
+    const std::size_t dropped = std::stoul(lines.front().substr(std::string("--- log trimmed: ").size()));
+    const std::size_t first_surviving = static_cast<std::size_t>(std::stoi(lines[1].substr(5)));
+
+    // Every log line missing from the head is accounted for. The count also covers the
+    // notice each earlier trim left behind, which the next trim drops in turn.
+    const std::size_t trims_at_most = (static_cast<std::size_t>(written) / (max_lines / 2)) + 1;
+
+    REQUIRE(dropped >= first_surviving);
+    REQUIRE(dropped <= first_surviving + trims_at_most);
+}
+
+TEST_CASE("capped_log_sink_survives_a_budget_of_one_line", "log_sink") {
+    const std::string path = "capped_log_minimum.log";
+
+    {
+        auto logger = make_logger(path, 1);
+
+        for (int i = 0; i < 20; i++) {
+            logger->info("line {}", i);
+        }
+    }
+
+    const std::vector<std::string> lines = read_lines(path);
+    std::remove(path.c_str());
+
+    REQUIRE(!lines.empty());
+    REQUIRE(lines.size() <= 3);
+    REQUIRE(lines.front().rfind("--- log trimmed: ", 0) == 0);
+}


### PR DESCRIPTION
## Problem

The log file has no bound at all. A trace-level filter on an emulator sitting in a
guest busy-wait wrote **37 GB in twenty minutes** here and came close to filling
the host disk. Nothing about that file was useful either: when a log is that large
the only part anyone reads is the tail.

## What this does

The file sink now keeps a **line budget** rather than growing forever. Log lines
measure 110-160 bytes across real captures, so 640000 lines stands in for roughly
100 MB without having to track sizes, and the cap only has to be approximate.

When the budget is reached the sink drops the oldest half of the lines and rewrites
what is left. Halving makes the rewrite rare enough that the copy does not matter,
and cutting by line count rather than by byte offset keeps the budget exact whatever
the lines happen to measure. The file always resumes on a message boundary.

The first line of a trimmed file says how many lines have been dropped from it so
far, so a reader is never left guessing whether the file starts at the beginning of
the run:

```
--- log trimmed: 182080569 oldest lines dropped so far ---
T .../kernel/src/libmanager.cpp:1178 [Kernel]: Calling SVC 0x4c session_send_sync
```

A failed rewrite starts the file over instead of letting it grow: the budget has to
hold either way.

## Verification

Reproducing the original flood — `log-filter: "*:trace"` with the emulator parked in
a guest busy-wait — and sampling the file every 30 seconds for five minutes:

```
23:33:55  size=52027352   --- log trimmed: 21440067 oldest lines dropped so far ---
23:34:56  size=65759504   --- log trimmed: 51840162 oldest lines dropped so far ---
23:35:57  size=55407443   --- log trimmed: 82560258 oldest lines dropped so far ---
23:37:29  size=54403040   --- log trimmed: 128960403 oldest lines dropped so far ---
23:38:00  size=77502148   --- log trimmed: 144320451 oldest lines dropped so far ---
23:38:30  size=50835864   --- log trimmed: 160000500 oldest lines dropped so far ---
```

The file oscillates between 40 and 78 MB and never grows past that; the same five
minutes previously produced about 17 GB. Measured 124 bytes a line over that
capture, which puts the full budget at 79 MB.

Three unit tests cover it: the budget holds and the surviving tail stays contiguous,
the dropped count in the notice accounts for the lines that are gone, and a budget
of a single line does not run away. `ekatests`: 223 listed, 223 run, all passed.
