### PR TITLE
android: preserve restored main activity fragments

### DIFF
--- a/src/emu/android/app/src/main/java/com/github/eka2l1/MainActivity.java
+++ b/src/emu/android/app/src/main/java/com/github/eka2l1/MainActivity.java
@@ -94,8 +94,12 @@ public class MainActivity extends BaseActivity {
     private void showAppList() {
         Emulator.initializeFolders();
         setVolumeControlStream(AudioManager.STREAM_MUSIC);
-        AppsListFragment appsListFragment = new AppsListFragment();
         FragmentManager fragmentManager = getSupportFragmentManager();
+        // Keep the restored page and back stack together after activity recreation.
+        if (fragmentManager.findFragmentById(R.id.container) != null) {
+            return;
+        }
+        AppsListFragment appsListFragment = new AppsListFragment();
         fragmentManager.beginTransaction()
                 .replace(R.id.container, appsListFragment).commitNowAllowingStateLoss();
     }


### PR DESCRIPTION
Activity recreation restores the current fragment and its navigation back stack, but `MainActivity` then unconditionally replaces that page with a new app list. If recreation happened on a child page, pressing Back can restore the original app list alongside the new one, producing overlapping icons/text and duplicate toolbar actions. This matches the reported screenshot; device reproduction is still pending.

Preserve the existing container fragment when initializing the main activity. Folder initialization and volume routing still run, and an empty container (including after permission handling) still receives an app list. The change is limited to the Android frontend.

Validation: reviewed the diff and passed `git diff --check` at `7db0090b2`, based on upstream master `19d2a4a0e`. No local compilation or runtime tests were run; build validation is delegated to CI, with manual verification using its APK pending.

Manual verification with the CI APK:
- Open Settings or device management, trigger activity recreation (for example, enable Android's “Don't keep activities”, leave the app and return), then press Back. Confirm the child page is restored and only one app list and one set of toolbar actions remain.
- Repeat with process death while backgrounded and restoration from Recents.
- Check ordinary cold launch, recreation on the app list, grid/list switching, and initial storage permission grant where applicable.

The upstream fork-PR artifact is unsigned when signing secrets are unavailable; it must be signed before installation.
