### PR TITLE
fix(sensor): return array info when the client asks without an array index

### DIFF
--- a/src/emu/drivers/src/sensor/backend/android/sensor_android.cpp
+++ b/src/emu/drivers/src/sensor/backend/android/sensor_android.cpp
@@ -118,11 +118,13 @@ namespace eka2l1::drivers {
 
         switch (prop) {
             case SENSOR_PROPERTY_SAMPLE_RATE:
-                if (array_index == -2) {
-                    data.set_as_array_status(sensor_property_data::DATA_TYPE_INT, SAMPLING_RATE_MAX_OPTION - 1,
+                // A client that has not picked an element yet queries with
+                // ESensrvSingleProperty and expects the array info back.
+                if (array_index < 0) {
+                    data.set_as_array_status(sensor_property_data::DATA_TYPE_INT, SAMPLING_RATE_MAX_OPTION,
                                              active_sampling_rate_);
                 } else {
-                    if ((array_index >= SAMPLING_RATE_MAX_OPTION) || (array_index < 0)) {
+                    if (array_index >= SAMPLING_RATE_MAX_OPTION) {
                         LOG_ERROR(SERVICE_SENSOR, "Trying to get out-of-bound sample rate!");
                         return false;
                     }
@@ -163,11 +165,13 @@ namespace eka2l1::drivers {
                     break;
 
                 case SENSOR_PROPERTY_MEASURE_RANGE:
-                    if (array_index == -2) {
-                        data.set_as_array_status(sensor_property_data::DATA_TYPE_DOUBLE, ACCELEROMETER_MEASURE_RANGE_MAX_OPTION - 1,
+                    // Array info carries the index range, so it is an int
+                    // property even though the elements are real values.
+                    if (array_index < 0) {
+                        data.set_as_array_status(sensor_property_data::DATA_TYPE_INT, ACCELEROMETER_MEASURE_RANGE_MAX_OPTION,
                                                  active_accel_measure_range_);
                     } else {
-                        if ((array_index >= ACCELEROMETER_MEASURE_RANGE_MAX_OPTION) || (array_index < 0)) {
+                        if (array_index >= ACCELEROMETER_MEASURE_RANGE_MAX_OPTION) {
                             LOG_ERROR(SERVICE_SENSOR, "Trying to get out-of-bound measure range!");
                             return false;
                         }

--- a/src/emu/drivers/src/sensor/backend/ios/sensor_ios.mm
+++ b/src/emu/drivers/src/sensor/backend/ios/sensor_ios.mm
@@ -108,11 +108,13 @@ namespace eka2l1::drivers {
 
         switch (prop) {
         case SENSOR_PROPERTY_SAMPLE_RATE:
-            if (array_index == SENSOR_PROPERTY_ARRAY) {
-                data.set_as_array_status(sensor_property_data::DATA_TYPE_INT, SAMPLING_RATE_MAX_OPTION - 1,
+            // A client that has not picked an element yet queries with
+            // ESensrvSingleProperty and expects the array info back.
+            if (array_index < 0) {
+                data.set_as_array_status(sensor_property_data::DATA_TYPE_INT, SAMPLING_RATE_MAX_OPTION,
                     active_sampling_rate_);
             } else {
-                if ((array_index >= SAMPLING_RATE_MAX_OPTION) || (array_index < 0)) {
+                if (array_index >= SAMPLING_RATE_MAX_OPTION) {
                     LOG_ERROR(SERVICE_SENSOR, "Trying to get out-of-bound sample rate!");
                     return false;
                 }
@@ -140,11 +142,13 @@ namespace eka2l1::drivers {
             break;
 
         case SENSOR_PROPERTY_MEASURE_RANGE:
-            if (array_index == SENSOR_PROPERTY_ARRAY) {
-                data.set_as_array_status(sensor_property_data::DATA_TYPE_DOUBLE, ACCELEROMETER_MEASURE_RANGE_MAX_OPTION - 1,
+            // Array info carries the index range, so it is an int property
+            // even though the elements themselves are real values.
+            if (array_index < 0) {
+                data.set_as_array_status(sensor_property_data::DATA_TYPE_INT, ACCELEROMETER_MEASURE_RANGE_MAX_OPTION,
                     active_accel_measure_range_);
             } else {
-                if ((array_index >= ACCELEROMETER_MEASURE_RANGE_MAX_OPTION) || (array_index < 0)) {
+                if (array_index >= ACCELEROMETER_MEASURE_RANGE_MAX_OPTION) {
                     LOG_ERROR(SERVICE_SENSOR, "Trying to get out-of-bound measure range!");
                     return false;
                 }


### PR DESCRIPTION
Fixes https://github.com/EKA2L1/EKA2L1/issues/698

## Symptom

A Qt app using `QAccelerometer` dies with `KERN-EXEC 3` inside `qtsensors_sym.dll` a moment after the first sensor sample arrives. Reproduced with **iBomber Defence** on an **RM-707 (Symbian Anna)** ROM:

```
E [Kernel]: Access violation reading address 0x4D000004 in thread iBomber Defence
T [Kernel]: Last instruction: .byte 0x40, 0x68 (0xf7fe6840)      ; ldr r0, [r0, #4]
T [CPU]: pc: 0x70cf3252   ; qtsensors_sym.dll + 0x2252
T [CPU]: r0: 0x4d000000
T [Kernel]: Thread iBomber Defence terminated peacefully with category: KERN-EXEC and exit code: 3
```

Preceded, every run, by:

```
E [Service.Sensor]: Trying to get out-of-bound sample rate!
E [Service.Sensor]: Trying to get out-of-bound measure range!
```

The crash only happens where the host actually has an accelerometer, so it is invisible on the iOS simulator and on any host whose backend reports no sensors — which is why it went unnoticed.

## Root cause

`MSsyPropertyProvider::GetPropertyL()` (`devicesrv_plat/sensor_plugin_api/inc/ssypropertyprovider.h`) — the interface EKA2L1's sensor driver is standing in for — specifies:

> In case of array property, the required array index is also included.
> **If array index is not defined and the property is an array property, then array info property object must be returned (ESensrvArrayPropertyInfo).**

The server side is a pure pass-through (`CSensrvSsyMediator` hands the client's `TSensrvProperty` to `provider->GetPropertyL()` and writes it back), so that comment is the whole spec.

What "not defined" means on the wire: `CSensrvChannelImpl` accepts only three kinds of array index — a real index `>= 0`, `ESensrvSingleProperty (-1)` and `ESensrvArrayPropertyInfo (-2)` — and the `GetPropertyL(id, itemIndex, property)` overload that takes *no* array index sends a default-constructed `TSensrvProperty`, whose `iArrayIndex` is `-1`. So an unindexed query reaches the plugin as **-1**, never -2.

Both backends only produced array info for `-2` and treated `-1` as an out-of-bound element index, returning `KErrNotFound` for every unindexed data rate / measure range query. `CSensorBackendSym::GetMeasurementrangeAndAccuracy()` therefore never calls `addOutputRange()`, and `QAccelerometer::outputRanges()` stays empty. `CAccelerometerSensorSym::RecvData()` then indexes that empty list unconditionally as soon as a reading arrives:

```cpp
if (iScaleRange && iUnit == ESensevChannelUnitAcceleration) {
    qoutputrangelist rangeList = sensor()->outputRanges();
    int outputRange = sensor()->outputRange();
    if (outputRange == -1) outputRange = 0;
    TReal maxValue = rangeList[outputRange].maximum;   // <-- empty QList
```

That is the faulting `ldr r0, [r0, #4]`.

Independent corroboration that clients ask this way: the JRT Java sensor backend (`javaextensions/sensor/src.s60/cacceleratorsensor.cpp`) uses the same pattern — query without an array index, then check `GetArrayIndex() == ESensrvArrayPropertyInfo` on the reply.

## Fix

Treat any negative array index as the array info request. Two related contract deviations in the same descriptor, both from `sensrvproperty.h`:

**1. Array info is an int property.** The `ESensrvArrayPropertyInfo` definition:

> This property is the information item for an array of properties. **iIntValueMin and iIntValueMax** values in a property of this type defines the range of the property array

Measure range declared its array info as a real property, so the client read integer indices as `TReal`.

**2. Max is the last index, inclusive.** The documented example happens to use exactly the rates this code is modelled on:

```
property ID     Array index     Value    Min Value    Max Value    Read only
0x00000002      -2              1        0            2            EFalse
0x00000002      0               10       n/a          n/a          ETrue
0x00000002      1               40       n/a          n/a          ETrue
0x00000002      2               50       n/a          n/a          ETrue
```

> Min value: 0 is the start index of the property array
> Max value: **2 is the last index** of the property array

`set_as_array_status()` already subtracts one, so callers passing `MAX_OPTION - 1` subtracted twice and hid the last available rate/range (50 Hz here).

## Verification

Device build (iPhone Air, RM-707, Release): the access violation and both out-of-bound property errors are gone, the game thread is never terminated, and the game runs. Causality was pinned down first by forcing `accelerometer_available()` to true on the iOS simulator, which reproduces the failure there with the identical four sensor log lines.

The Android backend carries the identical change — it is the same code path with the same `-2`-only test; I have no Android device to test on.

## Not addressed here

- `get_all_properties()` is unimplemented in both backends (returns an empty list), so `CSensorBackendSym::GetDescription()` and the accuracy query come back empty. Not fatal — accuracy degrades to 0 and the output ranges now come from measure range — but it is the same area.
- `ESensrvSrvReqSetProperty` (opcode 0x12) has no handler in `sensor_client_session::process_message`, so `QSensor::setDataRate()` / `setOutputRange()` would leave the client's `SendReceiveSync` waiting forever. Not triggered by this title.
