### PR TITLE
applist: select legacy launcher icons by list size

### DIFF
--- a/src/emu/android/app/src/main/cpp/src/launcher.cpp
+++ b/src/emu/android/app/src/main/cpp/src/launcher.cpp
@@ -232,7 +232,7 @@ namespace eka2l1::android {
                 }
             }
         } else {
-            std::optional<eka2l1::apa_app_masked_icon_bitmap> icon_pair = alserv->get_icon(*reg, 0);
+            std::optional<eka2l1::apa_app_masked_icon_bitmap> icon_pair = alserv->get_list_icon(*reg);
 
             if (icon_pair.has_value()) {
                 eka2l1::epoc::bitwise_bitmap *main_bitmap = icon_pair->first;

--- a/src/emu/ios/Bridge/IosEmulator.mm
+++ b/src/emu/ios/Bridge/IosEmulator.mm
@@ -170,7 +170,7 @@ namespace eka2l1::ios {
     // Order of attempts matches the Android side:
     //   .mif → lunasvg (after svgb / nvg debinarization, cached to disk)
     //   .mbm → epoc::convert_to_rgba8888 against sbm header 0
-    //   anything else → applist_server::get_icon -> bitwise_bitmap pair
+    //   anything else → applist_server::get_list_icon -> bitwise_bitmap pair
     static NSData *encode_rgba_to_png(const std::uint8_t *pixels,
                                       std::size_t width, std::size_t height,
                                       std::size_t requested_side) {
@@ -327,7 +327,7 @@ namespace eka2l1::ios {
                                        eka2l1::applist_server *alserv,
                                        eka2l1::fbs_server *fbsserv,
                                        std::size_t side) {
-        auto icon_pair = alserv->get_icon(*reg, 0);
+        auto icon_pair = alserv->get_list_icon(*reg);
         if (!icon_pair.has_value() || !icon_pair->first) return nil;
         auto *bitmap = icon_pair->first;
         const std::size_t w = bitmap->header_.size_pixels.x;

--- a/src/emu/qt/src/applistwidget.cpp
+++ b/src/emu/qt/src/applistwidget.cpp
@@ -644,7 +644,7 @@ void applist_widget::add_registeration_item_native(eka2l1::apa_app_registry &reg
             }
         }
     } else {
-        std::optional<eka2l1::apa_app_masked_icon_bitmap> icon_pair = lister_->get_icon(reg, 0);
+        std::optional<eka2l1::apa_app_masked_icon_bitmap> icon_pair = lister_->get_list_icon(reg);
 
         if (icon_pair.has_value()) {
             eka2l1::epoc::bitwise_bitmap *main_bitmap = icon_pair->first;

--- a/src/emu/services/include/services/applist/applist.h
+++ b/src/emu/services/include/services/applist/applist.h
@@ -23,6 +23,7 @@
 #include <services/applist/common.h>
 #include <services/framework.h>
 
+#include <common/vecx.h>
 #include <utils/des.h>
 #include <vfs/vfs.h>
 
@@ -348,7 +349,11 @@ namespace eka2l1 {
         bool launch_app(apa_app_registry &registry, epoc::apa::command_line &parameter, kernel::uid *thread_id,
                         std::function<void(kernel::process*)> app_exit_callback = nullptr);
 
-        std::optional<apa_app_masked_icon_bitmap> get_icon(apa_app_registry &registry, const std::int8_t index);
+        std::optional<apa_app_masked_icon_bitmap> get_icon(apa_app_registry &registry, const std::size_t index);
+
+        // Exact dimensions win; otherwise choose the nearest area that does not exceed the request.
+        std::optional<apa_app_masked_icon_bitmap> get_icon_by_size(apa_app_registry &registry, const eka2l1::vec2 &size);
+        std::optional<apa_app_masked_icon_bitmap> get_list_icon(apa_app_registry &registry);
 
         std::mutex list_access_mut_;
 

--- a/src/emu/services/src/applist/applist.cpp
+++ b/src/emu/services/src/applist/applist.cpp
@@ -40,6 +40,7 @@
 #include <utils/des.h>
 #include <vfs/vfs.h>
 
+#include <algorithm>
 #include <functional>
 #include <utils/err.h>
 
@@ -1587,11 +1588,11 @@ namespace eka2l1 {
             environment_main.empty() ? nullptr : &environment_main);
     }
 
-    std::optional<apa_app_masked_icon_bitmap> applist_server::get_icon(apa_app_registry &registry, const std::int8_t index) {
+    std::optional<apa_app_masked_icon_bitmap> applist_server::get_icon(apa_app_registry &registry, const std::size_t index) {
         epoc::bitwise_bitmap *real_bmp = nullptr;
         epoc::bitwise_bitmap *real_mask_bmp = nullptr;
 
-        if (index * 2 >= registry.app_icons.size()) {
+        if (index >= registry.app_icons.size() / 2) {
             return std::nullopt;
         }
 
@@ -1610,6 +1611,60 @@ namespace eka2l1 {
             real_mask_bmp = eka2l1::ptr<epoc::bitwise_bitmap>(registry.app_icons[index * 2 + 1].bmp_rom_addr_).get(sys->get_memory_system());
 
         return std::make_optional(std::make_pair(real_bmp, real_mask_bmp));
+    }
+
+    std::optional<apa_app_masked_icon_bitmap> applist_server::get_icon_by_size(apa_app_registry &registry, const eka2l1::vec2 &size) {
+        const std::size_t pair_count = registry.app_icons.size() / 2;
+        std::optional<apa_app_masked_icon_bitmap> chosen;
+
+        for (std::size_t i = 0; i < pair_count; i++) {
+            std::optional<apa_app_masked_icon_bitmap> candidate = get_icon(registry, i);
+
+            if (candidate.has_value() && (candidate->first->header_.size_pixels == size)) {
+                chosen = candidate;
+            }
+        }
+
+        if (chosen.has_value()) {
+            return chosen;
+        }
+
+        const std::int64_t wanted_area = static_cast<std::int64_t>(size.x) * size.y;
+        std::int64_t smallest_diff = 0;
+
+        for (std::size_t i = 0; i < pair_count; i++) {
+            std::optional<apa_app_masked_icon_bitmap> candidate = get_icon(registry, i);
+
+            if (!candidate.has_value()) {
+                continue;
+            }
+
+            const eka2l1::vec2 candidate_size = candidate->first->header_.size_pixels;
+            const std::int64_t diff = wanted_area - static_cast<std::int64_t>(candidate_size.x) * candidate_size.y;
+
+            if ((diff >= 0) && (!chosen.has_value() || (diff < smallest_diff))) {
+                smallest_diff = diff;
+                chosen = candidate;
+            }
+        }
+
+        return chosen;
+    }
+
+    std::optional<apa_app_masked_icon_bitmap> applist_server::get_list_icon(apa_app_registry &registry) {
+        // S60 AIFs distinguish list and context icons by size, not by pair order.
+        static const eka2l1::vec2 LEGACY_LIST_ICON_SIZE(42, 29);
+
+        if (common::compare_ignore_case(eka2l1::path_extension(registry.rsc_path), u".aif") == 0) {
+            std::optional<apa_app_masked_icon_bitmap> icon = get_icon_by_size(registry, LEGACY_LIST_ICON_SIZE);
+
+            if (icon.has_value()) {
+                return icon;
+            }
+        }
+
+        // Preserve host launcher icons when no legacy list size fits or the resource is not an AIF.
+        return get_icon(registry, 0);
     }
 
     void applist_server::add_app_uid_to_host_launch_name(const epoc::uid app_uid, const std::u16string &host_launch_name) {


### PR DESCRIPTION
Tomb Raider's N-Gage AIF stores a fully transparent 44×44 context icon before its visible 42×29 list icon. The Android, iOS and Qt launchers always read pair zero, so this otherwise valid installation has an invisible launcher icon.

Select legacy AIF launcher icons by the S60 list size (42×29). The size selector matches the official nem-4 ApGrfx implementation: the last exact dimension match wins; otherwise choose the nearest area not exceeding the request, retaining the first equal-area candidate. This does not inspect transparency or special-case a title. Keep the first-pair fallback for non-AIF resources and AIFs without a fitting icon, preserving host launcher behavior for larger-only assets. MIF/MBM loading and guest IPC handling remain unchanged.

The nem-4 MenuEng code at 0x50A1E020/0x50A1E022 supplies literal 42/29 before calling GetAppIcon(TSize). Its ApGrfx selection routine is at 0x505F7390. Later SDK CApaAppIconArray::IconBySize source corroborates the dimension/area rule. AknsUtils::CreateAppIconLC in the inspected rm-84, rm-86, rm-320, rm-321, rm-409, rm-507 and rm-707 firmware also distinguishes 42×29 list icons from 44×44 context icons; these are source-selection dimensions, not a universal rendered size.

The pair accessor now accepts size_t and rejects incomplete pairs, allowing selection beyond the former signed 8-bit index range. Area arithmetic uses int64_t.

Validation on fork commit `11232e10c` (the same five-file patch applied to upstream master `228476e7d`):

- Final Release iOS simulator build passed.
- Default iOS regression: 12 checks passed, 0 failed (Final Battle, Calculator, N95 Calculator, strings); screenshots visually reviewed.
- nem-4 launcher: Tomb Raider now shows its face icon; Sky Force, Ashen and Call of Duty icons also render. Inspected logs contain no panic, access violation or emulation halt.
- macOS Qt build passed. `ekatests` completed from its build directory: 5,884 assertions in 230 test cases passed.
- Android was not built locally; relying on upstream CI for Android/platform-specific coverage.

The fork-only investigation document is excluded. Existing fork verification is reused; there was no second simulator run on the upstream worktree.
