### PR TITLE
Fix the Windows build: line endings in the log trim notice and its test

### DIFF
--- a/src/emu/common/src/log.cpp
+++ b/src/emu/common/src/log.cpp
@@ -39,6 +39,7 @@
 #endif
 
 #include <spdlog/details/file_helper.h>
+#include <spdlog/details/os.h>
 #include <spdlog/sinks/base_sink.h>
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
@@ -206,7 +207,9 @@ namespace eka2l1 {
 
         private:
             std::string trim_notice(const std::size_t dropped_total) const {
-                return "--- log trimmed: " + std::to_string(dropped_total) + " oldest lines dropped so far ---\n";
+                // The rest of the file ends its lines the way spdlog does, so this one has to too.
+                return "--- log trimmed: " + std::to_string(dropped_total) + " oldest lines dropped so far ---"
+                    + spdlog::details::os::default_eol;
             }
 
             void drop_oldest_lines() {

--- a/src/tests/common/logsink.cpp
+++ b/src/tests/common/logsink.cpp
@@ -35,6 +35,11 @@ namespace {
         std::string line;
 
         while (std::getline(stream, line)) {
+            // The file is read as binary, so a Windows line ending keeps its carriage return.
+            if (!line.empty() && (line.back() == '\r')) {
+                line.pop_back();
+            }
+
             lines.push_back(line);
         }
 


### PR DESCRIPTION
Follow-up to #696, which left `build-desktop (windows-latest)` red.

## The test

`capped_log_sink_keeps_the_newest_lines_within_its_budget` reads the log file back
as binary and compares whole lines, so on Windows the CRLF ending stays in the
string and `"line 999\r" != "line 999"`. It strips the carriage return now.

```
D:\a\EKA2L1\EKA2L1\src\tests\common\logsink.cpp(73): FAILED:
  REQUIRE( lines.back() == "line 999" )
with expansion:
  "line 999
" == "line 999"
```

## The sink

The same defect was real in the product, just invisible to an assertion: the notice
that a trim writes as the first line ended in a bare `"\n"` while spdlog ends every
other line with `SPDLOG_EOL`, so a trimmed log on Windows mixed both endings. It
uses `spdlog::details::os::default_eol` now.

`ekatests` locally: 224 listed, 224 run, all passed.
