### PR TITLE
Fix per-mode screen depth and missing-file ROM address replies

### DIFF
--- a/src/emu/services/include/services/window/classes/config.h
+++ b/src/emu/services/include/services/window/classes/config.h
@@ -35,6 +35,8 @@ namespace eka2l1::epoc {
             int rotation;
 
             std::string style;
+            epoc::display_mode disp_mode;
+            epoc::display_mode dsa_disp_mode;
         };
 
         struct hardware_state {
@@ -46,13 +48,6 @@ namespace eka2l1::epoc {
 
         struct screen {
             int screen_number;
-            epoc::display_mode disp_mode;
-
-            // Depth of the physical framebuffer that direct screen access clients write
-            // into. WINDOWMODE only describes what WSERV composes in; on EKA1 panels the
-            // two differ, so keep them apart.
-            epoc::display_mode dsa_disp_mode;
-
             bool auto_clear;
             bool flicker_free;
             bool blt_offscreen;

--- a/src/emu/services/include/services/window/screen.h
+++ b/src/emu/services/include/services/window/screen.h
@@ -89,9 +89,8 @@ namespace eka2l1::epoc {
 
         epoc::display_mode disp_mode;
 
-        // Pixel format of the direct screen access framebuffer. Usually the same as
-        // disp_mode, but EKA1 panels expose a 16-bit framebuffer while WSERV composes
-        // in the deeper mode their wsini.ini declares.
+        // Some EKA1 clients hardcode 16-bit writes despite a deeper reported mode.
+        // Keep the detected DSA format separate from the screen device's mode.
         epoc::display_mode dsa_disp_mode;
         epoc::display_mode dsa_disp_mode_initial;
 

--- a/src/emu/services/src/fs/fs.cpp
+++ b/src/emu/services/src/fs/fs.cpp
@@ -622,14 +622,14 @@ namespace eka2l1 {
         auto final_path = get_full_symbian_path(ss_path, path.value());
         symfile f = ctx->sys->get_io_system()->open_file(final_path, READ_MODE);
 
-        if (!f) {
-            ctx->complete(0);
-            return;
+        // The address must be written back even when the file does not exist at all: clients read it
+        // unconditionally on KErrNone, so leaving it untouched hands them uninitialised stack as a ROM address.
+        address addr = 0;
+
+        if (f) {
+            addr = f->rom_address();
+            f->close();
         }
-
-        address addr = f->rom_address();
-
-        f->close();
 
         ctx->write_data_to_descriptor_argument<address>(1, addr);
         ctx->complete(epoc::error_none);

--- a/src/emu/services/src/window/classes/scrdvc.cpp
+++ b/src/emu/services/src/window/classes/scrdvc.cpp
@@ -98,7 +98,12 @@ namespace eka2l1::epoc {
 
     void screen_device::set_screen_mode(eka2l1::service::ipc_context &ctx, eka2l1::ws_cmd &cmd) {
         const int mode = *reinterpret_cast<int *>(cmd.data_ptr);
+        if (!scr->mode_info(mode)) {
+            ctx.complete(epoc::error_argument);
+            return;
+        }
         scr->set_screen_mode(&client->get_ws(), client->get_ws().get_graphics_driver(), mode);
+        ctx.complete(epoc::error_none);
     }
 
     void screen_device::get_screen_size_mode_list(eka2l1::service::ipc_context &ctx, eka2l1::ws_cmd &cmd) {
@@ -283,7 +288,6 @@ namespace eka2l1::epoc {
 
         case ws_sd_op_set_screen_mode: {
             set_screen_mode(ctx, cmd);
-            ctx.complete(epoc::error_none);
 
             break;
         }
@@ -316,10 +320,9 @@ namespace eka2l1::epoc {
         }
 
         case ws_sd_op_get_screen_mode_display_mode: {
-            int mode = *reinterpret_cast<int *>(cmd.data_ptr);
-
-            ctx.write_data_to_descriptor_argument(reply_slot, scr->disp_mode);
-            ctx.complete(epoc::error_none);
+            const int mode = *reinterpret_cast<int *>(cmd.data_ptr);
+            const auto *info = scr->mode_info(mode);
+            ctx.complete(info ? static_cast<int>(info->disp_mode) : epoc::error_argument);
 
             break;
         }

--- a/src/emu/services/src/window/screen.cpp
+++ b/src/emu/services/src/window/screen.cpp
@@ -136,9 +136,9 @@ namespace eka2l1::epoc {
         , screen_redraw_callbacks(screen_redraw_callback_free_check_func, screen_redraw_callback_free_func)
         , screen_mode_change_callbacks(screen_mode_change_callback_free_check_func, screen_mode_change_callback_free_func) {
         root = std::make_unique<epoc::window>(nullptr, this, nullptr);
-        disp_mode = scr_conf.disp_mode;
-        dsa_disp_mode = scr_conf.dsa_disp_mode;
-        dsa_disp_mode_initial = scr_conf.dsa_disp_mode;
+        disp_mode = current_mode().disp_mode;
+        dsa_disp_mode = current_mode().dsa_disp_mode;
+        dsa_disp_mode_initial = current_mode().dsa_disp_mode;
 
         for (std::size_t i = 0; i < scr_config.modes.size(); i++) {
             if (scr_config.modes[i].rotation == 0) {
@@ -564,7 +564,13 @@ namespace eka2l1::epoc {
     }
 
     void screen::set_screen_mode(window_server *winserv, drivers::graphics_driver *drv, const int mode) {
+        const auto *new_mode = mode_info(mode);
+        if (!new_mode) {
+            return;
+        }
+
         const int old_mode = crr_mode;
+        const bool display_mode_changed = disp_mode != new_mode->disp_mode;
         bool really_changed = false;
 
         if (crr_mode != mode) {
@@ -572,8 +578,26 @@ namespace eka2l1::epoc {
             really_changed = true;
         }
 
+        if (display_mode_changed) {
+            abort_all_dsas(dsa_terminate_screen_display_mode_change);
+        }
+
         crr_mode = mode;
-        resize(drv, mode_info(mode)->size);
+        if (really_changed) {
+            disp_mode = new_mode->disp_mode;
+            dsa_disp_mode_initial = new_mode->dsa_disp_mode;
+            reset_dsa_depth_guess();
+
+            if (dsa_texture) {
+                drivers::graphics_command_builder builder;
+                builder.destroy_bitmap(dsa_texture);
+                auto commands = builder.retrieve_command_list();
+                drv->submit_command_list(commands);
+                dsa_texture = 0;
+            }
+        }
+
+        resize(drv, new_mode->size);
 
         if (really_changed) {
             fire_screen_mode_change_callbacks(old_mode);
@@ -585,8 +609,10 @@ namespace eka2l1::epoc {
             const epoc::config::screen_mode *modeinfo_n = mode_info(crr_mode);
 
             if (modeinfo_o && modeinfo_n) {
-                if (modeinfo_o->size != modeinfo_n->size) {
-                    abort_all_dsas(dsa_terminate_rotation_change);
+                if ((modeinfo_o->size != modeinfo_n->size) || display_mode_changed) {
+                    if (!display_mode_changed) {
+                        abort_all_dsas(dsa_terminate_rotation_change);
+                    }
                     
                     // Do it right now (when are we gonna redraw again to calculate the visible region clueless)
                     need_update_visible_regions(true);

--- a/src/emu/services/src/window/window.cpp
+++ b/src/emu/services/src/window/window.cpp
@@ -1370,7 +1370,6 @@ namespace eka2l1 {
 
         common::ini_node_ptr window_mode_node = ws_config.find("WINDOWMODE");
         epoc::display_mode scr_mode_global = epoc::display_mode::color16ma;
-        epoc::display_mode dsa_mode_global = epoc::display_mode::color16ma;
 
         if (window_mode_node) {
             common::ini_pair *window_mode_pair = window_mode_node->get_as<common::ini_pair>();
@@ -1399,22 +1398,6 @@ namespace eka2l1 {
                 scr_mode_global = epoc::string_to_display_mode(modes[0]);
             }
 
-            // NGA render stages report every 32bpp target as DisplayMode16M (EColor16MA).
-            if ((kern->get_epoc_version() >= epocver::epoc10)
-                && (epoc::get_bpp_from_display_mode(scr_mode_global) == 32)) {
-                scr_mode_global = epoc::display_mode::color16ma;
-            }
-
-            dsa_mode_global = scr_mode_global;
-
-            // WINDOWMODE is the mode WSERV composes in; it is not proof of what a direct
-            // screen access client writes into the panel buffer. Most EKA1 guests follow
-            // the reported mode, but some hardcode 16-bit pixels, so start narrow and let
-            // screen::promote_dsa_depth_if_deep_pixels_written() widen once the guest
-            // shows it writes deeper ones.
-            if (kern->is_eka1() && (epoc::get_bpp_from_display_mode(dsa_mode_global) > 16)) {
-                dsa_mode_global = epoc::display_mode::color64k;
-            }
         }
 
         bool is_auto_clear = false;
@@ -1470,8 +1453,6 @@ namespace eka2l1 {
             epoc::config::screen scr;
 
             scr.screen_number = total_screen - 1;
-            scr.disp_mode = scr_mode_global;
-            scr.dsa_disp_mode = dsa_mode_global;
             scr.auto_clear = is_auto_clear;
             scr.flicker_free = flicker_free;
             scr.blt_offscreen = blit_offscreen;
@@ -1520,6 +1501,27 @@ namespace eka2l1 {
                 }
 
                 current_mode_str = std::to_string(total_mode);
+
+                scr_mode.disp_mode = scr_mode_global;
+                const std::string display_mode_key = "SCR_WINDOWMODE" + current_mode_str;
+                auto display_mode_node = screen_node->get_as<common::ini_section>()->find(display_mode_key.c_str());
+                if (display_mode_node) {
+                    std::vector<std::string> mode_names(1);
+                    display_mode_node->get_as<common::ini_pair>()->get(mode_names);
+                    scr_mode.disp_mode = epoc::string_to_display_mode(mode_names[0]);
+                }
+
+                // NGA render stages expose 32-bit targets as EColor16MA.
+                if ((kern->get_epoc_version() >= epocver::epoc10)
+                    && (epoc::get_bpp_from_display_mode(scr_mode.disp_mode) == 32)) {
+                    scr_mode.disp_mode = epoc::display_mode::color16ma;
+                }
+
+                scr_mode.dsa_disp_mode = scr_mode.disp_mode;
+                // Start narrow for legacy DSA clients; actual writes can promote the format.
+                if (kern->is_eka1() && (epoc::get_bpp_from_display_mode(scr_mode.disp_mode) > 16)) {
+                    scr_mode.dsa_disp_mode = epoc::display_mode::color64k;
+                }
 
                 std::string screen_mode_rot_key = "SCR_ROTATION";
                 screen_mode_rot_key += current_mode_str;

--- a/src/tests/epoc/services/window/surface.cpp
+++ b/src/tests/epoc/services/window/surface.cpp
@@ -13,6 +13,8 @@
 #include <services/window/surface.h>
 #include <services/window/bitmap_cache.h>
 #include <services/window/classes/gstore.h>
+#include <services/window/classes/winbase.h>
+#include <services/window/screen.h>
 #include <services/fbs/bitmap.h>
 
 #include <algorithm>
@@ -155,6 +157,47 @@ namespace {
         auto commands = builder.retrieve_command_list();
         driver.submit_command_list(commands);
     }
+}
+
+TEST_CASE("Same-size screen modes switch color depth and discard the old DSA texture", "[screen_mode]") {
+    epoc::config::screen config{};
+    config.modes = {
+        { 0, 1, { 176, 208 }, 0, "", epoc::display_mode::color16mu, epoc::display_mode::color64k },
+        { 0, 2, { 176, 208 }, 0, "", epoc::display_mode::color64k, epoc::display_mode::color64k }
+    };
+    epoc::screen screen(0, config);
+    surface_driver driver;
+
+    CHECK(screen.disp_mode == epoc::display_mode::color16mu);
+    CHECK(screen.screen_buffer_byte_width() == 704);
+    CHECK(screen.dsa_disp_mode == epoc::display_mode::color64k);
+
+    screen.dsa_disp_mode = epoc::display_mode::color16mu;
+    const auto old_texture = drivers::create_bitmap(&driver, { 208, 208 }, 32);
+    screen.dsa_texture = old_texture;
+    screen.set_screen_mode(nullptr, &driver, 1);
+    CHECK(screen.crr_mode == 1);
+    CHECK(screen.disp_mode == epoc::display_mode::color64k);
+    CHECK(screen.screen_buffer_byte_width() == 352);
+    CHECK(screen.dsa_disp_mode == epoc::display_mode::color64k);
+    CHECK(screen.dsa_texture == 0);
+    CHECK(driver.images.count(old_texture) == 0);
+
+    screen.set_screen_mode(nullptr, &driver, 0);
+    CHECK(screen.disp_mode == epoc::display_mode::color16mu);
+    CHECK(screen.screen_buffer_byte_width() == 704);
+    CHECK(screen.dsa_disp_mode_initial == epoc::display_mode::color64k);
+
+    screen.dsa_disp_mode = epoc::display_mode::color16mu;
+    screen.set_screen_mode(nullptr, &driver, 0);
+    CHECK(screen.dsa_disp_mode == epoc::display_mode::color16mu);
+    screen.set_screen_mode(nullptr, &driver, -1);
+    screen.set_screen_mode(nullptr, &driver, 2);
+    CHECK(screen.crr_mode == 0);
+    CHECK(screen.disp_mode == epoc::display_mode::color16mu);
+
+    screen.deinit(&driver);
+    CHECK_FALSE(driver.invalid_use);
 }
 
 TEST_CASE("Window background replacement is independent of producer publication", "[window_surface]") {


### PR DESCRIPTION
N70 wsini defines equal-size 16MU and 64K screen modes, but the window server kept one global pixel format. Switching modes therefore left the active format and stride unchanged. A separate file-server path returned success for a missing ROM file without initializing the address descriptor.

- Parse `SCR_WINDOWMODE` per screen mode, preserving global defaults, and update the active display/DSA format and stride when switching modes. Terminate DSA for depth changes and discard its transfer texture.
- Return `GetScreenModeDisplayMode` through integer IPC completion, matching the Symbian client/server contract, and reject invalid mode selections.
- Write a zero ROM address on failed file lookup so clients cannot interpret uninitialized data as a ROM pointer.

Validation on the fork, 2026-09-12: revision `9da421a52` plus the screen-mode change committed as `185acd4f4`, Release iOS simulator. The selected files match this branch exactly. Screen-mode tests passed 16 assertions; surface/GDI tests passed 104 assertions across 17 cases. Default regression passed 12/12; Angry Birds passed 5/5. N70 Tomb Raider reached Lara’s Home with mode 1 selected manually; native N-Gage menu/input remained functional. These results are reused because extraction introduced no production changes.

This does not change `GetDefModeMaxNumColors` or add game-specific overrides: Tomb Raider still fails in its renderer factory under N70’s default 16MU mode. One initial UIKit `objc_release` crash did not recur in a complete retry with the same Release binary and remains unresolved.
